### PR TITLE
docs(plugin): plugin capability & dependency foundation — spec, plan, ADRs (holomush-oeb4d)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,9 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Typed-entry requires model for plugin manifests (capability/service kind tags)](holomush-mg4x6-typed-entry-requires-model-plugin-manifests-capability-servi.md) | 2026-06-11 | Accepted | `holomush-mg4x6` |
+| [Fail-fast fail-closed plugin-loader policy with structured ResolveResult](holomush-dfkca-fail-fast-fail-closed-plugin-loader-policy-structured-resolv.md) | 2026-06-11 | Accepted | `holomush-dfkca` |
+| [Lua plugin capability/service transport via in-process gRPC over the host broker](holomush-gtkzy-lua-plugin-capability-service-transport-via-process-grpc-ove.md) | 2026-06-11 | Accepted | `holomush-gtkzy` |
 | [KEK presence is the single activation gate for sensitive-event crypto](holomush-gkw77-kek-presence-is-single-activation-gate-sensitive-event-crypt.md) | 2026-06-09 | Accepted | `holomush-gkw77` |
 | [Require a provisioned KEK to boot; auto-generate keyfile, never the passphrase](holomush-kddop-require-provisioned-kek-boot-auto-generate-keyfile-never-pas.md) | 2026-06-09 | Accepted | `holomush-kddop` |
 | [DEK seed failure is FATAL and refuses scene focus](holomush-mihtk-dek-seed-failure-is-fatal-and-refuses-scene-focus.md) | 2026-06-09 | Accepted | `holomush-mihtk` |

--- a/docs/adr/holomush-dfkca-fail-fast-fail-closed-plugin-loader-policy-structured-resolv.md
+++ b/docs/adr/holomush-dfkca-fail-fast-fail-closed-plugin-loader-policy-structured-resolv.md
@@ -1,0 +1,38 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-dfkca; do not edit manually; use `/adr update holomush-dfkca` -->
+
+# Fail-fast fail-closed plugin-loader policy with structured ResolveResult
+
+**Date:** 2026-06-11
+**Status:** Accepted
+**Decision:** holomush-dfkca
+**Deciders:** Sean Brandt
+
+## Context
+
+The legacy plugin resolver returned `(order, error)` and, on any unsatisfied `requires`, emitted a WARN and fell back to a global priority sort for the ENTIRE plugin set — masking the breadth (it returned on the first miss) and silently violating load-order on every boot. This is the root of bug holomush-oeb4d / holomush-o262d (three of four phantom requires were hidden behind the first).
+
+## Decision
+
+Replace `(order, error)` with a structured `ResolveResult{Ordered, Unsatisfied[], Cycles[]}`. The loader's default policy treats any non-empty `Unsatisfied` (excluding `optional: true` entries, which are skipped) or any `Cycles` as a FATAL boot error — fail-fast, fail-closed. The structured shape lets a future per-plugin quarantine policy be a policy-layer flip, not a resolver rewrite.
+
+## Rationale
+
+- Fail-closed mirrors the crypto KEK-mandatory-boot posture (INV-CRYPTO-119): unsatisfied plugin dependencies are as load-bearing as missing encryption keys.
+- The structured result decouples resolver logic from policy, so per-plugin quarantine (future) needs no resolver changes.
+- Collecting ALL unsatisfied entries in one pass surfaces the full breadth, unlike the legacy first-miss-then-stop that hid three of the four phantom requires.
+
+## Alternatives Considered
+
+**Legacy WARN + global priority-sort fallback** — rejected: masks the count (first-miss stop), silently violates load-order, hid the boot bug.
+**Pure whole-server fatal on first unsatisfied dep (no structured result)** — rejected: no future quarantine path without a rewrite; one error per run.
+**Structured ResolveResult + fail-fast default policy** — CHOSEN.
+
+## Consequences
+
+**Positive:** boot fails loudly + completely on any non-optional unsatisfied dep — no silent degradation; all unsatisfied deps reported in one pass; future quarantine needs no resolver change. **Negative:** a missing provider refuses the whole boot until fixed; the four phantom requires MUST be reclassified before fail-fast lands safely (spec §4, in the foundation). **Neutral:** `optional: true` deps are skipped, preserving an explicit graceful-degrade path.

--- a/docs/adr/holomush-gtkzy-lua-plugin-capability-service-transport-via-process-grpc-ove.md
+++ b/docs/adr/holomush-gtkzy-lua-plugin-capability-service-transport-via-process-grpc-ove.md
@@ -1,0 +1,38 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-gtkzy; do not edit manually; use `/adr update holomush-gtkzy` -->
+
+# Lua plugin capability/service transport via in-process gRPC over the host broker
+
+**Date:** 2026-06-11
+**Status:** Accepted
+**Decision:** holomush-gtkzy
+**Deciders:** Sean Brandt
+
+## Context
+
+Lua plugins receive most host functions unconditionally via direct VM injection (hostfunc/functions.go:253-265), bypassing any declaration gate; binary plugins consume host capabilities and plugin services via the grpcbroker over mTLS (carrying the plugin ABAC subject). The plugin-runtime-symmetry rule mandates both runtimes share one gate path, and the plugin→host→plugin path (a Lua plugin reaching another plugin's service) has no Go-shim solution.
+
+## Decision
+
+Lua plugins obtain access to host capabilities AND plugin services exclusively through an injected in-process gRPC proxy over the host broker — identical in contract, declaration-gating, and PluginSubject authorization to the binary path. Transport wiring/performance (bufconn, batching, hot-path fast lane) is deferred to sub-spec 3 but cannot reopen this invariant.
+
+## Rationale
+
+- The plugin→host→plugin path requires Lua to reach arbitrary plugin-provided services; no Go shim can exist for an arbitrary plugin's proto contract, so Lua MUST have a brokered gRPC path.
+- Once that path exists for plugin services, host capabilities use the same path — one gate, not two.
+- A Go-shim transport would split the least-privilege gate (broker for binary, injection for Lua), recreating the privilege asymmetry plugin-runtime-symmetry exists to prevent.
+- It makes 'every capability is a gRPC contract' the REAL consumption path for both runtimes, not nominal.
+
+## Alternatives Considered
+
+**Go shim per capability injected into the Lua VM** — rejected: cannot serve plugin→host→plugin (no shim for an arbitrary plugin service); splits the gate across two paths (drift hazard); makes the gRPC contract nominal for Lua.
+**In-process gRPC proxy over the host broker** — CHOSEN.
+
+## Consequences
+
+**Positive:** single least-privilege gate at the broker/registry common path covers both runtimes; Lua can call plugin services (plugin→host→plugin unblocked); symmetry satisfied structurally. **Negative:** gRPC serialization overhead on Lua calls until sub-spec 3 adds a fast lane; unconditional Lua injection must be removed — a breaking change requiring all Lua plugins to declare capabilities (sub-spec 5). **Neutral:** the binary grpcbroker transport is reused unchanged; only the Lua side gains a path.

--- a/docs/adr/holomush-mg4x6-typed-entry-requires-model-plugin-manifests-capability-servi.md
+++ b/docs/adr/holomush-mg4x6-typed-entry-requires-model-plugin-manifests-capability-servi.md
@@ -1,0 +1,38 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-mg4x6; do not edit manually; use `/adr update holomush-mg4x6` -->
+
+# Typed-entry requires model for plugin manifests (capability/service kind tags)
+
+**Date:** 2026-06-11
+**Status:** Accepted
+**Decision:** holomush-mg4x6
+**Deciders:** Sean Brandt
+
+## Context
+
+The plugin manifest `requires:` field held a flat list of proto service names, conflating host capabilities with plugin-provided services and overloading one field for both DAG load-order and Lua capability injection. The manifest already carries a DEPRECATED top-level `capabilities:` field (manifest.go:94-96) that exists only to detect old-format manifests and error.
+
+## Decision
+
+Adopt typed object entries in `requires:`, each with a mandatory `capability:` or `service:` kind tag plus optional per-entry attributes (`version`, `optional`, `scope`). `capability` names use a controlled short vocabulary (host-provided, no DAG edge); `service` names use full proto paths (provider-before-consumer edge). The pre-existing `dependencies:` version map folds into service entries' `version`. `provides:` is unchanged.
+
+## Rationale
+
+- Per-entry attributes (least-privilege scope/access, optional, version) require the object form; flat strings would force a second manifest-wide migration later.
+- The explicit kind tag is an author assertion the resolver VALIDATES: `capability: X` where X is plugin-provided yields MISDECLARED_DEPENDENCY, never a silent reclassification.
+- The deprecated top-level `capabilities:` field makes the two-flat-fields option actively hazardous (name collision).
+
+## Alternatives Considered
+
+**Two flat fields (`capabilities:` + `requires:`)** — rejected: collides with the deprecated top-level `capabilities:` field; flat strings cannot carry per-entry attributes.
+**One flat list with implicit kind detection** — rejected: resolver must guess kind; a mis-typed capability silently reclassifies to an unsatisfied service; still no attributes.
+**Typed object entries with explicit kind tag** — CHOSEN.
+
+## Consequences
+
+**Positive:** resolver enforces kind correctness at boot; forward-compatible (new attributes need no migration); single declaration site absorbs the `dependencies:` map. **Negative:** all in-tree manifests need a migration pass (sub-spec 5); tooling reading flat `requires` must update. **Neutral:** `provides:` unchanged — only the consumer side is redesigned.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -313,6 +313,11 @@ invariants.
 | `INV-PLUGIN-38` | Lua Load-pass DoString errors MUST fail plugin load with the same wrapper shape as the syntax-check error (oops.In("lua"), operation=load); the Hint string is branch-specific ("INV-S5 capture pass execution error" for crypto plugins). | `INV-M6` | pending |
 | `INV-PLUGIN-39` | Every primitive in the INV-S5 mechanism MUST ship a Go SDK method + Lua hostfunc + parity test together (per parent substrate invariant INV-S3 / INV-PLUGIN-31). | `INV-M7` | pending |
 | `INV-PLUGIN-40` | Every emitted wire event type and every verbs[].type MUST be plugin-qualified <owning-plugin>:<verb> (one colon). The registered-emit set and crypto.emits[].event_type stay bare (INV-PLUGIN-32 set-equality + requests_decryption); the host bridges bare<->qualified only via emitEntryMatchesWireType. Manifest.Validate rejects an unqualified verbs[].type with PLUGIN_WIRE_TYPE_NOT_QUALIFIED. | — | bound |
+| `INV-PLUGIN-41` | The plugin dependency resolver MUST validate and order a single graph spanning host capabilities (satisfied without an ordering edge) and plugin-provided services (provider-before-consumer edge). A declared dependency unsatisfiable by either provider source MUST be reported, never silently dropped or reclassified. | — | pending |
+| `INV-PLUGIN-42` | A requires `capability:` entry MUST resolve to a registered host capability and a `service:` entry to a provided proto service; a kind/provider mismatch MUST be a hard MISDECLARED_DEPENDENCY error, not a silent reclassification. | — | pending |
+| `INV-PLUGIN-43` | An unsatisfied non-optional plugin dependency or a dependency cycle MUST fail the boot; the loader MUST NOT downgrade it to a WARN + priority-sort fallback. `optional: true` entries MAY be skipped. | — | pending |
+| `INV-PLUGIN-44` | Binary and Lua plugins MUST obtain every declared dependency through the one host gRPC broker, gated by the declaration and authorized as PluginSubject; neither runtime MAY receive an undeclared capability or service. Consumption-path facet of plugin-runtime-symmetry; distinct from INV-CRYPTO-34 (emit/fence/audit path). | — | pending |
+| `INV-PLUGIN-45` | The declaration gate that enforces least privilege MUST live at the broker/registry common path shared by both runtimes; per-runtime gating that could diverge is forbidden. | — | pending |
 
 ### `INV-EVENTBUS`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3713,6 +3713,38 @@ invariants:
       - "internal/plugin/manifest_test.go"
       - "internal/plugin/lua/corecomm_sensitive_emit_test.go"
       - "test/meta/plugin_verb_qualification_test.go"
+  - id: INV-PLUGIN-41
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md"
+    summary: "The plugin dependency resolver MUST validate and order a single graph spanning host capabilities (satisfied
+      without an ordering edge) and plugin-provided services (provider-before-consumer edge). A declared dependency unsatisfiable
+      by either provider source MUST be reported, never silently dropped or reclassified."
+    binding: pending
+  - id: INV-PLUGIN-42
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md"
+    summary: "A requires `capability:` entry MUST resolve to a registered host capability and a `service:` entry to a provided
+      proto service; a kind/provider mismatch MUST be a hard MISDECLARED_DEPENDENCY error, not a silent reclassification."
+    binding: pending
+  - id: INV-PLUGIN-43
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md"
+    summary: "An unsatisfied non-optional plugin dependency or a dependency cycle MUST fail the boot; the loader MUST NOT
+      downgrade it to a WARN + priority-sort fallback. `optional: true` entries MAY be skipped."
+    binding: pending
+  - id: INV-PLUGIN-44
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md"
+    summary: "Binary and Lua plugins MUST obtain every declared dependency through the one host gRPC broker, gated by the
+      declaration and authorized as PluginSubject; neither runtime MAY receive an undeclared capability or service. Consumption-path
+      facet of plugin-runtime-symmetry; distinct from INV-CRYPTO-34 (emit/fence/audit path)."
+    binding: pending
+  - id: INV-PLUGIN-45
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md"
+    summary: "The declaration gate that enforces least privilege MUST live at the broker/registry common path shared by both
+      runtimes; per-runtime gating that could diverge is forbidden."
+    binding: pending
   - id: INV-COMMAND-1
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -178,6 +178,71 @@ binding, `5rh.8.29.11` comms-seed PlayerID asymmetry).
   terminal does this; future clients must too. Documented in
   `site/docs/extending/binary-plugins.md`.
 
+### `theme:plugin-capability-architecture` — Unified plugin capability & dependency model
+
+Epic `holomush-eykuh`. A do-it-right redesign of how plugins declare,
+discover, and consume capabilities and dependencies — triggered by a small
+bug (`holomush-oeb4d`: a phantom `requires` that silently disabled DAG
+load-order validation on every boot) that root-caused into a deeper
+architectural conflation.
+
+#### Why now
+
+There are no users or deployments yet, so the cost of getting the plugin
+trust-and-dependency substrate *right* is at its lowest it will ever be. The
+current model has accreted three problems that compound:
+
+- The manifest `requires` field is **overloaded** — it drives both DAG
+  load-order resolution *and* Lua capability injection, and the resolver is
+  blind to the capability registry, so capability-backed requires fail
+  `UNSATISFIED_REQUIRES` and the loader silently falls back to a priority
+  sort for the whole plugin set on every boot.
+- Capability delivery is **asymmetric and not least-privilege**: Lua plugins
+  get most host functions *unconditionally* (every Lua plugin can mutate the
+  world), while binary plugins consume host capabilities as gRPC services via
+  the grpcbroker. `PluginHostService` is a 25-RPC god-service, so
+  service-granularity declarations can't express least privilege.
+- There is **no `plugin → host → plugin` story for Lua**: binary plugins can
+  call another plugin's provided service through the broker, but Lua plugins
+  have no mechanism to consume a plugin-provided service at all.
+
+#### The three mandates
+
+1. **Runtime parity** — binary and Lua plugins consume host capabilities *and*
+   plugin services through one identical host-brokered mechanism (extends the
+   `plugin-runtime-symmetry` invariant).
+2. **Full dependency graph** — the model covers `plugin → host` (capabilities),
+   `host → plugin` (event/command delivery), and `plugin → host → plugin` (a
+   plugin depends on another plugin's service).
+3. **Least-privilege security** — capability-scoped contracts (decompose the
+   `PluginHostService` god-service), declaration-gated access, plugin-as-ABAC
+   subject.
+
+#### Decomposition (foundation-first)
+
+| Sub-spec | Bead | Scope |
+| --- | --- | --- |
+| 1 — Foundation | `holomush-oeb4d` | Capability/dependency model, manifest vocabulary, unified resolver, symmetry contract. Fixes the boot bug as a byproduct. |
+| 2 — Host-service decomposition | `holomush-eykuh.1` | Split `PluginHostService` into capability-scoped proto contracts. |
+| 3 — Lua parity layer | `holomush-eykuh.2` | Host-brokered consumption of capabilities + plugin services from Lua. |
+| 4 — Least-privilege + plugin-trust security | `holomush-eykuh.3` | Declaration-gated access; ABAC with plugin subject. |
+| 5 — Migration + `o262d` | `holomush-eykuh.4` | Atomic manifest cutover; fail-fast on unsatisfied deps. |
+
+Framing decision recorded in `holomush-eykuh.5`. Grounds against the existing
+`docs/superpowers/specs/2026-04-06-grpcbroker-service-injection-design.md` and
+`2026-03-28-plugin-first-command-architecture-design.md`.
+
+#### Risks / sequencing
+
+- **Atomic cutover**: moving Lua from unconditional to declared capabilities
+  breaks any plugin that uses an undeclared host function (`core-building`
+  declares zero `requires` today but mutates the world). Every manifest must
+  be audited and updated in lockstep with the enforcement flip.
+- **God-service decomposition** is a long-lived refactor touching every plugin
+  and both runtimes; partial-migration limbo is the main hazard. The foundation
+  sub-spec sequences it so each capability contract lands behind a stable
+  declaration model.
+
 ## Completed themes
 
 ### `theme:docs-platform` — Docs site migration, IA, and gRPC reference — closed 2026-05-29

--- a/docs/superpowers/plans/2026-06-11-plugin-capability-dependency-foundation.md
+++ b/docs/superpowers/plans/2026-06-11-plugin-capability-dependency-foundation.md
@@ -1,0 +1,924 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Capability & Dependency Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use dev-flow:subagent-driven-development (recommended) or dev-flow:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the overloaded flat-string `requires` field with a typed
+capability/service dependency model, make the plugin loader's resolver validate
+and order that unified graph with a structured result + fail-fast policy, and
+reclassify the four phantom `requires` so the every-boot DAG-fallback bug is
+fixed end-to-end.
+
+**Architecture:** A new `Dependency` value type (kind = `capability` | `service`,
+plus `version`/`optional` attributes) parsed from string-or-map YAML;
+`Manifest.Requires` becomes `[]Dependency` with behavior-preserving accessors
+for the existing Lua/binary consumers; a `CapabilityVocabulary` registry of
+valid host-capability names; `ResolveDependencyOrder` returns a structured
+`ResolveResult` and validates each entry by kind; `resolveLoadOrder` fails the
+boot on any non-optional unsatisfied entry or cycle.
+
+**Tech Stack:** Go, `gopkg.in/yaml.v3` (custom `UnmarshalYAML`), testify, the
+invariant registry (`cmd/inv-render`).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md`
+**Design bead:** `holomush-oeb4d` (epic `holomush-eykuh`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `internal/plugin/dependency_type.go` | The `Dependency` value type + `UnmarshalYAML` + `RequireServices` constructor | Create |
+| `internal/plugin/dependency_type_test.go` | Unit tests for parsing both forms + attributes + constructor | Create |
+| `internal/plugin/manifest.go` | `Requires []string` → `[]Dependency`; accessor methods (incl `RequiresDisplay`) | Modify (`:99`, add accessors) |
+| `internal/plugin/lua/host.go` | Use `RequiredServiceNames()` accessor (behavior-preserving) | Modify (`:323`,`:402`,`:508`) |
+| `internal/plugin/goplugin/host.go` | Use `RequiredServiceNames()` in the broker loop + guard | Modify (`:344`,`:666`,`:667`) |
+| `internal/command/handlers/plugin_admin.go` | `plugin info` renderer: `strings.Join(m.Requires…)` → `m.RequiresDisplay()` | Modify (`:86-87`) |
+| Test literals: `dependency_test.go`, `manifest_test.go:1615,1651`, `lua/host_test.go:1643`, `goplugin/host_test.go:1225,1301`, `command/handlers/plugin_admin_test.go:100`, `test/integration/plugin/binary_plugin_test.go:131` | Migrate `Requires: []string{…}` → `RequireServices(…)` and `m.Requires` asserts → accessor | Modify (Task 2) |
+| `internal/plugin/capability_vocab.go` | `CapabilityVocabulary` registry + minimal default set | Create |
+| `internal/plugin/capability_vocab_test.go` | Unit tests for the vocabulary | Create |
+| `internal/plugin/dependency.go` | `ResolveResult` + typed, kind-validated resolver | Modify (`ResolveDependencyOrder` at `:30`) |
+| `internal/plugin/dependency_test.go` | Extend with typed-entry + structured-result tests | Modify |
+| `internal/plugin/manager.go` | `resolveLoadOrder` consumes `ResolveResult` + fail-fast | Modify (`:809`); `LoadAll` propagates error (`:658`) |
+| `plugins/core-communication/plugin.yaml` | Reclassify `SessionService` → `capability: session` | Modify (`:10-11`) |
+| `plugins/core-objects/plugin.yaml` | Reclassify Property/WorldQuery → capabilities | Modify |
+| `plugins/core-aliases/plugin.yaml` | Drop the phantom `requires` block | Modify (`:10-11`) |
+| `schemas/plugin.schema.json` | Allow typed `requires` entries (string or object) | Modify |
+| `internal/plugin/loadall_regression_test.go` | Real `plugins/*` set resolves with no fallback | Create |
+| `docs/architecture/invariants.yaml` | Register `INV-PLUGIN-41..45` | Modify |
+
+---
+
+### Task 1: The `Dependency` value type
+
+**Files:**
+
+- Create: `internal/plugin/dependency_type.go`
+- Test: `internal/plugin/dependency_type_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/plugin/dependency_type_test.go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDependencyUnmarshalsBareStringAsService(t *testing.T) {
+	var d Dependency
+	require.NoError(t, yaml.Unmarshal([]byte(`holomush.scene.v1.SceneService`), &d))
+	assert.Equal(t, DependencyService, d.Kind)
+	assert.Equal(t, "holomush.scene.v1.SceneService", d.Name)
+	assert.False(t, d.Optional)
+}
+
+func TestDependencyUnmarshalsCapabilityEntry(t *testing.T) {
+	var d Dependency
+	require.NoError(t, yaml.Unmarshal([]byte(`{capability: world.query}`), &d))
+	assert.Equal(t, DependencyCapability, d.Kind)
+	assert.Equal(t, "world.query", d.Name)
+}
+
+func TestDependencyUnmarshalsServiceEntryWithAttributes(t *testing.T) {
+	var d Dependency
+	require.NoError(t, yaml.Unmarshal([]byte(`{service: holomush.scene.v1.SceneService, version: ">=1.0.0", optional: true}`), &d))
+	assert.Equal(t, DependencyService, d.Kind)
+	assert.Equal(t, "holomush.scene.v1.SceneService", d.Name)
+	assert.Equal(t, ">=1.0.0", d.Version)
+	assert.True(t, d.Optional)
+}
+
+func TestDependencyRejectsEntryWithBothKinds(t *testing.T) {
+	var d Dependency
+	err := yaml.Unmarshal([]byte(`{capability: x, service: y}`), &d)
+	assert.Error(t, err)
+}
+
+func TestDependencyRejectsEntryWithNeitherKind(t *testing.T) {
+	var d Dependency
+	err := yaml.Unmarshal([]byte(`{version: ">=1.0.0"}`), &d)
+	assert.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestDependency ./internal/plugin/`
+Expected: FAIL — `undefined: Dependency`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// internal/plugin/dependency_type.go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins
+
+import (
+	"github.com/samber/oops"
+	"gopkg.in/yaml.v3"
+)
+
+// DependencyKind distinguishes a host-provided capability (no DAG edge) from a
+// plugin-or-host-provided gRPC service (provider-before-consumer edge).
+type DependencyKind string
+
+const (
+	// DependencyCapability is a host-provided capability named in the controlled
+	// capability vocabulary (short name, e.g. "world.query").
+	DependencyCapability DependencyKind = "capability"
+	// DependencyService is a gRPC service contract named by its full proto path.
+	DependencyService DependencyKind = "service"
+)
+
+// Dependency is one typed entry in a manifest's requires list (spec §1).
+type Dependency struct {
+	Kind     DependencyKind
+	Name     string
+	Version  string // semver constraint; services only
+	Optional bool
+	// Scope carries least-privilege parameters; semantics are sub-spec 4. The
+	// foundation parses and round-trips it but does not interpret it.
+	Scope string
+}
+
+// dependencyYAML is the object form accepted by UnmarshalYAML.
+type dependencyYAML struct {
+	Capability string `yaml:"capability"`
+	Service    string `yaml:"service"`
+	Version    string `yaml:"version"`
+	Optional   bool   `yaml:"optional"`
+	Scope      string `yaml:"scope"`
+}
+
+// UnmarshalYAML accepts either a bare string (treated as a service path, for
+// backward compatibility with the legacy flat-string requires form) or a typed
+// object with exactly one of capability/service.
+func (d *Dependency) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		d.Kind = DependencyService
+		d.Name = value.Value
+		return nil
+	}
+	var raw dependencyYAML
+	if err := value.Decode(&raw); err != nil {
+		return oops.Code("DEPENDENCY_MALFORMED").Wrap(err)
+	}
+	hasCap, hasSvc := raw.Capability != "", raw.Service != ""
+	if hasCap == hasSvc {
+		return oops.Code("DEPENDENCY_KIND_AMBIGUOUS").
+			Errorf("a requires entry MUST have exactly one of capability/service")
+	}
+	d.Version, d.Optional, d.Scope = raw.Version, raw.Optional, raw.Scope
+	if hasCap {
+		d.Kind, d.Name = DependencyCapability, raw.Capability
+	} else {
+		d.Kind, d.Name = DependencyService, raw.Service
+	}
+	return nil
+}
+
+// RequireServices builds a []Dependency of service-kind entries. It exists so
+// that test fixtures (and any caller constructing a manifest in Go) can migrate
+// from the old []string{...} form with minimal churn.
+func RequireServices(names ...string) []Dependency {
+	out := make([]Dependency, 0, len(names))
+	for _, n := range names {
+		out = append(out, Dependency{Kind: DependencyService, Name: n})
+	}
+	return out
+}
+```
+
+Add to the test file (Step 1):
+
+```go
+func TestRequireServicesConstructsServiceDeps(t *testing.T) {
+	deps := RequireServices("a", "b")
+	require.Len(t, deps, 2)
+	assert.Equal(t, DependencyService, deps[0].Kind)
+	assert.Equal(t, "a", deps[0].Name)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run 'TestDependency|TestRequireServices' ./internal/plugin/`
+Expected: PASS (6 subtests).
+
+- [ ] **Step 5: Commit**
+
+Commit per `references/vcs-preamble.md`: `feat(plugin): typed Dependency value type (holomush-oeb4d)`.
+
+---
+
+### Task 2: Switch `Manifest.Requires` to `[]Dependency` + accessors
+
+**Files:**
+
+- Modify: `internal/plugin/manifest.go:99` (field type), add accessor methods
+- Modify: `internal/plugin/lua/host.go:323,402,508`
+- Modify: `internal/plugin/goplugin/host.go:344,667`
+- Test: `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/plugin/manifest_test.go — add
+func TestParseManifestTypedRequiresAccessors(t *testing.T) {
+	m, err := ParseManifest([]byte(`
+name: t
+version: 1.0.0
+type: lua
+requires:
+  - capability: world.query
+  - service: holomush.scene.v1.SceneService
+`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"world.query"}, m.RequiredCapabilities())
+	assert.Equal(t, []string{"holomush.scene.v1.SceneService"}, m.RequiredServiceNames())
+}
+
+func TestParseManifestLegacyFlatRequiresParsesAsServices(t *testing.T) {
+	m, err := ParseManifest([]byte(`
+name: t
+version: 1.0.0
+type: lua
+requires:
+  - holomush.world.v1.WorldService
+`))
+	require.NoError(t, err)
+	assert.Empty(t, m.RequiredCapabilities())
+	assert.Equal(t, []string{"holomush.world.v1.WorldService"}, m.RequiredServiceNames())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestParseManifestTypedRequires ./internal/plugin/`
+Expected: FAIL — `m.RequiredCapabilities undefined` and a type error on `Requires`.
+
+- [ ] **Step 3: Change the field + add accessors**
+
+In `internal/plugin/manifest.go`, change line 99 from
+`Requires []string ...` to:
+
+```go
+	Requires []Dependency `yaml:"requires,omitempty" json:"requires,omitempty"`
+```
+
+Add accessor methods near the `Manifest` type:
+
+```go
+// RequiredServiceNames returns the names of the service-kind dependencies,
+// preserving the legacy flat-string semantics for broker / InjectRequired
+// consumers.
+func (m *Manifest) RequiredServiceNames() []string {
+	out := make([]string, 0, len(m.Requires))
+	for _, d := range m.Requires {
+		if d.Kind == DependencyService {
+			out = append(out, d.Name)
+		}
+	}
+	return out
+}
+
+// RequiredCapabilities returns the names of the capability-kind dependencies.
+func (m *Manifest) RequiredCapabilities() []string {
+	out := make([]string, 0, len(m.Requires))
+	for _, d := range m.Requires {
+		if d.Kind == DependencyCapability {
+			out = append(out, d.Name)
+		}
+	}
+	return out
+}
+
+// RequiresDisplay returns human-readable "<kind>:<name>" strings for admin /
+// `plugin info` rendering.
+func (m *Manifest) RequiresDisplay() []string {
+	out := make([]string, 0, len(m.Requires))
+	for _, d := range m.Requires {
+		out = append(out, string(d.Kind)+":"+d.Name)
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Update the production consumers (behavior-preserving)**
+
+In `internal/plugin/lua/host.go`, at lines 323, 402, 508, change
+`requires := p.manifest.Requires` to `requires := p.manifest.RequiredServiceNames()`.
+(The legacy `InjectRequired` path keys on proto service names; capability
+entries are delivered by the unconditional path in the foundation — injection
+gating is sub-spec 3/4, so service-name semantics are preserved here.)
+
+In `internal/plugin/goplugin/host.go`: line 344 `len(m.Requires) > 0` compiles
+unchanged (RequiresServices guard). Change the broker-loop guard + range at
+lines 666-667 to use service-kind only:
+
+```go
+	if len(manifest.RequiredServiceNames()) > 0 && grpcPlugin.broker != nil && h.registry != nil {
+		for _, svcName := range manifest.RequiredServiceNames() {
+```
+
+In `internal/command/handlers/plugin_admin.go:86-87`, change the `plugin info`
+renderer:
+
+```go
+	if len(m.Requires) > 0 {
+		fmt.Fprintf(&sb, "\nRequires: %s", strings.Join(m.RequiresDisplay(), ", "))
+	}
+```
+
+- [ ] **Step 5: Migrate the test fixtures (compile fix for the type change)**
+
+Every `Requires: []string{...}` struct literal and every `[]string` assertion
+on `m.Requires` breaks at the field-type change. Update each:
+
+- `internal/plugin/dependency_test.go` (lines 16, 28, 39-40, 48, 87-89):
+  `Requires: []string{"svc-a"}` → `Requires: RequireServices("svc-a")` (repeat
+  per site, preserving each site's service names). *(The 2-arg
+  `ResolveDependencyOrder(plugins, nil)` call signature is migrated in Task 4.)*
+- `internal/plugin/manifest_test.go:1615,1651`:
+  `assert.Equal(t, []string{"holomush.world.v1.WorldService"}, m.Requires)` →
+  `assert.Equal(t, []string{"holomush.world.v1.WorldService"}, m.RequiredServiceNames())`.
+- `internal/plugin/lua/host_test.go:1643`: `Requires: []string{"test-svc"}` →
+  `Requires: plugins.RequireServices("test-svc")` (this is package `lua`; the
+  constructor is exported from package `plugins`).
+- `internal/plugin/goplugin/host_test.go:1225,1301`: same pattern —
+  `plugins.RequireServices("event-store")` / `plugins.RequireServices("holomush.scene.v1.SceneService")`.
+- `internal/command/handlers/plugin_admin_test.go:100`:
+  `Requires: []string{"holomush.world.v1.WorldService"}` →
+  `Requires: plugins.RequireServices("holomush.world.v1.WorldService")`.
+- `test/integration/plugin/binary_plugin_test.go:131`:
+  `Expect(dp.Manifest.Requires).To(ContainElement("holomush.world.v1.WorldService"))` →
+  `Expect(dp.Manifest.RequiredServiceNames()).To(ContainElement("holomush.world.v1.WorldService"))`.
+
+- [ ] **Step 6: Run unit + build**
+
+Run: `task test -- ./internal/plugin/... ./internal/command/...` then `task build`
+Expected: PASS; build succeeds (all consumers + fixtures migrated).
+
+- [ ] **Step 7: Run integration (Requires type change is shared-type surface)**
+
+Run: `task test:int -- -run TestDEKIntegration\|TestPlugin ./internal/plugin/... ./test/integration/...`
+Expected: PASS. (Per CLAUDE.md: `task test` does not compile integration files; a shared-type change MUST run `task test:int`. This compiles `binary_plugin_test.go`, migrated in Step 5.)
+
+- [ ] **Step 8: Commit**
+
+`feat(plugin): Manifest.Requires becomes typed []Dependency with accessors (holomush-oeb4d)`.
+
+---
+
+### Task 3: Capability vocabulary registry
+
+**Files:**
+
+- Create: `internal/plugin/capability_vocab.go`
+- Test: `internal/plugin/capability_vocab_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/plugin/capability_vocab_test.go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCapabilityVocabularyHasRegisteredName(t *testing.T) {
+	v := NewCapabilityVocabulary()
+	v.Register("world.query")
+	assert.True(t, v.Has("world.query"))
+	assert.False(t, v.Has("not.a.capability"))
+}
+
+func TestDefaultCapabilityVocabularyCoversFoundationMinimum(t *testing.T) {
+	v := DefaultCapabilityVocabulary()
+	for _, name := range []string{"session", "property", "world.query"} {
+		assert.True(t, v.Has(name), "default vocabulary MUST include %q", name)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestCapabilityVocabulary\|TestDefaultCapability ./internal/plugin/`
+Expected: FAIL — `undefined: NewCapabilityVocabulary`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// internal/plugin/capability_vocab.go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins
+
+// CapabilityVocabulary is the controlled set of valid host-capability names a
+// manifest may reference via `requires: [{capability: <name>}]` (spec §1). The
+// FULL taxonomy is defined in sub-spec 2; the foundation registers only the
+// minimum the four reclassified manifests require.
+type CapabilityVocabulary struct {
+	names map[string]struct{}
+}
+
+// NewCapabilityVocabulary returns an empty vocabulary.
+func NewCapabilityVocabulary() *CapabilityVocabulary {
+	return &CapabilityVocabulary{names: make(map[string]struct{})}
+}
+
+// Register adds a capability name to the vocabulary.
+func (v *CapabilityVocabulary) Register(name string) { v.names[name] = struct{}{} }
+
+// Has reports whether name is a registered capability.
+func (v *CapabilityVocabulary) Has(name string) bool {
+	_, ok := v.names[name]
+	return ok
+}
+
+// DefaultCapabilityVocabulary returns the foundation's minimal vocabulary —
+// only the names the four reclassified manifests (spec §4) depend on. Sub-spec
+// 2 replaces this with the full taxonomy bound to capability-scoped contracts.
+func DefaultCapabilityVocabulary() *CapabilityVocabulary {
+	v := NewCapabilityVocabulary()
+	for _, name := range []string{"session", "property", "world.query"} {
+		v.Register(name)
+	}
+	return v
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestCapabilityVocabulary\|TestDefaultCapability ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`feat(plugin): minimal host-capability vocabulary registry (holomush-oeb4d)`.
+
+---
+
+### Task 4: Structured, kind-validated resolver
+
+**Files:**
+
+- Modify: `internal/plugin/dependency.go` (`ResolveDependencyOrder` at `:30`)
+- Test: `internal/plugin/dependency_test.go`
+
+The current signature is
+`func ResolveDependencyOrder(plugins []*DiscoveredPlugin, serverServices []string) ([]*DiscoveredPlugin, error)`.
+It is replaced by a structured-result form that also takes the capability vocabulary.
+
+- [ ] **Step 1: Write the failing tests**
+
+Migrate the existing scenarios in `dependency_test.go` (their `Requires` struct
+literals were already converted to `RequireServices(...)` in Task 2 Step 5):
+each existing `order, err := ResolveDependencyOrder(plugins, nil)` becomes
+`res, err := ResolveDependencyOrder(plugins, nil, NewCapabilityVocabulary())`,
+and assertions on `order[i]` become `res.Ordered[i]`; the two "returns error
+for unsatisfied / detects circular" subtests now assert on `res.Unsatisfied` /
+`res.Cycles` (non-empty) instead of `assert.Error`. Then add the new tests:
+
+```go
+// internal/plugin/dependency_test.go — add
+
+func TestResolveResultReportsUnsatisfiedCapability(t *testing.T) {
+	plugins := []*DiscoveredPlugin{
+		{Manifest: &Manifest{Name: "c", Requires: []Dependency{{Kind: DependencyCapability, Name: "world.query"}}}},
+	}
+	vocab := NewCapabilityVocabulary() // empty — world.query unknown
+	res, err := ResolveDependencyOrder(plugins, nil, vocab)
+	require.NoError(t, err) // structured result, not a Go error
+	require.Len(t, res.Unsatisfied, 1)
+	assert.Equal(t, "world.query", res.Unsatisfied[0].Entry.Name)
+}
+
+func TestResolveResultSatisfiesRegisteredCapability(t *testing.T) {
+	plugins := []*DiscoveredPlugin{
+		{Manifest: &Manifest{Name: "c", Requires: []Dependency{{Kind: DependencyCapability, Name: "session"}}}},
+	}
+	vocab := DefaultCapabilityVocabulary()
+	res, err := ResolveDependencyOrder(plugins, nil, vocab)
+	require.NoError(t, err)
+	assert.Empty(t, res.Unsatisfied)
+	assert.Len(t, res.Ordered, 1)
+}
+
+func TestResolveResultMisdeclaredCapabilityThatIsPluginProvided(t *testing.T) {
+	plugins := []*DiscoveredPlugin{
+		{Manifest: &Manifest{Name: "consumer", Requires: []Dependency{{Kind: DependencyCapability, Name: "holomush.scene.v1.SceneService"}}}},
+		{Manifest: &Manifest{Name: "provider", Provides: []string{"holomush.scene.v1.SceneService"}}},
+	}
+	res, err := ResolveDependencyOrder(plugins, nil, NewCapabilityVocabulary())
+	require.NoError(t, err)
+	require.Len(t, res.Unsatisfied, 1)
+	assert.Equal(t, "MISDECLARED_DEPENDENCY", res.Unsatisfied[0].Reason)
+}
+
+func TestResolveResultOptionalUnsatisfiedIsSkipped(t *testing.T) {
+	plugins := []*DiscoveredPlugin{
+		{Manifest: &Manifest{Name: "c", Requires: []Dependency{{Kind: DependencyService, Name: "holomush.absent.v1.X", Optional: true}}}},
+	}
+	res, err := ResolveDependencyOrder(plugins, nil, NewCapabilityVocabulary())
+	require.NoError(t, err)
+	assert.Empty(t, res.Unsatisfied)
+	assert.Len(t, res.Ordered, 1)
+}
+
+func TestResolveResultServiceEdgeOrdersProviderFirst(t *testing.T) {
+	plugins := []*DiscoveredPlugin{
+		{Manifest: &Manifest{Name: "consumer", Requires: []Dependency{{Kind: DependencyService, Name: "svc-a"}}}},
+		{Manifest: &Manifest{Name: "provider", Provides: []string{"svc-a"}}},
+	}
+	res, err := ResolveDependencyOrder(plugins, nil, NewCapabilityVocabulary())
+	require.NoError(t, err)
+	require.Empty(t, res.Unsatisfied)
+	assert.Equal(t, "provider", res.Ordered[0].Manifest.Name)
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `task test -- -run TestResolveResult ./internal/plugin/`
+Expected: FAIL — `ResolveDependencyOrder` arity/return mismatch; `ResolveResult` undefined.
+
+- [ ] **Step 3: Implement the structured resolver**
+
+Replace `ResolveDependencyOrder` in `internal/plugin/dependency.go`. Add the
+result types and validate per-kind. Service edges still drive Kahn ordering;
+capability entries add no edge. A bare Go `error` is returned only for the
+hard structural faults (`DUPLICATE_PLUGIN_NAME`, `DUPLICATE_SERVICE_PROVIDER`);
+unsatisfied / misdeclared / cycles are reported in the result.
+
+```go
+// UnsatisfiedDep records one declared dependency the resolver could not satisfy.
+type UnsatisfiedDep struct {
+	Plugin string
+	Entry  Dependency
+	Reason string // UNSATISFIED_CAPABILITY | UNSATISFIED_SERVICE | MISDECLARED_DEPENDENCY | VERSION_UNSATISFIED
+}
+
+// ResolveResult is the structured output of dependency resolution. A future
+// per-plugin quarantine policy reads Unsatisfied/Cycles without a resolver
+// rewrite (spec §2).
+type ResolveResult struct {
+	Ordered     []*DiscoveredPlugin
+	Unsatisfied []UnsatisfiedDep
+	Cycles      [][]string
+}
+
+// ResolveDependencyOrder validates and orders the unified dependency graph
+// (host capabilities — no edge; plugin/host services — provider-before-consumer
+// edge) and returns a structured result. serverServices lists host gRPC services
+// (e.g. holomush.world.v1.WorldService); vocab lists valid host capabilities.
+func ResolveDependencyOrder(plugins []*DiscoveredPlugin, serverServices []string, vocab *CapabilityVocabulary) (*ResolveResult, error) {
+	// ... index byName (DUPLICATE_PLUGIN_NAME), build svcProvider from
+	// serverServices + each plugin's Provides (DUPLICATE_SERVICE_PROVIDER) —
+	// unchanged from the prior implementation.
+
+	res := &ResolveResult{}
+	for _, p := range plugins {
+		for _, dep := range p.Manifest.Requires {
+			switch dep.Kind {
+			case DependencyCapability:
+				if !vocab.Has(dep.Name) {
+					reason := "UNSATISFIED_CAPABILITY"
+					if _, isService := svcProvider[dep.Name]; isService {
+						reason = "MISDECLARED_DEPENDENCY"
+					}
+					if !dep.Optional {
+						res.Unsatisfied = append(res.Unsatisfied, UnsatisfiedDep{p.Manifest.Name, dep, reason})
+					}
+				}
+			case DependencyService:
+				if _, ok := svcProvider[dep.Name]; !ok {
+					if vocab.Has(dep.Name) {
+						if !dep.Optional {
+							res.Unsatisfied = append(res.Unsatisfied, UnsatisfiedDep{p.Manifest.Name, dep, "MISDECLARED_DEPENDENCY"})
+						}
+						continue
+					}
+					if !dep.Optional {
+						res.Unsatisfied = append(res.Unsatisfied, UnsatisfiedDep{p.Manifest.Name, dep, "UNSATISFIED_SERVICE"})
+					}
+				}
+				// version check: when svcProvider[dep.Name] is a plugin and dep.Version
+				// is set, verify the provider's Manifest.Version satisfies the
+				// constraint (reuse the existing Dependencies semver check helper);
+				// on miss append VERSION_UNSATISFIED.
+			}
+		}
+	}
+	// Kahn's algorithm over service edges + named Dependencies map (unchanged);
+	// record cycles in res.Cycles instead of returning CIRCULAR_DEPENDENCY.
+	// On success set res.Ordered.
+	return res, nil
+}
+```
+
+> Implementer note: lift the existing `byName` / `svcProvider` construction and
+> the Kahn loop verbatim from the prior `ResolveDependencyOrder`
+> (`internal/plugin/dependency.go:30-130`); only the per-entry validation and
+> the return shape change. Reuse the semver helper already used for
+> `Manifest.Dependencies` (`manifest.go:413`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `task test -- -run 'TestResolveResult|TestResolveDependencyOrder' ./internal/plugin/`
+Expected: PASS (new + migrated existing scenarios).
+
+- [ ] **Step 5: Commit**
+
+`feat(plugin): structured ResolveResult + kind-validated resolver (holomush-oeb4d)`.
+
+---
+
+### Task 5: Fail-fast loader policy
+
+**Files:**
+
+- Modify: `internal/plugin/manager.go` (`resolveLoadOrder` at `:809`, `LoadAll` at `:658`)
+- Test: `internal/plugin/manager_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/plugin/manager_test.go — add
+func TestResolveLoadOrderFailsFastOnUnsatisfiedRequired(t *testing.T) {
+	m := &Manager{registry: NewServiceRegistry(), capVocab: NewCapabilityVocabulary()}
+	discovered := []*DiscoveredPlugin{
+		{Manifest: &Manifest{Name: "c", Requires: []Dependency{{Kind: DependencyService, Name: "holomush.absent.v1.X"}}}},
+	}
+	_, err := m.resolveLoadOrder(discovered)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "PLUGIN_DEPENDENCY_UNSATISFIED")
+}
+
+func TestResolveLoadOrderSucceedsWhenAllSatisfied(t *testing.T) {
+	m := &Manager{registry: NewServiceRegistry(), capVocab: DefaultCapabilityVocabulary()}
+	discovered := []*DiscoveredPlugin{
+		{Manifest: &Manifest{Name: "c", Requires: []Dependency{{Kind: DependencyCapability, Name: "session"}}}},
+	}
+	ordered, err := m.resolveLoadOrder(discovered)
+	require.NoError(t, err)
+	assert.Len(t, ordered, 1)
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `task test -- -run TestResolveLoadOrder ./internal/plugin/`
+Expected: FAIL — `resolveLoadOrder` returns one value, not `([]*DiscoveredPlugin, error)`; `m.capVocab` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add a `capVocab *CapabilityVocabulary` field to `Manager` (default
+`DefaultCapabilityVocabulary()` where the manager is constructed in
+`internal/plugin/setup/subsystem.go`). Change `resolveLoadOrder` (`manager.go:809`)
+to return `([]*DiscoveredPlugin, error)` and fail-fast:
+
+```go
+func (m *Manager) resolveLoadOrder(discovered []*DiscoveredPlugin) ([]*DiscoveredPlugin, error) {
+	if m.registry == nil {
+		return prioritySort(discovered), nil // no registry: legacy priority order
+	}
+	serverServiceNames := make([]string, 0)
+	for _, svc := range m.registry.List() {
+		serverServiceNames = append(serverServiceNames, svc.Name)
+	}
+	res, err := ResolveDependencyOrder(discovered, serverServiceNames, m.capVocab)
+	if err != nil {
+		return nil, oops.Code("PLUGIN_DEPENDENCY_RESOLVE_FAILED").Wrap(err)
+	}
+	if len(res.Unsatisfied) > 0 || len(res.Cycles) > 0 {
+		return nil, oops.Code("PLUGIN_DEPENDENCY_UNSATISFIED").
+			With("unsatisfied", res.Unsatisfied).With("cycles", res.Cycles).
+			Errorf("plugin dependency resolution failed; fail-closed (INV-PLUGIN-43)")
+	}
+	return res.Ordered, nil
+}
+```
+
+Update `LoadAll` (`manager.go:658`) to propagate the error:
+
+```go
+	ordered, err := m.resolveLoadOrder(discovered)
+	if err != nil {
+		return err
+	}
+```
+
+Extract the old priority sort into a `prioritySort` helper for the no-registry path.
+
+- [ ] **Step 4: Run unit + integration**
+
+Run: `task test -- ./internal/plugin/...` then `task test:int -- -run TestPlugin ./test/integration/...`
+Expected: PASS. (Integration boots the real loader; fail-fast must not trip on the real, now-reclassified plugin set — Task 6 lands those edits, so run Task 6 before the int run if iterating strictly TDD.)
+
+- [ ] **Step 5: Commit**
+
+`feat(plugin): fail-fast loader policy on unsatisfied deps (holomush-oeb4d)`.
+
+---
+
+### Task 6: Reclassify the four manifests + schema + regression test
+
+**Files:**
+
+- Modify: `plugins/core-communication/plugin.yaml`, `plugins/core-objects/plugin.yaml`, `plugins/core-aliases/plugin.yaml`
+- Modify: `schemas/plugin.schema.json`
+- Create: `internal/plugin/loadall_regression_test.go`
+
+- [ ] **Step 1: Write the failing regression test**
+
+```go
+// internal/plugin/loadall_regression_test.go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Verifies: INV-PLUGIN-41
+// Verifies: INV-PLUGIN-43
+func TestDefaultPluginSetResolvesWithNoUnsatisfiedDeps(t *testing.T) {
+	root, err := filepath.Abs("../../plugins")
+	require.NoError(t, err)
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+
+	var discovered []*DiscoveredPlugin
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		data, rErr := os.ReadFile(filepath.Join(root, e.Name(), "plugin.yaml"))
+		if os.IsNotExist(rErr) {
+			continue
+		}
+		require.NoError(t, rErr)
+		man, pErr := ParseManifest(data)
+		require.NoError(t, pErr, "plugin %s", e.Name())
+		discovered = append(discovered, &DiscoveredPlugin{Manifest: man, Dir: e.Name()})
+	}
+
+	// Host services present at resolution time on main: only WorldService.
+	res, err := ResolveDependencyOrder(discovered, []string{"holomush.world.v1.WorldService"}, DefaultCapabilityVocabulary())
+	require.NoError(t, err)
+	require.Empty(t, res.Unsatisfied, "default plugin set MUST resolve with no unsatisfied deps")
+	require.Empty(t, res.Cycles)
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `task test -- -run TestDefaultPluginSetResolves ./internal/plugin/`
+Expected: FAIL — `core-aliases`/`core-communication`/`core-objects` still carry phantom `service` requires → `res.Unsatisfied` non-empty.
+
+- [ ] **Step 3: Reclassify the manifests**
+
+`plugins/core-communication/plugin.yaml` — replace the `requires:` block:
+
+```yaml
+requires:
+  - capability: session
+```
+
+`plugins/core-objects/plugin.yaml` — replace the `requires:` block:
+
+```yaml
+requires:
+  - capability: property
+  - capability: world.query
+```
+
+`plugins/core-aliases/plugin.yaml` — **delete** the `requires:` block entirely
+(lines 10-11; aliases are command-layer via `command.AliasCache`, never a
+capability dependency).
+
+- [ ] **Step 4: Update the schema**
+
+In `schemas/plugin.schema.json`, change the `requires` property's `items` to
+accept a string **or** a typed object:
+
+```json
+"requires": {
+  "type": "array",
+  "items": {
+    "oneOf": [
+      { "type": "string" },
+      {
+        "type": "object",
+        "oneOf": [
+          { "required": ["capability"] },
+          { "required": ["service"] }
+        ],
+        "properties": {
+          "capability": { "type": "string" },
+          "service": { "type": "string" },
+          "version": { "type": "string" },
+          "optional": { "type": "boolean" },
+          "scope": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 5: Run regression + schema check + full plugin build**
+
+Run: `task test -- -run TestDefaultPluginSetResolves ./internal/plugin/` → PASS
+Run: `task lint` (validates `schemas/plugin.schema.json`) → rc=0
+Run: `task plugin:build-all` → all binary plugins build
+
+- [ ] **Step 6: Run integration (real loader boots clean)**
+
+Run: `task test:int -- -run TestPlugin ./test/integration/...`
+Expected: PASS — no `PLUGIN_DEPENDENCY_UNSATISFIED`, no DAG fallback.
+
+- [ ] **Step 7: Commit**
+
+`fix(plugin): reclassify phantom requires to capabilities; fail-fast resolution (holomush-oeb4d)`.
+
+---
+
+### Task 7: Register the invariants
+
+**Files:**
+
+- Modify: `docs/architecture/invariants.yaml`
+- Generated: `docs/architecture/invariants.md` (via `task invariants:render`)
+
+- [ ] **Step 1: Add the five entries**
+
+Append `INV-PLUGIN-41`…`45` to `docs/architecture/invariants.yaml` with the
+summaries from the spec's Invariants section. Bindings:
+
+- `INV-PLUGIN-41`, `INV-PLUGIN-43` → `binding: bound`, `asserted_by:
+  ["internal/plugin/loadall_regression_test.go"]` (the `// Verifies:` annotations
+  from Task 6) plus `internal/plugin/dependency_test.go` for 41.
+- `INV-PLUGIN-42` → `binding: bound`, `asserted_by:
+  ["internal/plugin/dependency_test.go"]` (the `MISDECLARED_DEPENDENCY` test).
+  Add a `// Verifies: INV-PLUGIN-42` annotation above
+  `TestResolveResultMisdeclaredCapabilityThatIsPluginProvided`.
+- `INV-PLUGIN-44`, `INV-PLUGIN-45` → `binding: pending` (consumption-path
+  invariants; bound in sub-spec 3/4). Do NOT list `asserted_by` while pending.
+
+- [ ] **Step 2: Regenerate + format**
+
+Run: `task fmt` then `task invariants:render`
+(`task fmt` first — the `lint:yaml` block-scalar re-wrap gotcha.)
+
+- [ ] **Step 3: Verify meta-tests**
+
+Run: `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestProvenanceGuard|TestBoundInvariantsAreGenuinelyAsserted' ./test/meta/`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+`docs(invariants): register INV-PLUGIN-41..45 (holomush-oeb4d)`.
+
+---
+
+## Verification (whole-plan)
+
+- [ ] `task test -- ./internal/plugin/...` — all unit tests pass
+- [ ] `task test:int -- -run TestPlugin ./test/integration/...` — real loader boots with no fallback
+- [ ] `task lint` rc=0 (schema + yaml + go)
+- [ ] `task plugin:build-all` — binary plugins build
+- [ ] Manual: `task dev` boots with **no** `UNSATISFIED_REQUIRES` WARN and no
+  `DAG dependency resolution failed` line (the `oeb4d` acceptance criterion).
+- [ ] `task pr-prep` green before push.

--- a/docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md
@@ -1,0 +1,320 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Capability & Dependency Foundation — Design
+
+**Bead:** `holomush-oeb4d` (foundation sub-spec of epic `holomush-eykuh`)
+**Theme:** `theme:plugin-capability-architecture` (`docs/roadmap.md`)
+**Status:** draft for design review
+**Date:** 2026-06-11
+
+## Overview
+
+This is the **foundation** sub-spec of a do-it-right redesign of the plugin
+capability & dependency model. It establishes the declaration vocabulary, the
+unified resolver, and the parity / least-privilege / fail-fast **invariants**
+that the remaining sub-specs build on. It deliberately does **not** define the
+full capability taxonomy, decompose `PluginHostService`, specify the Lua
+transport wiring, or migrate the manifests — those are sub-specs 2–5
+(`holomush-eykuh.1`–`.4`).
+
+It was triggered by a small bug (`holomush-oeb4d`): `core-aliases` declares
+`requires: holomush.alias.v1.AliasService`, which nothing provides, so the DAG
+dependency resolver fails `UNSATISFIED_REQUIRES` and the loader silently falls
+back to a global priority sort for the **entire** plugin set on every boot
+(`internal/plugin/manager.go:809-830`). Root-causing that bug surfaced a deeper
+architectural conflation, captured below.
+
+## RFC2119 Keywords
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in
+this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+## Goals
+
+- Define a single manifest vocabulary for everything a plugin depends on: host
+  capabilities **and** other plugins' services.
+- Make the dependency resolver validate **and** order the unified graph, with a
+  structured result and a fail-fast default policy.
+- Establish the runtime-parity, least-privilege, and fail-fast **invariants** as
+  registry entries (`INV-PLUGIN-41`…`45`).
+- Fix the boot bug (`holomush-oeb4d`) as a byproduct of the corrected model.
+
+## Non-Goals (deferred to later sub-specs)
+
+| Deferred concern | Sub-spec / bead |
+| --- | --- |
+| The concrete capability taxonomy + `PluginHostService` decomposition into capability-scoped proto contracts | 2 — `holomush-eykuh.1` |
+| The Lua transport **wiring** (in-process gRPC over bufconn/loopback, hot-path optimization) | 3 — `holomush-eykuh.2` |
+| Least-privilege **enforcement** mechanics + ABAC policy on capability/service access | 4 — `holomush-eykuh.3` |
+| The **full** least-privilege migration: gate Lua injection + declare capabilities for plugins that consume host functions without declaring them today (e.g. `core-building`) | 5 — `holomush-eykuh.4` |
+
+The foundation **does** reclassify the four existing phantom `requires` (§4) —
+that minimal manifest edit is in scope here because fail-fast (`INV-PLUGIN-43`)
+cannot land safely while those four entries remain unsatisfiable. Sub-spec 5 is
+the *remaining* migration (injection gating + full declaration audit).
+
+This spec settles the **model and invariants**; the sub-specs cannot reopen
+them, only implement them.
+
+## Background — current state (grounded)
+
+Three accreted problems, all confirmed against `main`:
+
+1. **The `requires` field is overloaded.** It drives both DAG load-order
+   resolution (`internal/plugin/dependency.go:30` `ResolveDependencyOrder`,
+   satisfied only by host `serverServices` + plugin `Provides`) **and** Lua
+   capability injection (`internal/plugin/lua/host.go:344`
+   `h.hostFuncs.Register(L, name, requires...)` in `DeliverEvent`, and the
+   identical call in `DeliverCommand` — both gate on `requires` →
+   `internal/plugin/hostfunc/capability.go:42` `InjectRequired`). The resolver
+   is blind to the capability registry.
+
+2. **Four `requires` name services that exist in no registry.** On `main`, the
+   service registry registers only `holomush.world.v1.WorldService`
+   (`internal/plugin/setup/subsystem.go:238`). `core-aliases`→`AliasService`,
+   `core-communication`→`SessionService`, and `core-objects`→`PropertyService`
+   - `WorldQueryService` are unsatisfiable by the resolver; it returns on the
+   **first** miss, so the boot WARN names only one — masking the breadth. None
+   of those four proto services exist under `api/proto/`.
+
+3. **Capability delivery is asymmetric and not least-privilege.** Lua plugins
+   receive most host functions **unconditionally**: `query_*`, `set_property`,
+   `create_*` are set on the per-VM `mod` table
+   (`internal/plugin/hostfunc/functions.go:253-265`) for every plugin **before**
+   the `requires`-gated `InjectRequired` guard (`functions.go:308`), so they
+   exist in every VM regardless of declarations (only the `capability.go`
+   registry path is `requires`-gated, and it is inert for the default set).
+   Binary plugins, by contrast, consume host capabilities as gRPC services via
+   the grpcbroker
+   (`internal/plugin/goplugin/host.go:658-705`, design
+   `docs/superpowers/specs/2026-04-06-grpcbroker-service-injection-design.md`).
+   `PluginHostService` is a 25-RPC god-service
+   (`api/proto/holomush/plugin/v1/plugin.proto`), so service-granularity
+   declarations cannot express least privilege. There is **no `plugin → host →
+   plugin` path for Lua** at all: binary plugins reach another plugin's provided
+   service through the broker; Lua plugins have no mechanism to call a
+   plugin-provided service.
+
+The binary half of the target model already exists and is **reused, not
+redesigned**: the grpcbroker authenticates each plugin over mTLS by its
+per-plugin cert CN (the plugin name; `tlscerts.GenerateServerCert`) and
+guarantees providers load before consumers
+(`2026-04-06-grpcbroker-service-injection-design.md` §1.2, §2.2). That transport
+identity is the same string value as the plugin's ABAC `PluginSubject`
+(`internal/access`-side, e.g. `pluginauthz/evaluate.go:81`); the two are
+distinct concepts (transport CN vs. authorization subject) that happen to share
+the plugin name. INV-PLUGIN-44's "authorized as `PluginSubject`" refers to the
+ABAC subject, which the Lua in-process proxy MUST stamp identically.
+
+## Design
+
+### §1 — Manifest model: typed dependency entries
+
+A plugin declares dependencies as a single `requires:` list of **typed
+entries**, each carrying a kind tag plus optional attributes. `provides:`
+(services this plugin implements) is unchanged.
+
+```yaml
+requires:
+  - capability: world.query                       # host capability (short vocab)
+  - capability: world.mutation
+    scope: own-location                           # least-privilege parameter (future)
+  - capability: kv
+  - service: holomush.scene.v1.SceneService       # another plugin's service (proto path)
+    version: ">=1.0.0"                            # version constraint
+    optional: true                                # per-dependency graceful-degrade
+provides:
+  - holomush.scene.v1.SceneService
+```
+
+Rules:
+
+- An entry MUST be exactly one of `capability:` or `service:`.
+- `capability:` values are drawn from a **controlled short vocabulary**
+  (`world.query`, `kv`, `session`, …) — host-provided, decoupled from proto
+  naming. The vocabulary itself is defined in sub-spec 2; the foundation only
+  requires that it **exists and is validated**.
+- `service:` values are **full proto service paths** — a contract provided by
+  some plugin (or the host).
+- Each entry MAY carry attributes: `version` (semver constraint, services
+  only), `optional` (boolean, default `false`), and capability-scoping
+  parameters (e.g. `scope`, `access`) whose semantics are defined in sub-spec 4.
+- The pre-existing `dependencies:` version-constraint map is **folded into**
+  `requires` `service` entries' `version` attribute — one place to declare
+  every dependency.
+
+**Why typed entries (not two flat fields, not implicit-kind):** the object form
+is the only one that carries per-entry attributes, which least-privilege
+(`scope`/`access`), versioning, and optionality all require; choosing flat
+strings now would force a manifest-wide migration to objects later. The explicit
+kind tag is an author **assertion** the resolver **validates** (declare
+`capability: X` but `X` is plugin-provided → hard error, never a silent
+reclassification).
+
+### §2 — Unified resolver
+
+`ResolveDependencyOrder` is generalized to validate and order the unified graph,
+and to return a **structured result** rather than `(order, error)`:
+
+```text
+ResolveResult {
+    Ordered     []*DiscoveredPlugin   // topological load order
+    Unsatisfied []UnsatisfiedDep      // {plugin, entry, reason}
+    Cycles      [][]string            // plugin-name cycles, if any
+}
+```
+
+Resolution:
+
+1. **Provider set** = `{registered host capabilities}` (the controlled
+   vocabulary, no DAG edge — they are always host-available) ∪ `{plugin
+   provides}` (each creates a provider→consumer edge).
+2. **Per-entry validation:**
+   - `capability: X` — `X` MUST be a registered host capability. If `X` is
+     instead plugin-provided, that is a `MISDECLARED_DEPENDENCY` error.
+   - `service: Y` — `Y` MUST be provided by some plugin/host; the `version`
+     constraint MUST be satisfied; an edge is added.
+   - A non-optional entry that is unsatisfiable is recorded in `Unsatisfied`.
+3. **Ordering:** Kahn's algorithm over service edges only (capabilities add
+   none). A cycle is recorded in `Cycles`.
+4. **Policy (loader, not resolver):** the default policy turns any non-empty
+   `Unsatisfied` (excluding `optional` entries, which are simply skipped) or
+   `Cycles` into a **fatal boot error** — fail-fast, fail-closed, mirroring the
+   crypto KEK-mandatory-boot posture (`INV-CRYPTO-119`). Because the resolver
+   returns structured data, a future **per-plugin quarantine** policy is a
+   policy-layer flip over the same result — not a resolver rewrite.
+
+This deletes the error-masking that hid the bug (`o262d`): the loader MUST NOT
+silently downgrade an unsatisfied non-optional dependency to a WARN + priority
+sort.
+
+### §3 — The parity / consumption contract
+
+The core symmetry invariant the foundation establishes:
+
+> For any declared dependency `D` (a capability **or** a plugin service), both
+> the binary and Lua runtimes obtain access to `D` through the **one host gRPC
+> broker**, **gated by the declaration** (a plugin gets only what it declared —
+> least-privilege), and **authorized as `PluginSubject`**. The delivery shim
+> differs by runtime — binary receives a grpcbroker `ClientConn`, Lua receives
+> an injected in-process gRPC proxy — but the **contract, gating, and
+> authorization are identical**.
+
+This commits the foundation to **one brokered gRPC consumption path for both
+runtimes**, covering host capabilities and plugin services alike, with the
+least-privilege gate at the **single broker/registry common path**.
+
+**Why the Lua transport is forced to in-process gRPC (not a Go shim), at the
+foundation level:**
+
+- The `plugin → host → plugin` mandate requires a Lua plugin to reach another
+  plugin's gRPC service. No host Go shim can exist for an arbitrary plugin's
+  service, so Lua MUST have a brokered gRPC consumption path. Once it exists for
+  plugin services, host capabilities use the same path.
+- It makes "every capability is a gRPC contract" the **real** consumption path
+  for both runtimes, not a nominal parallel definition.
+- It yields a **single** least-privilege gate at the broker/registry common
+  path, satisfying the `plugin-runtime-symmetry` rule's "gate at the common
+  path." A Go-shim transport would split the gate (broker for binary, injection
+  for Lua) — the drift hazard that rule exists to prevent.
+
+The unconditional Lua injection
+(`internal/plugin/hostfunc/functions.go:253-265`) is replaced by
+declaration-gated consumption. This is the breaking change that the manifest
+migration (sub-spec 5) exists to absorb — e.g. `core-building` declares zero
+`requires` today yet calls `create_location`/`query_location`, so it MUST gain
+explicit capability declarations.
+
+**Deferred to sub-spec 3 (cannot reopen this invariant):** only the in-process
+gRPC transport **wiring and performance** — bufconn/loopback, batching, whether
+hot paths get a fast lane behind the contract.
+
+### §4 — The boot bug as a byproduct
+
+The foundation reclassifies the four existing phantom `requires` so the resolver
+no longer fails `UNSATISFIED_REQUIRES`:
+
+| Plugin | Today (phantom `service`) | Foundation |
+| --- | --- | --- |
+| `core-communication` | `holomush.session.v1.SessionService` | `capability: session` |
+| `core-objects` | `holomush.property.v1.PropertyService` | `capability: property` |
+| `core-objects` | `holomush.world.v1.WorldQueryService` | `capability: world.query` |
+| `core-aliases` | `holomush.alias.v1.AliasService` | **dropped** — aliases are delivered at the command layer (`command.AliasCache`), never wired as a capability in production; `core-aliases` has no capability dependency |
+
+The foundation registers the **minimal** vocabulary these reclassifications need
+(`session`, `property`, `world.query`); the full taxonomy + contracts are
+sub-spec 2. With these edits the DAG order is honored and the every-boot WARN +
+fallback disappear — the boot bug is fixed end-to-end, and fail-fast
+(`INV-PLUGIN-43`) is safe to enable.
+
+## Invariants (proposed)
+
+To be registered in `docs/architecture/invariants.yaml` on spec finalization
+(per `.claude/rules/invariants.md`). Each will be `binding: pending` until a
+test asserts it.
+
+- **INV-PLUGIN-41 (unified dependency graph).** The plugin dependency resolver
+  MUST validate and order a single graph spanning host capabilities (satisfied
+  without an ordering edge) and plugin-provided services (provider-before-
+  consumer edge). A declared dependency unsatisfiable by either provider source
+  MUST be reported, never silently dropped or reclassified.
+- **INV-PLUGIN-42 (declaration kind is validated).** A `capability:` entry MUST
+  resolve to a registered host capability and a `service:` entry to a provided
+  proto service; a kind/provider mismatch MUST be a hard `MISDECLARED_DEPENDENCY`
+  error, not a silent reclassification.
+- **INV-PLUGIN-43 (fail-fast, fail-closed).** An unsatisfied non-optional
+  dependency or a dependency cycle MUST fail the boot; the loader MUST NOT
+  downgrade it to a WARN + priority-sort fallback. `optional: true` entries MAY
+  be skipped.
+- **INV-PLUGIN-44 (runtime-parity consumption).** Binary and Lua plugins MUST
+  obtain every declared dependency through the one host gRPC broker, gated by
+  the declaration and authorized as `PluginSubject`; neither runtime MAY receive
+  an undeclared capability or service.
+- **INV-PLUGIN-45 (single least-privilege gate).** The declaration gate that
+  enforces least privilege MUST live at the broker/registry common path shared
+  by both runtimes; per-runtime gating that could diverge is forbidden.
+
+INV-PLUGIN-44/45 do **not** duplicate `INV-CRYPTO-34` (runtime symmetry for the
+emit/fence/audit capability path): they govern the dependency-**consumption**
+path (broker access to declared capabilities/services), a distinct surface.
+Both are facets of the broader `plugin-runtime-symmetry` mandate.
+
+## Testing strategy
+
+- **Resolver unit tests** (`internal/plugin/dependency_test.go`): typed-entry
+  validation (capability vs service), `MISDECLARED_DEPENDENCY`, version
+  constraints, `optional` skip, structured-result shape, cycle reporting.
+- **Default-set regression** (the original `oeb4d` acceptance): load the real
+  `plugins/*` manifests and assert resolution completes with no `Unsatisfied`
+  and no fallback — the test that pins INV-PLUGIN-41/43.
+- **Parity tests** land with sub-spec 3 (consumption path) — the foundation
+  registers INV-PLUGIN-44/45 as `pending` and the binding follows the
+  implementation.
+
+## Risks
+
+- **Atomic cutover.** Declaration-gated consumption breaks any plugin using an
+  undeclared host function; every manifest MUST be audited and updated in
+  lockstep with the enforcement flip (sub-spec 5). The foundation's fail-fast
+  default makes such a gap loud rather than silent — by design.
+- **Capability-vocabulary governance.** A controlled vocabulary needs an owner
+  and a validation point (sub-spec 2). Until it exists, the resolver cannot
+  distinguish a typo from an unregistered capability.
+- **In-process gRPC overhead** for Lua hot paths (`query_*` per delivery) — a
+  sub-spec 3 performance concern, behind the invariant.
+
+## References
+
+- Bug + grounding trail: `holomush-oeb4d` (`bd show`).
+- grpcbroker service injection (binary half, reused):
+  `docs/superpowers/specs/2026-04-06-grpcbroker-service-injection-design.md`.
+- Plugin-first command architecture:
+  `docs/specs/2026-03-28-plugin-first-command-architecture-design.md`.
+- Runtime symmetry rule: `.claude/rules/plugin-runtime-symmetry.md`.
+- Resolver: `internal/plugin/dependency.go`, `internal/plugin/manager.go:806-830`.
+- Capability injection: `internal/plugin/hostfunc/functions.go:228-308`,
+  `internal/plugin/hostfunc/capability.go`.
+<!-- adr-capture: sha256=fc0e5fe059a6762f; session=cli; ts=2026-06-11T15:44:43Z; adrs=holomush-mg4x6,holomush-dfkca,holomush-gtkzy -->


### PR DESCRIPTION
## Summary

Lands the **foundation design** for epic `holomush-eykuh` — a do-it-right redesign of the plugin capability & dependency model (`theme:plugin-capability-architecture`, see `docs/roadmap.md`). Docs + invariant-registry only; no implementation code. Lands ahead of the implementation beads so subagent execution reads canonical spec/plan/ADRs from `main`.

It started as a one-line bug (`holomush-oeb4d`: a phantom `requires` disabling DAG load-order validation on every boot) that root-caused into a deeper architectural conflation.

## What's here

- **Spec** (`docs/superpowers/specs/2026-06-11-...-foundation-design.md`) — typed-entry manifest model, unified validating resolver (structured `ResolveResult` + fail-fast), and the parity / least-privilege / fail-fast invariants. **design-reviewer: READY.**
- **Plan** (`docs/superpowers/plans/2026-06-11-...-foundation.md`) — 7-task TDD implementation, materialized to beads `oeb4d.1`–`.7`. **plan-reviewer: READY** (round 2).
- **3 ADRs:**
  - `holomush-mg4x6` — typed-entry `requires` model (over flat fields / implicit kind)
  - `holomush-dfkca` — fail-fast fail-closed loader policy with structured `ResolveResult`
  - `holomush-gtkzy` — Lua capability/service transport via in-process gRPC over the host broker
- **`INV-PLUGIN-41..45`** registered (`binding: pending`; 41/42/43 flip to `bound` during impl Task 7).
- **roadmap.md** — the `theme:plugin-capability-architecture` section.

## Three mandates (operator-directed; no users/deployments yet → do it right)

1. **Runtime parity** — binary & Lua consume host capabilities *and* plugin services through one identical host-brokered mechanism.
2. **Full dependency graph** — `plugin→host`, `host→plugin`, and `plugin→host→plugin`.
3. **Least-privilege security** — capability-scoped contracts, declaration-gated, plugin-as-ABAC-subject.

## Scope

Foundation only. Deferred to sub-specs 2–5 (`eykuh.1–.4`): the full capability taxonomy + `PluginHostService` decomposition, the Lua transport wiring, enforcement/ABAC mechanics, and the full least-privilege migration. The foundation *does* reclassify the four existing phantom `requires` so the boot bug is fixed end-to-end and fail-fast lands safely.

## Verification

`task pr-prep` green (fast lane: bats + lint + fmt + license + full unit tests + build). Invariant meta-tests pass (orphan + binding checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)