### PR TITLE
fix(eventbus): empty-window short-circuit for scene IC backfill below scope floor (holomush-tn12i)

### DIFF
--- a/internal/grpc/query_stream_history.go
+++ b/internal/grpc/query_stream_history.go
@@ -285,6 +285,47 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 		notAfter = time.UnixMilli(req.NotAfterMs).UTC()
 	}
 
+	// Step 6c: Empty-window short-circuit (holomush-tn12i). The Step 6 clamp
+	// raises notBefore to the server-side scope floor, but notAfter keeps the
+	// client value. When a non-zero notAfter falls below that floor — e.g. a
+	// scene backfill whose attach_moment precedes the focus JoinedAt floor — the
+	// requested upper bound sits under the floor, so the authorized window is
+	// empty. That is a legitimately empty result, not a malformed query:
+	// returning the empty page here avoids handing an inverted range to the tier
+	// reader's validateQuery, which would otherwise reject it as
+	// EVENTBUS_HISTORY_INVALID_TIME_RANGE (the observed connect-time browser
+	// 500). Logged at debug so a sustained flood — which can signal frontend
+	// clock skew or a stale attach_moment — stays visible without noising the
+	// normal path.
+	//
+	// Only the FLOOR-induced inversion short-circuits. If the client's own lower
+	// bound (raw NotBeforeMs, pre-clamp) already exceeds notAfter, the request
+	// itself is inverted — that is a client error, and it MUST stay on the
+	// validateQuery rejection path rather than being masked as a successful
+	// empty page. The clamp can only ever raise notBefore, so a client whose
+	// supplied bounds were valid (clientNotBefore <= notAfter, or unbounded) is
+	// the only one whose inversion is purely floor-induced.
+	if !notAfter.IsZero() && notBefore.After(notAfter) {
+		var clientNotBefore time.Time
+		if req.NotBeforeMs > 0 {
+			clientNotBefore = time.UnixMilli(req.NotBeforeMs).UTC()
+		}
+		if clientNotBefore.IsZero() || !clientNotBefore.After(notAfter) {
+			slog.DebugContext(
+				ctx, "history query window empty below scope floor",
+				"session_id", req.SessionId,
+				"stream", stream,
+				"not_before", notBefore,
+				"not_after", notAfter,
+			)
+			return &corev1.QueryStreamHistoryResponse{
+				Meta: responseMeta(requestID),
+			}, nil
+		}
+		// Client supplied not_before_ms > not_after_ms: fall through so the tier
+		// reader's validateQuery rejects the malformed range as before.
+	}
+
 	// Step 7: Fetch count+1 to detect has_more.
 	// Delegate to the JetStream/PostgreSQL tier crossover reader (F4+).
 	// Both paths produce ascending (oldest→newest) slices of count+1 events maximum.

--- a/internal/grpc/query_stream_history_test.go
+++ b/internal/grpc/query_stream_history_test.go
@@ -486,6 +486,121 @@ func TestQueryStreamHistoryNotBeforeMsForwardsToBus(t *testing.T) {
 	assert.Equal(t, eventbus.DirectionBackward, reader.gotQ.Direction)
 }
 
+// TestQueryStreamHistoryEmptyWindowShortCircuit covers the Step 6c guard
+// (holomush-tn12i): a non-zero notAfter below the scope floor yields an empty
+// page without querying the bus; a notAfter at or above the floor does not
+// short-circuit; and a client-supplied inverted range (not_before_ms >
+// not_after_ms) is NOT masked as empty — it falls through to the reader, where
+// validateQuery rejects it. Both floor sources are exercised — scene focus
+// JoinedAt and location LocationArrivedAt — since the bug manifests on either.
+func TestQueryStreamHistoryEmptyWindowShortCircuit(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(time.Hour)
+	charID := ulid.MustParse("01HYXYZCHAR0000000000000CH")
+	sceneStream, fm := sceneFocusMembership(t)
+	// Millisecond-truncated floor so the equal-boundary case is exact across the
+	// Postgres round-trip (timestamps persist as epoch-ns; a ms floor survives
+	// losslessly, and req.NotAfterMs is ms-precision).
+	floor := time.UnixMilli(time.Now().Add(-time.Hour).UnixMilli()).UTC()
+	fm.JoinedAt = floor
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
+	locStream := "location." + locID.String()
+
+	tests := []struct {
+		name         string
+		info         *session.Info
+		stream       string
+		notBeforeMs  int64
+		notAfterMs   int64
+		wantBusQuery bool // true ⇒ guard does NOT fire and the bus is queried
+	}{
+		{
+			name: "scene backfill below focus JoinedAt floor returns empty without querying bus",
+			info: &session.Info{
+				ID: "s1", CharacterID: charID, ExpiresAt: &future,
+				FocusMemberships: []session.FocusMembership{fm},
+			},
+			stream:       sceneStream,
+			notAfterMs:   floor.Add(-time.Hour).UnixMilli(),
+			wantBusQuery: false,
+		},
+		{
+			name: "location backfill below arrival floor returns empty without querying bus",
+			info: &session.Info{
+				ID: "s1", CharacterID: charID, ExpiresAt: &future,
+				LocationID: locID, LocationArrivedAt: floor,
+			},
+			stream:       locStream,
+			notAfterMs:   floor.Add(-time.Hour).UnixMilli(),
+			wantBusQuery: false,
+		},
+		{
+			name: "notAfter exactly at the floor does not short-circuit",
+			info: &session.Info{
+				ID: "s1", CharacterID: charID, ExpiresAt: &future,
+				LocationID: locID, LocationArrivedAt: floor,
+			},
+			stream:       locStream,
+			notAfterMs:   floor.UnixMilli(),
+			wantBusQuery: true,
+		},
+		{
+			// Client itself sends not_before_ms > not_after_ms. The clamp can only
+			// raise notBefore, so this inversion is the client's, not the floor's:
+			// it must reach the reader (where validateQuery rejects it), never be
+			// swallowed as an empty page.
+			name: "client-supplied inverted range is not swallowed as empty",
+			info: &session.Info{
+				ID: "s1", CharacterID: charID, ExpiresAt: &future,
+				LocationID: locID, LocationArrivedAt: floor,
+			},
+			stream:       locStream,
+			notBeforeMs:  floor.Add(time.Hour).UnixMilli(),
+			notAfterMs:   floor.UnixMilli(),
+			wantBusQuery: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sess := newTestSessionStore(t, map[string]*session.Info{"s1": tc.info})
+			// Seed an event so an empty response can only originate from the
+			// short-circuit, never from the bus returning nothing. Use the
+			// fully-qualified subject the handler resolves the stream to
+			// (currentGameID defaults to "main"; an already-qualified scene
+			// subject passes through Qualify unchanged).
+			eventSubject, qErr := eventbus.Qualify("main", tc.stream)
+			require.NoError(t, qErr)
+			reader := &fakeHistoryReader{events: []eventbus.Event{{
+				ID:        core.NewULID(),
+				Subject:   eventSubject,
+				Type:      "scene.pose",
+				Timestamp: floor,
+				Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
+				Payload:   []byte("p"),
+			}}}
+			s := newQueryStreamHistoryServer(t, reader, sess)
+			resp, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
+				SessionId:   "s1",
+				Stream:      tc.stream,
+				NotBeforeMs: tc.notBeforeMs,
+				NotAfterMs:  tc.notAfterMs,
+				Count:       10,
+			})
+			require.NoError(t, err)
+			if tc.wantBusQuery {
+				assert.NotEmpty(t, reader.gotQ.Subject, "bus MUST be queried when the window is non-empty")
+				return
+			}
+			assert.Empty(t, resp.GetEvents())
+			assert.False(t, resp.GetHasMore())
+			assert.Empty(t, resp.GetNextCursor())
+			assert.Empty(t, reader.gotQ.Subject, "bus MUST NOT be queried for an empty authorized window")
+		})
+	}
+}
+
 // TestQueryStreamHistoryRejectsCursorWithStaleEpoch covers the epoch-mismatch
 // branch: a cursor whose Epoch != CurrentEpoch() gets FailedPrecondition.
 func TestQueryStreamHistoryRejectsCursorWithStaleEpoch(t *testing.T) {
@@ -1273,12 +1388,21 @@ func TestQueryStreamHistoryNotAfterMsPlumbing(t *testing.T) {
 			future := time.Now().Add(time.Hour)
 			locA := ulid.MustParse("01HYXLOCA0000000000000000A")
 			charID := ulid.MustParse("01HYXCHAR00000000000000001")
+			// Set LocationArrivedAt well before attachMoment so the scope floor
+			// stays below notAfter. Without this, Postgres COALESCEs a zero
+			// LocationArrivedAt to now() (holomush-9mxr), making scopeFloor > the
+			// past attachMoment and tripping the empty-window short-circuit
+			// (holomush-tn12i) — which returns empty before forwarding NotAfter,
+			// defeating this plumbing assertion. A non-empty window is the
+			// precondition under which NotAfter is forwarded at all.
+			arrivedAt := time.Now().Add(-3 * time.Hour)
 			sess := newTestSessionStore(t, map[string]*session.Info{
 				"sess-1": {
-					ID:          "sess-1",
-					CharacterID: charID,
-					LocationID:  locA,
-					ExpiresAt:   &future,
+					ID:                "sess-1",
+					CharacterID:       charID,
+					LocationID:        locA,
+					LocationArrivedAt: arrivedAt,
+					ExpiresAt:         &future,
 				},
 			})
 			reader := &fakeHistoryReader{events: nil}


### PR DESCRIPTION
## Summary

- `QueryStreamHistory` clamps `notBefore` **up** to the server-side stream scope floor (`streamScopeFloor`) but leaves the client-supplied `notAfter` (the Subscribe `attach_moment`) untouched. When the floor exceeds a non-zero `notAfter`, the inverted range reached the tier reader's `validateQuery` (`internal/eventbus/history/tier.go:478`) and was rejected as `EVENTBUS_HISTORY_INVALID_TIME_RANGE` — surfacing as a connect-time browser 500 (`NotBefore must be <= NotAfter`).
- Adds a **Step 6c empty-window guard** in `internal/grpc/query_stream_history.go`: when `notAfter` is non-zero and `notBefore.After(notAfter)`, the authorized window lies entirely below the scope floor and is legitimately empty — return an empty page **before** `fetchHistoryFramesFromBus` rather than building an inverted query. `validateQuery` is left unchanged (it correctly rejects a genuinely client-malformed range; this inversion is server-introduced by the clamp).
- Chose short-circuit-empty over clamping `notAfter = notBefore` to avoid surfacing an event exactly at the floor instant.

### Triggers (both produce floor > attach_moment)
- **Scene IC backfill** whose `attach_moment` precedes the focus `JoinedAt` floor.
- **Location stream** whose Postgres-COALESCEd `LocationArrivedAt = now()` exceeds a past `attach_moment`.

This corrects the earlier mis-attribution recorded on the bead: `notAfterMs=0` is the server's *unbounded* sentinel and never inverts; the real trigger is a non-zero client `notAfter` below the scope floor.

## Test Plan

- [x] New `TestQueryStreamHistoryReturnsEmptyWhenScopeFloorExceedsNotAfter` — backed by the real Postgres store (`sessiontest.NewStore`), so it exercises the actual scope-floor computation; asserts empty result **and** that the bus is never queried (proving the short-circuit, not an empty bus). Red before the guard, green after.
- [x] Fixed pre-existing `TestQueryStreamHistoryNotAfterMsPlumbing`, which accidentally relied on an inverted window (no explicit `LocationArrivedAt` → COALESCEd to `now()` > a past `attachMoment`); now sets `LocationArrivedAt=-3h` so its plumbing assertion runs against a non-empty window.
- [x] `task test -- ./internal/grpc/` — 437 tests pass.
- [x] `task lint` — exit 0.
- [x] `task pr-prep` (fast lane) — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)