### PR TITLE
docs(rules): fix grpc-errors.md opaque-Internal example — errutil logger + wrapcheck-clean return (holomush-x1zol)

### DIFF
--- a/.claude/rules/grpc-errors.md
+++ b/.claude/rules/grpc-errors.md
@@ -28,9 +28,20 @@ These rules come from CodeRabbit findings on PR #267 (`holomush-095g`). They wer
 return nil, status.Errorf(codes.Internal, "load scene: %v", err)
 
 // RIGHT — log internally, return generic message
-slog.ErrorContext(ctx, "load scene failed", "err", err)
-return nil, status.Error(codes.Internal, "internal error")
+errutil.LogErrorContext(ctx, "load scene failed", err)
+return nil, status.Errorf(codes.Internal, "internal error")
 ```
+
+**Log with `errutil.LogErrorContext(ctx, msg, err, extraAttrs...)`** (per the
+CLAUDE.md Error Handling rule), not a bare `slog.*Context`. It forwards `ctx`
+for trace/span correlation **and** extracts the oops `code` + context map as
+structured fields — a bare `slog.ErrorContext(ctx, msg, "err", err)` flattens
+the oops error to a plain string, losing the code you would filter on in
+Loki/Sentry. It still takes extra key/value attrs for handler context
+(`"scene_id", id`).
+
+**Return `status.Errorf` with a static string (no format verb):** it is
+wrapcheck-allowlisted, so the opaque return needs no `//nolint`. `status.Error(codes.Internal, "internal error")` is behaviorally identical but is **not** allowlisted, so it requires a line-scoped `//nolint:wrapcheck` (see [Linter compliance](#linter-compliance)). Either is fine; prefer `Errorf` to keep the diff nolint-free.
 
 ## Translate gRPC errors at ONE layer only
 


### PR DESCRIPTION
## Summary

The canonical "RIGHT" example in `.claude/rules/grpc-errors.md` had two problems when followed literally:

1. **Logging form** — it used a bare `slog.ErrorContext(ctx, "…", "err", err)`. That carries `ctx` but flattens an `oops` error to a plain string, losing the `code` + `.With()` context map you'd filter on in Loki/Sentry. Switched to **`errutil.LogErrorContext(ctx, msg, err)`** — the repo's canonical error logger (per the CLAUDE.md Error Handling rule), which forwards `ctx` *and* extracts the oops structured fields, and still accepts extra attrs for handler context (`"scene_id", id`).

2. **Return form** — it used `status.Error(codes.Internal, "internal error")` with no `//nolint`, but `status.Error` trips `wrapcheck` (`Errorf` is allowlisted, `Error` is not). So the example **failed the repo's own lint as written** — surfaced as a 15-site detour on PR #4421 (`holomush-2dsxm`). Switched to `status.Errorf(codes.Internal, "internal error")` (static string, no verb → nolint-free) and noted the `status.Error` equivalent needs a line-scoped `//nolint:wrapcheck`.

Docs-only; no code changes. Both points are now copy-paste-correct against the repo's linters and conventions.

## Test Plan

- [x] `task pr-prep` — pass (docs lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)