### PR TITLE
fix(web/scenes): stamp scene_id from event subject so live IC events reach the scenes log (holomush-5rh.8.29.14)

### DIFF
--- a/internal/web/translate.go
+++ b/internal/web/translate.go
@@ -6,6 +6,7 @@ package web
 import (
 	"encoding/json"
 	"log/slog"
+	"strings"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -121,6 +122,16 @@ func (h *Handler) translateEvent(ev *corev1.EventFrame) *webv1.GameEvent {
 		meta["target_name"] = p.TargetName
 	}
 
+	// Stamp scene_id from the event subject for scene IC events.
+	// The subject is always cleartext dot-delimited:
+	// events.<game_id>.scene.<scene_id>[.<facet>...]
+	// Extract the token immediately after the "scene" segment.
+	// Sensitive payloads may be encrypted so we MUST NOT gate on payload
+	// contents — the subject is always available and cleartext.
+	if sceneID := sceneIDFromSubject(ev.GetStream()); sceneID != "" {
+		meta["scene_id"] = sceneID
+	}
+
 	var metadata *structpb.Struct
 	if len(meta) > 0 {
 		s, err := structpb.NewStruct(meta)
@@ -163,6 +174,22 @@ func formatMovementText(eventType, actor string, p *genericPayload) string {
 	default:
 		return ""
 	}
+}
+
+// sceneIDFromSubject extracts the scene ID from a fully-qualified dot-delimited
+// NATS subject of the form events.<game_id>.scene.<scene_id>[.<facet>...].
+// The "scene" domain token is matched at its canonical position (index 2,
+// immediately after "events" and the game_id) so a game_id that is literally
+// "scene" cannot be mistaken for the domain. Returns an empty string for any
+// subject that is not a scene subject or that lacks a scene_id token. The
+// subject is always cleartext even for encrypted events, so this is safe to
+// call unconditionally.
+func sceneIDFromSubject(subject string) string {
+	parts := strings.Split(subject, ".")
+	if len(parts) < 4 || parts[0] != "events" || parts[2] != "scene" || parts[3] == "" {
+		return ""
+	}
+	return parts[3]
 }
 
 // translateStateEvent handles state-category events where the entire payload

--- a/internal/web/translate_test.go
+++ b/internal/web/translate_test.go
@@ -474,6 +474,136 @@ func TestTranslateEvent_PopulatesEventIdForStateEvents(t *testing.T) {
 	assert.Equal(t, expectedID, got.GetEventId())
 }
 
+// TestTranslateEvent_SceneICEventStampsSceneIdFromSubject asserts that a live
+// scene IC frame (e.g. core-scenes:scene_pose delivered on the
+// events.<game>.scene.<id>.ic subject) has metadata["scene_id"] set from the
+// subject token immediately after "scene". This is the essential field the
+// web scenes workspace routes on; no top-level fallback exists in the client.
+func TestTranslateEvent_SceneICEventStampsSceneIdFromSubject(t *testing.T) {
+	tests := []struct {
+		name           string
+		eventType      string
+		stream         string
+		wantSceneID    string
+		wantSceneIDKey bool
+	}{
+		{
+			name:           "pose with fully-qualified dot subject stamps scene_id",
+			eventType:      "core-scenes:scene_pose",
+			stream:         "events.main.scene.01KTQKNB5EQR3048BBNVJTMVG5.ic",
+			wantSceneID:    "01KTQKNB5EQR3048BBNVJTMVG5",
+			wantSceneIDKey: true,
+		},
+		{
+			name:           "say with different game id stamps scene_id",
+			eventType:      "core-scenes:scene_say",
+			stream:         "events.game42.scene.01HSCENEID00000000000000AB.ic",
+			wantSceneID:    "01HSCENEID00000000000000AB",
+			wantSceneIDKey: true,
+		},
+		{
+			name:           "ooc stamps scene_id",
+			eventType:      "core-scenes:scene_ooc",
+			stream:         "events.main.scene.01HSCENEID00000000000000CC.ic",
+			wantSceneID:    "01HSCENEID00000000000000CC",
+			wantSceneIDKey: true,
+		},
+		{
+			name:           "emit stamps scene_id",
+			eventType:      "core-scenes:scene_emit",
+			stream:         "events.main.scene.01HSCENEID00000000000000DD.ic",
+			wantSceneID:    "01HSCENEID00000000000000DD",
+			wantSceneIDKey: true,
+		},
+		{
+			name:           "non-scene say event does not get scene_id",
+			eventType:      "core-communication:say",
+			stream:         "events.main.character.01HCHARID000000000000AAAA",
+			wantSceneIDKey: false,
+		},
+		{
+			name:           "arrive movement event does not get scene_id",
+			eventType:      "arrive",
+			stream:         "events.main.location.01HLOCID0000000000000BBBB",
+			wantSceneIDKey: false,
+		},
+		{
+			name:           "malformed subject with scene as last token does not panic and no scene_id",
+			eventType:      "core-scenes:scene_pose",
+			stream:         "events.main.scene",
+			wantSceneIDKey: false,
+		},
+		{
+			name:           "empty subject does not panic and no scene_id",
+			eventType:      "core-scenes:scene_pose",
+			stream:         "",
+			wantSceneIDKey: false,
+		},
+		{
+			name:           "subject without scene segment does not get scene_id",
+			eventType:      "core-scenes:scene_pose",
+			stream:         "events.main.location.01HLOCID0000000000000XXXX.ic",
+			wantSceneIDKey: false,
+		},
+		{
+			// game_id literally "scene": the domain "scene" is matched only at
+			// its canonical position (index 2), so parts[3] is the real id.
+			name:           "game_id equal to scene resolves the real scene id from index 3",
+			eventType:      "core-scenes:scene_pose",
+			stream:         "events.scene.scene.01HSCENEID00000000000000EE.ic",
+			wantSceneID:    "01HSCENEID00000000000000EE",
+			wantSceneIDKey: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandler(t)
+
+			// Build a rendering for the event type (use communication category for
+			// scene events; we just need a valid non-nil Rendering).
+			rendering := &corev1.RenderingMetadata{
+				Category:      "communication",
+				Format:        "action",
+				DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
+				SourcePlugin:  "core-scenes",
+			}
+			switch tt.eventType {
+			case "arrive":
+				rendering = testRenderings["arrive"]
+			case "core-communication:say":
+				rendering = testRenderings["core-communication:say"]
+			}
+
+			ev := &corev1.EventFrame{
+				Type:      tt.eventType,
+				Stream:    tt.stream,
+				Payload:   mustMarshal(t, map[string]any{"character_name": "Alice", "action": "waves.", "message": "Hello!"}),
+				Rendering: rendering,
+			}
+
+			// Must not panic.
+			got := h.translateEvent(ev)
+			require.NotNil(t, got)
+
+			if tt.wantSceneIDKey {
+				require.NotNil(t, got.GetMetadata(), "metadata must be set when scene_id expected")
+				meta := got.GetMetadata().AsMap()
+				assert.Equal(t, tt.wantSceneID, meta["scene_id"],
+					"metadata[scene_id] must equal the id token from the subject")
+			} else {
+				// Assert unconditionally: a nil metadata trivially has no
+				// scene_id, and a non-nil metadata must not carry the key.
+				var hasSceneID bool
+				if got.GetMetadata() != nil {
+					_, hasSceneID = got.GetMetadata().AsMap()["scene_id"]
+				}
+				assert.False(t, hasSceneID, "non-scene events must not have scene_id in metadata")
+			}
+		})
+	}
+}
+
 // TestEventChannelEnumsInLockstep is INV-EVENTBUS-16. corev1.EventChannel and
 // webv1.EventChannel MUST stay in lockstep — same enum values, same names,
 // same numeric assignments.


### PR DESCRIPTION
## Summary

Live scene IC events (`core-scenes:scene_pose/say/ooc/emit`) never rendered in the web scenes-workspace log because the gateway's `translateEvent` (`internal/web/translate.go`) built `GameEvent.metadata` without a `scene_id`. The scenes frontend routes live IC frames **solely** by `ev.metadata['scene_id']` (`web/src/lib/scenes/workspaceStore.svelte.ts:222-234`) and dropped every frame lacking it.

This stamps `scene_id` into the metadata for scene IC events, derived from the **event subject** (`ev.GetStream()` → `events.<game_id>.scene.<scene_id>[.<facet>...]`, set on the live path at `internal/grpc/server.go:672`). The subject is always cleartext even for encrypted (sensitive) payloads, so the routing fix is crypto-independent — the whole point of root-cause #1 in the bead.

`sceneIDFromSubject` matches the `scene` domain token at its canonical position (index 2, after `events` + game_id) so a game_id literally equal to `"scene"` cannot be mistaken for the domain.

## Scope notes

- Resolves **root-cause #1** (the e2e S3 blocker) of holomush-5rh.8.29.14.
- **Root-cause #2** (history backfill time window) was investigated and found to be **misdiagnosed**: `notAfterMs=0n` is the server's *unbounded* sentinel (`query_stream_history.go:283-286`; `tier.go:478` only validates when both bounds are non-zero), not an inversion, and a client-side clamp was a no-op (`client.ts:166` coalesces `undefined -> 0n`). The genuine server-side inversion (`notBefore=scopeFloor > notAfter=attachMomentMs` when `0 < attachMomentMs < scopeFloor`) is tracked as follow-up **holomush-tn12i**.
- Out of scope: the latent crypto follow-up — confirm live `scene_pose` is delivered *decrypted* (not metadata-only) to the web subscriber; if pose text renders empty after this lands, that's a separate crypto-gated bead.

## Test plan

- New table-driven `TestTranslateEvent_SceneICEventStampsSceneIdFromSubject` (pose/say/ooc/emit stamp; non-scene/movement no stamp; malformed/empty subject no panic; game_id=="scene" edge).
- `task test -- ./internal/web/` green (286 tests); `task pr-prep` fast lane green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)