### PR TITLE
fix(core-scenes): stop leaking inner error text on codes.Internal (holomush-2dsxm)

### DIFF
--- a/plugins/core-scenes/service.go
+++ b/plugins/core-scenes/service.go
@@ -275,7 +275,12 @@ func (s *SceneServiceImpl) CreateScene(ctx context.Context, req *scenev1.CreateS
 	id, err := newSceneID()
 	if err != nil {
 		recordError(span, err)
-		return nil, status.Errorf(codes.Internal, "failed to generate scene id: %v", err)
+		slog.WarnContext(
+			ctx, "scene.service.create_scene id generation error",
+			"subject_id", req.GetCharacterId(),
+			"error", err,
+		)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 	span.SetAttributes(attribute.String("scene_id", id))
 
@@ -314,7 +319,7 @@ func (s *SceneServiceImpl) CreateScene(ctx context.Context, req *scenev1.CreateS
 			"scene_id", id,
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to prepare scene event: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 	if s.eventSink == nil {
 		err := oops.Code("SCENE_EVENT_SINK_NOT_CONFIGURED").
@@ -327,7 +332,7 @@ func (s *SceneServiceImpl) CreateScene(ctx context.Context, req *scenev1.CreateS
 			"scene_id", id,
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to prepare scene event: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	if err := s.store.CreateWithOwner(ctx, row); err != nil {
@@ -338,7 +343,7 @@ func (s *SceneServiceImpl) CreateScene(ctx context.Context, req *scenev1.CreateS
 			"scene_id", id,
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to create scene: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	if err := s.eventSink.Emit(ctx, intent); err != nil {
@@ -354,7 +359,7 @@ func (s *SceneServiceImpl) CreateScene(ctx context.Context, req *scenev1.CreateS
 			"scene_id", id,
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to emit scene event: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 	metricSceneCreated(string(visibility), false)
 	slog.InfoContext(
@@ -651,7 +656,7 @@ func (s *SceneServiceImpl) EndScene(ctx context.Context, req *scenev1.EndSceneRe
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to end scene: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	metricSceneStateTransition(string(SceneStateActive)+"_or_paused", "ended", "rpc")
@@ -685,7 +690,7 @@ func (s *SceneServiceImpl) PauseScene(ctx context.Context, req *scenev1.PauseSce
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to pause scene: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	metricSceneStateTransition("active", "paused", "rpc")
@@ -720,7 +725,7 @@ func (s *SceneServiceImpl) ResumeScene(ctx context.Context, req *scenev1.ResumeS
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to resume scene: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	metricSceneStateTransition("paused", "active", "rpc")
@@ -794,7 +799,7 @@ func (s *SceneServiceImpl) UpdateScene(ctx context.Context, req *scenev1.UpdateS
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to update scene: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	// Auto-emit scene_pose_order_changed_ic when pose_order_mode actually
@@ -900,7 +905,7 @@ func (s *SceneServiceImpl) JoinScene(ctx context.Context, req *scenev1.JoinScene
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to join scene: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	// Auto-emit scene_join_ic notice event when this is a NEW membership
@@ -1209,7 +1214,13 @@ func (s *SceneServiceImpl) LeaveScene(ctx context.Context, req *scenev1.LeaveSce
 		if errors.As(err, &oe) && oe.Code() == "SCENE_NOT_FOUND" {
 			return nil, status.Errorf(codes.NotFound, "scene not found: %s", req.GetSceneId())
 		}
-		return nil, status.Errorf(codes.Internal, "failed to load scene: %v", err)
+		slog.WarnContext(
+			ctx, "scene.service.leave_scene load error",
+			"subject_id", req.GetCharacterId(),
+			"scene_id", req.GetSceneId(),
+			"error", err,
+		)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 	if sceneRow.OwnerID == req.GetCharacterId() {
 		err := status.Errorf(codes.FailedPrecondition,
@@ -1238,7 +1249,7 @@ func (s *SceneServiceImpl) LeaveScene(ctx context.Context, req *scenev1.LeaveSce
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to leave scene: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	// Auto-emit scene_leave_ic notice event. Non-fatal: membership is already
@@ -1278,7 +1289,7 @@ func (s *SceneServiceImpl) InviteToScene(ctx context.Context, req *scenev1.Invit
 			"target_id", req.GetTargetCharacterId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to invite: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	slog.InfoContext(
@@ -1321,7 +1332,7 @@ func (s *SceneServiceImpl) KickFromScene(ctx context.Context, req *scenev1.KickF
 			"target_id", req.GetTargetCharacterId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to kick: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	// Auto-emit scene_leave_ic notice event (reason=kicked). Non-fatal:
@@ -1375,7 +1386,7 @@ func (s *SceneServiceImpl) TransferOwnership(ctx context.Context, req *scenev1.T
 			"new_owner", req.GetNewOwnerCharacterId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to transfer ownership: %v", err)
+		return nil, status.Errorf(codes.Internal, "internal error")
 	}
 
 	slog.InfoContext(

--- a/plugins/core-scenes/service_test.go
+++ b/plugins/core-scenes/service_test.go
@@ -6,6 +6,9 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -786,6 +789,84 @@ func TestSceneServiceCreateSceneReturnsInternalWhenStoreFails(t *testing.T) {
 	require.Error(t, err)
 	st, _ := status.FromError(err)
 	assert.Equal(t, codes.Internal, st.Code())
+	// Opacity (.claude/rules/grpc-errors.md / holomush-2dsxm): the inner store
+	// error text MUST NOT reach the wire.
+	assert.Equal(t, "internal error", st.Message(),
+		"inner error text must not leak past the trust boundary")
+	assert.NotContains(t, st.Message(), "boom")
+}
+
+// TestSceneServiceJoinSceneReturnsOpaqueInternalWhenStoreFails verifies the
+// AddParticipant store-error path returns an opaque Internal (no inner text),
+// per .claude/rules/grpc-errors.md (holomush-2dsxm).
+func TestSceneServiceJoinSceneReturnsOpaqueInternalWhenStoreFails(t *testing.T) {
+	store := newFakeStore()
+	require.NoError(t, store.CreateWithOwner(context.Background(), &SceneRow{
+		ID: "scene-join-boom", OwnerID: "char-alice",
+		State: string(SceneStateActive), Visibility: string(SceneVisibilityOpen),
+	}))
+	// Plain (non-oops-coded) error so it falls past the mapped cases to the
+	// generic Internal branch.
+	store.addParticipantErr = errors.New("pgx: relation \"scene_participants\" does not exist")
+	svc := newTestService(t, store)
+
+	_, err := svc.JoinScene(context.Background(), &scenev1.JoinSceneRequest{
+		CharacterId: "char-bob", SceneId: "scene-join-boom",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Equal(t, "internal error", st.Message(),
+		"inner error text must not leak past the trust boundary")
+	assert.NotContains(t, st.Message(), "scene_participants")
+}
+
+// TestSceneServiceLeaveSceneReturnsOpaqueInternalWhenLoadFails verifies the
+// scene-load (store.Get) error path in LeaveScene returns an opaque Internal
+// for a non-NotFound store failure (holomush-2dsxm).
+func TestSceneServiceLeaveSceneReturnsOpaqueInternalWhenLoadFails(t *testing.T) {
+	store := newFakeStore()
+	// Non-SCENE_NOT_FOUND error → the Internal branch, not the NotFound branch.
+	store.getErr = errors.New("pgx: connection refused")
+	svc := newTestService(t, store)
+
+	_, err := svc.LeaveScene(context.Background(), &scenev1.LeaveSceneRequest{
+		CharacterId: "char-bob", SceneId: "scene-x",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Equal(t, "internal error", st.Message(),
+		"inner error text must not leak past the trust boundary")
+	assert.NotContains(t, st.Message(), "connection refused")
+}
+
+// TestNoInternalErrorLeaksInSceneSource guards .claude/rules/grpc-errors.md
+// (holomush-2dsxm): no codes.Internal status may interpolate an inner error into
+// its wire message. The behavioral tests above prove the contract for
+// representative handlers; this scan covers every site in the package and keeps
+// regressions out.
+func TestNoInternalErrorLeaksInSceneSource(t *testing.T) {
+	// The format string is the first literal after codes.Internal; a format verb
+	// inside it means an argument is interpolated into the wire message. \s* spans
+	// newlines so a call split across lines is still caught.
+	leak := regexp.MustCompile(`status\.Errorf\(\s*codes\.Internal\s*,\s*"[^"]*%[a-z]`)
+	srcs, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+	for _, fname := range srcs {
+		if strings.HasSuffix(fname, "_test.go") {
+			continue
+		}
+		src, readErr := os.ReadFile(fname)
+		require.NoError(t, readErr)
+		for _, loc := range leak.FindAllIndex(src, -1) {
+			line := 1 + strings.Count(string(src[:loc[0]]), "\n")
+			t.Errorf("%s:%d: codes.Internal status with a format verb leaks the inner "+
+				"error to the wire — log the error and return the opaque "+
+				`status.Errorf(codes.Internal, "internal error") `+
+				"(.claude/rules/grpc-errors.md)", fname, line)
+		}
+	}
 }
 
 func TestSceneServiceCreateSceneEmitsLifecycleEventWhenEventSinkConfigured(t *testing.T) {
@@ -819,7 +900,8 @@ func TestSceneServiceCreateSceneFailsWhenEventSinkIsMissing(t *testing.T) {
 	require.Error(t, err)
 	st, _ := status.FromError(err)
 	assert.Equal(t, codes.Internal, st.Code())
-	assert.Contains(t, st.Message(), "failed to prepare scene event")
+	// Opaque wire message — no inner detail (holomush-2dsxm).
+	assert.Equal(t, "internal error", st.Message())
 	assert.Empty(t, store.scenes)
 }
 
@@ -836,7 +918,9 @@ func TestSceneServiceCreateSceneReturnsInternalWhenEventEmitFailsAfterPersist(t 
 	require.Error(t, err)
 	st, _ := status.FromError(err)
 	assert.Equal(t, codes.Internal, st.Code())
-	assert.Contains(t, st.Message(), "failed to emit scene event")
+	// Opaque wire message — the inner "boom" must not leak (holomush-2dsxm).
+	assert.Equal(t, "internal error", st.Message())
+	assert.NotContains(t, st.Message(), "boom")
 	require.Len(t, store.scenes, 1)
 }
 


### PR DESCRIPTION
## Summary

`plugins/core-scenes/service.go` had **15** handler sites returning `status.Errorf(codes.Internal, "...: %v", err)`, interpolating the inner error into the gRPC `Status.message` — which reaches clients and can leak table names, query fragments, stack pointers, and file paths (`.claude/rules/grpc-errors.md`).

- All 15 now return the opaque `status.Errorf(codes.Internal, "internal error")`. Chose `Errorf` (not the rule's `status.Error`) because the repo's `wrapcheck` allowlist covers `Errorf` but not `Error`, and it matches the file's own safe precedent at `service.go:613` — avoiding 15 `//nolint` directives.
- **13** of the 15 already logged the inner error via a preceding `slog.WarnContext`; the two that did not — the `newSceneID` failure in `CreateScene` and `LeaveScene`'s `store.Get` error branch — gain a `slog.WarnContext` so the detail is captured internally rather than lost.
- `resolver.go` needed no change: its only `%v` site echoes the client's own `resource_id` under `codes.NotFound`, which is not an internal leak. (The bead's `resolver.go:95` and the `service.go` line numbers were stale — actual count was 15, not 17.)

## Test Plan

- [x] Strengthened `TestSceneServiceCreateSceneReturnsInternalWhenStoreFails` to assert the opaque message (was code-only).
- [x] Added `JoinScene` / `LeaveScene` opacity tests (message == `"internal error"`, inner text absent) using existing `fakeStore` error hooks. Red before the fix, green after.
- [x] Added `TestNoInternalErrorLeaksInSceneSource` — a source-scan guard covering all 15 sites and preventing regression (any `codes.Internal` status that regains a format verb fails it).
- [x] Updated 2 pre-existing tests that asserted the **old leaky** messages.
- [x] `plugins/core-scenes` — 612 tests pass · `task lint` — exit 0 · `task pr-prep` (fast lane) — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)