### PR TITLE
fix(crypto): resolve PlayerID at comms DEK genesis — close player-branch AuthGuard asymmetry (holomush-5rh.8.29.11)

### DIFF
--- a/cmd/holomush/crypto_rekey_wiring.go
+++ b/cmd/holomush/crypto_rekey_wiring.go
@@ -166,10 +166,10 @@ func buildRekeyWiring(
 
 	// BindingResolver: production uses worldpostgres.NewBindingRepository.
 	// dek.NewManager requires a non-nil BindingResolver at construction
-	// time; the BindingRepository's Current method satisfies the interface
-	// shape directly. The rekey path itself does not invoke BindingResolver
-	// — it is only consumed by Manager.Add for character participant
-	// management.
+	// time; the BindingRepository's CurrentWithPlayer method satisfies the
+	// interface shape directly. The rekey path itself does not invoke
+	// BindingResolver — it is only consumed by Manager.GetOrCreate/Add for
+	// character participant management.
 	bindings := worldpostgres.NewBindingRepository(deps.Pool)
 
 	mgr, mgrErr := dek.NewManager(deps.KEKProvider, dekStore, dekCache, partCache, invFn, bindings)

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -171,6 +171,7 @@ invariants.
 | `INV-CRYPTO-119` | The server MUST refuse to boot without a provisionable KEK; missing keyfile path, missing passphrase, or keyfile absent without auto-gen all produce a fatal error — degraded KEK-less boot is never permitted. | — | bound |
 | `INV-CRYPTO-120` | Every character-creation path (normal and guest) MUST mint a current DEK binding in the same transaction, so bindings.Current always resolves for a newly created character with no orphan row. | — | bound |
 | `INV-CRYPTO-121` | The first SetSceneFocus on a scene context with no active DEK MUST genesis the DEK, seeded with the focusing reader as a participant; a participant-seeding focus MUST NOT fail solely because no DEK pre-existed. The publisher's scene-context genesis remains participant-empty (the scene genesis asymmetry, publisher.go initialParticipantsForContext, preserved). | — | bound |
+| `INV-CRYPTO-122` | Comms DEK genesis for a character.<id> context MUST resolve and record the recipient's player_id (from the recipient's active player↔character binding row) on the seeded participant, so the AuthGuard player-history branch (guard.go checkPlayer, §7.2 Branch 2) can match after a later binding rotation — symmetric with the scene-focus seed (INV-CRYPTO-121). The fill MUST NOT overwrite a caller-supplied player_id (the scene seed supplies its own). | — | bound |
 
 ### `INV-PRIVACY`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -4435,3 +4435,16 @@ invariants:
       - "test/integration/crypto/scene_focus_genesis_test.go"
     refs:
       - {file: "test/integration/crypto/scene_focus_genesis_test.go", token: "INV-CRYPTO-121"}
+  - id: INV-CRYPTO-122
+    scope: INV-CRYPTO
+    origin_spec: "docs/adr/holomush-olpdd-seed-comms-recipients-host-side-at-publisher-genesis-boundar.md"
+    legacy: []
+    summary: "Comms DEK genesis for a character.<id> context MUST resolve and record the recipient's player_id (from the recipient's
+      active player↔character binding row) on the seeded participant, so the AuthGuard player-history branch (guard.go checkPlayer,
+      §7.2 Branch 2) can match after a later binding rotation — symmetric with the scene-focus seed (INV-CRYPTO-121). The
+      fill MUST NOT overwrite a caller-supplied player_id (the scene seed supplies its own)."
+    binding: bound
+    asserted_by:
+      - "internal/eventbus/crypto/dek/manager_integration_test.go"
+    refs:
+      - {file: "internal/eventbus/crypto/dek/manager_integration_test.go", token: "INV-CRYPTO-122"}

--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -116,9 +116,15 @@ type ActiveDEKRecord struct {
 // action is one of "rotate", "participants_changed", or "rekey".
 type Invalidator func(ctx context.Context, ctxID ContextID, action string, version, successorVersion uint32) error
 
-// BindingResolver resolves a character's current binding_id.
+// BindingResolver resolves a character's current binding: the active
+// binding_id and the player_id it is bound to. The player_id is recorded on
+// the seeded participant so the AuthGuard player-history branch (§7.2 Branch 2,
+// guard.go checkPlayer) can match after a later binding rotation — symmetric
+// with the scene-focus seed (sceneaccess_service.go), which carries the
+// session player_id. Both values come from the same active binding row so they
+// are atomically consistent (holomush-5rh.8.29.11).
 type BindingResolver interface {
-	Current(ctx context.Context, characterID string) (string, error)
+	CurrentWithPlayer(ctx context.Context, characterID string) (bindingID, playerID string, err error)
 }
 
 // manager is the concrete impl.
@@ -242,21 +248,29 @@ func (m *manager) GetOrCreate(ctx context.Context, ctxID ContextID, initial []Pa
 		return codec.Key{}, validateErr
 	}
 	// Resolve any participant supplied without a BindingID (e.g. the publisher's
-	// genesis-seed for a character.<id> context). Pre-bound participants pass
-	// through unchanged. m.bindings is guaranteed non-nil (NewManager:175).
-	// Mirrors the resolution Add performs (manager.go:364). Genesis-only: the
-	// active-row short-circuit above means this never runs once the DEK exists.
+	// genesis-seed for a character.<id> context). m.bindings is guaranteed
+	// non-nil (NewManager). Mirrors the resolution Add performs. Genesis-only:
+	// the active-row short-circuit above means this never runs once the DEK
+	// exists. PlayerID is filled from the same binding row only when the caller
+	// left it empty — the publisher comms seed supplies neither, while the scene
+	// seed (sceneaccess_service.go) supplies an explicit PlayerID we MUST NOT
+	// clobber (INV-CRYPTO-122). Caller contract: a participant supplied WITH a
+	// BindingID skips resolution entirely, so such a caller MUST also supply
+	// PlayerID if it needs the AuthGuard player-history branch to match.
 	resolved := initial
 	if len(initial) > 0 {
 		resolved = make([]Participant, len(initial))
 		for i, p := range initial {
 			if p.BindingID == "" {
-				bindingID, bErr := m.bindings.Current(ctx, p.CharacterID)
+				bindingID, playerID, bErr := m.bindings.CurrentWithPlayer(ctx, p.CharacterID)
 				if bErr != nil {
 					return codec.Key{}, oops.Code("DEK_BINDING_RESOLVE_FAILED").
 						With("character_id", p.CharacterID).Wrap(bErr)
 				}
 				p.BindingID = bindingID
+				if p.PlayerID == "" {
+					p.PlayerID = playerID
+				}
 			}
 			resolved[i] = p
 		}
@@ -370,12 +384,15 @@ func (m *manager) Add(ctx context.Context, ctxID ContextID, p Participant) error
 	}
 
 	if p.BindingID == "" {
-		bindingID, err := m.bindings.Current(ctx, p.CharacterID)
+		bindingID, playerID, err := m.bindings.CurrentWithPlayer(ctx, p.CharacterID)
 		if err != nil {
 			return oops.Code("DEK_BINDING_RESOLVE_FAILED").
 				With("character_id", p.CharacterID).Wrap(err)
 		}
 		p.BindingID = bindingID
+		if p.PlayerID == "" {
+			p.PlayerID = playerID
+		}
 	}
 
 	activeRow, added, err := m.store.updateParticipants(ctx, ctxID, p)

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -300,7 +300,78 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(parts).To(HaveLen(1))
 		Expect(parts[0].BindingID).To(Equal(wantBinding),
-			"genesis must resolve empty BindingID via BindingResolver.Current")
+			"genesis must resolve empty BindingID via BindingResolver.CurrentWithPlayer")
+	})
+
+	// Verifies: INV-CRYPTO-122
+	// The comms-seed player-branch symmetry fix (holomush-5rh.8.29.11): the
+	// publisher seeds a character.<id> comms recipient with CharacterID only (no
+	// PlayerID). Genesis must fill PlayerID from the same active binding row, so
+	// the AuthGuard player-history branch (guard.go checkPlayer) can match after
+	// a later binding rotation — matching the scene-focus seed, which carries the
+	// session player_id.
+	It("resolves an empty PlayerID on genesis via the BindingResolver", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		provider := newTestProvider(suiteT)
+		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		const wantBinding = "01RESOLVEDBINDING0000000"
+		const wantPlayer = "01RESOLVEDPLAYER00000000"
+		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache,
+			noopInvalidator, &stubBindingResolver{bindingID: wantBinding, playerID: wantPlayer})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Mirrors publisher.initialParticipantsForContext: CharacterID only.
+		ctxID := dek.ContextID{Type: "character", ID: "01HRECIPIENTCHAR000000000"}
+		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{{CharacterID: "01HRECIPIENTCHAR000000000"}})
+		Expect(err).NotTo(HaveOccurred())
+
+		parts, err := mgr.Participants(ctx, key.ID, key.Version)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1))
+		Expect(parts[0].PlayerID).To(Equal(wantPlayer),
+			"genesis must fill an empty PlayerID from the binding row so checkPlayer can match")
+		Expect(parts[0].BindingID).To(Equal(wantBinding))
+	})
+
+	// Verifies: INV-CRYPTO-122 (no-clobber clause)
+	// The scene-focus seed supplies an explicit PlayerID (ps.PlayerID); genesis
+	// MUST NOT overwrite it with the binding-resolved value, even though both
+	// should agree in production (holomush-5rh.8.29.11).
+	It("preserves a caller-supplied PlayerID on genesis (does not clobber)", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		provider := newTestProvider(suiteT)
+		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		const explicitPlayer = "01EXPLICITPLAYER00000000"
+		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache,
+			noopInvalidator, &stubBindingResolver{bindingID: "01BIND", playerID: "01RESOLVEDPLAYER00000000"})
+		Expect(err).NotTo(HaveOccurred())
+
+		ctxID := dek.ContextID{Type: "scene", ID: "01HSCENE00000000000000000"}
+		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{{
+			CharacterID: "01HCHAR0000000000000000000",
+			PlayerID:    explicitPlayer,
+		}})
+		Expect(err).NotTo(HaveOccurred())
+
+		parts, err := mgr.Participants(ctx, key.ID, key.Version)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1))
+		Expect(parts[0].PlayerID).To(Equal(explicitPlayer),
+			"genesis must not clobber a caller-supplied PlayerID")
 	})
 
 	It("Participants not found returns DEK_NOT_FOUND", func() {
@@ -939,6 +1010,87 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(parts).To(HaveLen(2))
 		Expect(parts[1].BindingID).To(Equal("bind-explicit"))
+	})
+
+	// Symmetric with the genesis fill (holomush-5rh.8.29.11): Add with an empty
+	// BindingID resolves the binding row and fills an empty PlayerID from it. No
+	// current production caller hits this (the scene-focus Add supplies an
+	// explicit PlayerID), but the branch mirrors GetOrCreate and is pinned here.
+	It("Add fills an empty PlayerID from the resolved binding", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		const wantBinding = "01ADDRESOLVEDBINDING0000"
+		const wantPlayer = "01ADDRESOLVEDPLAYER00000"
+		mgr, err := dek.NewManager(
+			newTestProvider(suiteT), dek.NewStore(pool),
+			dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+			dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+			noopInvalidator, &stubBindingResolver{bindingID: wantBinding, playerID: wantPlayer},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctxID := dek.ContextID{Type: "scene", ID: "01HADDFILLSCENE000000000"}
+		dekKey, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{PlayerID: "01SEEDPLAYER000000000000", CharacterID: "01SEEDCHAR0000000000000A", BindingID: "01SEEDBIND00000000000000", JoinedAt: time.Now().UTC()},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Add a participant with empty BindingID AND empty PlayerID.
+		Expect(mgr.Add(ctx, ctxID, dek.Participant{
+			CharacterID: "01ADDEDCHAR000000000000A", JoinedAt: time.Now().UTC(),
+		})).To(Succeed())
+
+		parts, err := mgr.Participants(ctx, dekKey.ID, dekKey.Version)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(2))
+		Expect(parts[1].BindingID).To(Equal(wantBinding))
+		Expect(parts[1].PlayerID).To(Equal(wantPlayer),
+			"Add must fill an empty PlayerID from the resolved binding row")
+	})
+
+	// Verifies: INV-CRYPTO-122 (no-clobber clause, Add path)
+	// Add with an empty BindingID resolves the binding, but a caller-supplied
+	// PlayerID MUST survive — the resolver's player_id does not overwrite it
+	// (holomush-5rh.8.29.11).
+	It("Add preserves a caller-supplied PlayerID when resolving the binding", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		const explicitPlayer = "01ADDEXPLICITPLAYER00000"
+		mgr, err := dek.NewManager(
+			newTestProvider(suiteT), dek.NewStore(pool),
+			dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+			dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+			noopInvalidator, &stubBindingResolver{bindingID: "01ADDNOCLOBBERBIND000000", playerID: "01ADDRESOLVEDPLAYER00000"},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctxID := dek.ContextID{Type: "scene", ID: "01HADDNOCLOBBERSCENE0000"}
+		dekKey, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{PlayerID: "01SEEDPLAYER000000000000", CharacterID: "01SEEDCHAR0000000000000A", BindingID: "01SEEDBIND00000000000000", JoinedAt: time.Now().UTC()},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Add a participant with explicit PlayerID but empty BindingID (resolution runs).
+		Expect(mgr.Add(ctx, ctxID, dek.Participant{
+			PlayerID: explicitPlayer, CharacterID: "01ADDEDCHAR000000000000A", JoinedAt: time.Now().UTC(),
+		})).To(Succeed())
+
+		parts, err := mgr.Participants(ctx, dekKey.ID, dekKey.Version)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(2))
+		Expect(parts[1].BindingID).To(Equal("01ADDNOCLOBBERBIND000000"))
+		Expect(parts[1].PlayerID).To(Equal(explicitPlayer),
+			"Add must not clobber a caller-supplied PlayerID with the resolved one")
 	})
 
 	// EnsureParticipant is the genesis-safe scene-reader seed: it must leave the

--- a/internal/eventbus/crypto/dek/manager_test.go
+++ b/internal/eventbus/crypto/dek/manager_test.go
@@ -18,11 +18,12 @@ import (
 // stubBindingResolver implements dek.BindingResolver for tests.
 type stubBindingResolver struct {
 	bindingID string
+	playerID  string
 	err       error
 }
 
-func (s *stubBindingResolver) Current(_ context.Context, _ string) (string, error) {
-	return s.bindingID, s.err
+func (s *stubBindingResolver) CurrentWithPlayer(_ context.Context, _ string) (bindingID, playerID string, err error) {
+	return s.bindingID, s.playerID, s.err
 }
 
 // TestNewManager_RejectsNilProvider verifies NewManager returns

--- a/internal/eventbus/crypto/dek/store_integration_test.go
+++ b/internal/eventbus/crypto/dek/store_integration_test.go
@@ -25,11 +25,11 @@ type testBindingStub struct {
 	err       error
 }
 
-func (s *testBindingStub) Current(_ context.Context, _ string) (string, error) {
+func (s *testBindingStub) CurrentWithPlayer(_ context.Context, _ string) (bindingID, playerID string, err error) {
 	if s.err != nil {
-		return "", s.err
+		return "", "", s.err
 	}
-	return s.bindingID, nil
+	return s.bindingID, "", nil
 }
 
 // TestSoftDeletedDEKAppearsAsNoRowsForProductionReads asserts that

--- a/internal/eventbus/publisher.go
+++ b/internal/eventbus/publisher.go
@@ -495,9 +495,12 @@ func (identityKeySelector) SelectForDecrypt(_ context.Context, _ codec.Name, _ c
 // genesis for a context, derived from the subject. A character.<id> context is
 // a personal stream whose owner (the recipient of a private message —
 // page/whisper/pemit) must be able to decrypt, so seed that character. The
-// BindingID is left empty; GetOrCreate resolves it via the BindingResolver on
-// its create branch (manager.go). Scene and other contexts seed nothing here
-// (scene readers are seeded at SetSceneFocus).
+// BindingID and PlayerID are left empty; GetOrCreate resolves both from the
+// recipient's active binding row via the BindingResolver on its create branch
+// (manager.go). The PlayerID lets the AuthGuard player-history branch match
+// after a later binding rotation — symmetric with the scene-focus seed
+// (holomush-5rh.8.29.11). Scene and other contexts seed nothing here (scene
+// readers are seeded at SetSceneFocus).
 func initialParticipantsForContext(ctxID dek.ContextID) []dek.Participant {
 	if ctxID.Type != "character" {
 		return nil

--- a/internal/testsupport/holomushtest/server.go
+++ b/internal/testsupport/holomushtest/server.go
@@ -533,8 +533,8 @@ func sanitizeEnvName(s string) string {
 // exercise the binding lookup path.
 type noopBindingResolver struct{}
 
-func (*noopBindingResolver) Current(_ context.Context, _ string) (string, error) {
-	return "noop-binding", nil
+func (*noopBindingResolver) CurrentWithPlayer(_ context.Context, _ string) (bindingID, playerID string, err error) {
+	return "noop-binding", "", nil
 }
 
 // testAuditPublisher satisfies dek.AuditPublisher for the in-process harness.

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -98,7 +98,7 @@ func newPluginCrypto(t *testing.T, bus *eventbustest.Embedded, pool *pgxpool.Poo
 		provider, dek.NewStore(pool),
 		dek.NewCache(cacheCfg), dek.NewParticipantsCache(cacheCfg),
 		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil }, // noop invalidator
-		worldpg.NewBindingRepository(pool),                                                   // satisfies dek.BindingResolver via Current
+		worldpg.NewBindingRepository(pool),                                                   // satisfies dek.BindingResolver via CurrentWithPlayer
 	)
 	require.NoError(t, err, "newPluginCrypto: dek.NewManager")
 

--- a/internal/world/postgres/binding_repo.go
+++ b/internal/world/postgres/binding_repo.go
@@ -57,21 +57,38 @@ func NewBindingRepository(pool *pgxpool.Pool) *BindingRepository {
 // Current returns the active binding_id for characterID. Returns
 // BINDING_NOT_FOUND if no active binding exists.
 func (s *BindingRepository) Current(ctx context.Context, characterID string) (string, error) {
-	var bindingID string
-	err := bindingDBFromCtx(ctx, s.pool).QueryRow(
+	bindingID, _, err := s.currentBinding(ctx, characterID)
+	return bindingID, err
+}
+
+// CurrentWithPlayer returns the active binding_id and the player_id it is bound
+// to for characterID, both from the same active binding row. Returns
+// BINDING_NOT_FOUND if no active binding exists. Satisfies dek.BindingResolver:
+// the player_id is recorded on genesis-seeded DEK participants so the AuthGuard
+// player-history branch matches after a later binding rotation
+// (holomush-5rh.8.29.11).
+func (s *BindingRepository) CurrentWithPlayer(ctx context.Context, characterID string) (bindingID, playerID string, err error) {
+	return s.currentBinding(ctx, characterID)
+}
+
+// currentBinding is the shared query backing Current and CurrentWithPlayer: it
+// selects the active binding row's id and player_id in one round-trip so the
+// two values are atomically consistent.
+func (s *BindingRepository) currentBinding(ctx context.Context, characterID string) (bindingID, playerID string, err error) {
+	err = bindingDBFromCtx(ctx, s.pool).QueryRow(
 		ctx,
-		`SELECT id FROM player_character_bindings WHERE character_id = $1 AND ended_at IS NULL`,
+		`SELECT id, player_id FROM player_character_bindings WHERE character_id = $1 AND ended_at IS NULL`,
 		characterID,
-	).Scan(&bindingID)
+	).Scan(&bindingID, &playerID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", oops.Code("BINDING_NOT_FOUND").
+			return "", "", oops.Code("BINDING_NOT_FOUND").
 				With("character_id", characterID).
 				Errorf("no active binding for character %s", characterID)
 		}
-		return "", oops.Code("BINDING_STORE_QUERY_FAILED").Wrap(err)
+		return "", "", oops.Code("BINDING_STORE_QUERY_FAILED").Wrap(err)
 	}
-	return bindingID, nil
+	return bindingID, playerID, nil
 }
 
 // Create inserts a new active binding for (playerID, characterID).

--- a/internal/world/postgres/binding_repo_test.go
+++ b/internal/world/postgres/binding_repo_test.go
@@ -63,6 +63,37 @@ func TestBindingRepositoryCreateReturnsIDAndCurrentReadsItBack(t *testing.T) {
 	assert.Equal(t, bindingID, got)
 }
 
+// TestBindingRepositoryCurrentWithPlayerReturnsBindingAndPlayer asserts that
+// CurrentWithPlayer surfaces both the active binding_id and the player_id it is
+// bound to from the same row — the player_id is what genesis records on a comms
+// DEK participant so the AuthGuard player-history branch can match after a later
+// binding rotation (holomush-5rh.8.29.11).
+func TestBindingRepositoryCurrentWithPlayerReturnsBindingAndPlayer(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewBindingRepository(testPool)
+
+	playerID, characterID := seedBindingTestData(ctx, t)
+
+	bindingID, err := repo.Create(ctx, playerID, characterID, "initial_bind")
+	require.NoError(t, err)
+	require.NotEmpty(t, bindingID)
+
+	gotBinding, gotPlayer, err := repo.CurrentWithPlayer(ctx, characterID)
+	require.NoError(t, err)
+	assert.Equal(t, bindingID, gotBinding)
+	assert.Equal(t, playerID, gotPlayer)
+}
+
+// TestBindingRepositoryCurrentWithPlayerReturnsNotFoundForCharacterWithoutBinding
+// asserts the BINDING_NOT_FOUND path is preserved on the player-carrying variant.
+func TestBindingRepositoryCurrentWithPlayerReturnsNotFoundForCharacterWithoutBinding(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewBindingRepository(testPool)
+
+	_, _, err := repo.CurrentWithPlayer(ctx, ulid.Make().String())
+	errutil.AssertErrorCode(t, err, "BINDING_NOT_FOUND")
+}
+
 func TestBindingRepositoryCurrentReturnsNotFoundForCharacterWithoutBinding(t *testing.T) {
 	ctx := context.Background()
 	repo := postgres.NewBindingRepository(testPool)

--- a/plugins/core-scenes/publish_snapshot_integration_test.go
+++ b/plugins/core-scenes/publish_snapshot_integration_test.go
@@ -119,8 +119,8 @@ func (snapNoopBackpressure) ShouldThrottle(_ string) bool { return false }
 
 type snapDEKBindingStub struct{ bindingID string }
 
-func (s *snapDEKBindingStub) Current(_ context.Context, _ string) (string, error) {
-	return s.bindingID, nil
+func (s *snapDEKBindingStub) CurrentWithPlayer(_ context.Context, _ string) (bindingID, playerID string, err error) {
+	return s.bindingID, "", nil
 }
 
 type snapAlwaysTrueCryptoKeysLookup struct{}

--- a/test/integration/crypto/e2e_test.go
+++ b/test/integration/crypto/e2e_test.go
@@ -54,8 +54,8 @@ type dekBindingStub struct {
 	bindingID string
 }
 
-func (s *dekBindingStub) Current(_ context.Context, _ string) (string, error) {
-	return s.bindingID, nil
+func (s *dekBindingStub) CurrentWithPlayer(_ context.Context, _ string) (bindingID, playerID string, err error) {
+	return s.bindingID, "", nil
 }
 
 // e2eEnv groups the bus + crypto + audit + reader fixture used by the

--- a/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
@@ -30,8 +30,8 @@ import (
 // that don't depend on a wizard binding store.
 type dekBindingStubE2E struct{ id string }
 
-func (s *dekBindingStubE2E) Current(_ context.Context, _ string) (string, error) {
-	return s.id, nil
+func (s *dekBindingStubE2E) CurrentWithPlayer(_ context.Context, _ string) (bindingID, playerID string, err error) {
+	return s.id, "", nil
 }
 
 // Scene log ciphertext and audit header round-trip specs — INV-CRYPTO-41 + INV-CRYPTO-47.

--- a/test/integration/privacy/scene_history_readback_test.go
+++ b/test/integration/privacy/scene_history_readback_test.go
@@ -85,8 +85,8 @@ func (rbPrivacyNoopBackpressure) ShouldThrottle(_ string) bool { return false }
 // rbPrivacyDEKBindingStub implements dek.BindingResolver with a fixed binding ID.
 type rbPrivacyDEKBindingStub struct{ bindingID string }
 
-func (s *rbPrivacyDEKBindingStub) Current(_ context.Context, _ string) (string, error) {
-	return s.bindingID, nil
+func (s *rbPrivacyDEKBindingStub) CurrentWithPlayer(_ context.Context, _ string) (bindingID, playerID string, err error) {
+	return s.bindingID, "", nil
 }
 
 // rbPrivacyAlwaysTrueCryptoKeysLookup always reports that a DEK exists.


### PR DESCRIPTION
## Summary

The comms genesis DEK seed (`publisher.initialParticipantsForContext`) seeded `character.<id>` private-message recipients (page/whisper/pemit) with `CharacterID` only, leaving `PlayerID` empty. `AuthGuard.checkPlayer` (`internal/eventbus/authguard/guard.go`) is `PlayerID`-gated, so the **player-history branch was structurally dead for comms recipients** — a recipient whose character↔player binding later *rotated* lost `read_own_history` access to their own old private messages, where a scene participant kept it. Fail-closed (no leak), but asymmetric with the scene-focus seed (`sceneaccess_service.go:417`), which records `PlayerID`.

Decision (recorded on `holomush-5rh.8.29.11`): **resolve `PlayerID` at comms genesis** — the ADR `holomush-olpdd` character-only scoping was a mechanical limit ("publisher has no PlayerID in scope"), not a policy that comms history should die with the binding.

- `internal/world/postgres/binding_repo.go` — keep `Current` (binding_id only, for the `grpc.BindingRepo` consumer) **untouched**; add `CurrentWithPlayer` (binding_id + player_id) backed by a shared private `currentBinding` query (`SELECT id, player_id … WHERE character_id=$1 AND ended_at IS NULL`), so both come from the same active row atomically.
- `internal/eventbus/crypto/dek/manager.go` — `BindingResolver.Current` → `CurrentWithPlayer`; `GetOrCreate` (genesis) and `Add` fill `p.PlayerID` from the binding row **only when empty**, never clobbering the scene seed's explicit `PlayerID`.
- 8 dek-side test stubs migrated; `grpc.BindingRepo` + `session_identity.go` left untouched (that consumer needs only `binding_id` and already holds `playerID`).
- ADR addendum recorded on `holomush-olpdd`.

## Test Plan

- [x] `manager_integration_test.go`: genesis fills empty `PlayerID` (RED-verified — fails with the populate line disabled); preserves a caller-supplied `PlayerID` (no clobber); `Add` fills empty `PlayerID` from the resolved binding.
- [x] `binding_repo_test.go`: `CurrentWithPlayer` returns binding_id + player_id; `BINDING_NOT_FOUND` path preserved.
- [x] Full impacted integration surface green (2928 tests across dek / world-postgres / grpc / plugins-core-scenes / privacy / crypto / eventbus_e2e / cmd-holomush / plugin / eventbus / testsupport).
- [x] `task pr-prep` fast lane: pass.
- [x] `crypto-reviewer`: READY. `code-reviewer`: READY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)