### PR TITLE
fix(plugin): fire DUPLICATE_SERVICE_PROVIDER on host/plugin service collision (holomush-et5lz)

### DIFF
--- a/internal/plugin/dependency.go
+++ b/internal/plugin/dependency.go
@@ -71,13 +71,23 @@ func ResolveDependencyOrder(plugins []*DiscoveredPlugin, serverServices []string
 	}
 	for _, p := range plugins {
 		for _, svc := range p.Manifest.Provides {
-			if existing, seen := svcProvider[svc]; seen && existing != "" {
+			// Any prior provider — a peer plugin OR the host ("" sentinel) — is a
+			// hard collision. The "" host case is deliberately NOT excused: a
+			// plugin declaring Provides of a server-owned service would otherwise
+			// silently overwrite the host's ownership below, corrupting load-order
+			// edges and broker/service routing (holomush-et5lz). A core service
+			// is never a plugin override target; that would be an explicit feature.
+			if existing, seen := svcProvider[svc]; seen {
+				providerA := existing
+				if providerA == "" {
+					providerA = "(server)"
+				}
 				return nil, oops.
 					Code("DUPLICATE_SERVICE_PROVIDER").
 					With("service", svc).
-					With("provider_a", existing).
+					With("provider_a", providerA).
 					With("provider_b", p.Manifest.Name).
-					Errorf("service %q is provided by both %q and %q", svc, existing, p.Manifest.Name)
+					Errorf("service %q is provided by both %q and %q", svc, providerA, p.Manifest.Name)
 			}
 			svcProvider[svc] = p.Manifest.Name
 		}

--- a/internal/plugin/dependency_test.go
+++ b/internal/plugin/dependency_test.go
@@ -6,6 +6,7 @@ package plugins
 import (
 	"testing"
 
+	"github.com/holomush/holomush/pkg/errutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +82,21 @@ func TestResolveDependencyOrder(t *testing.T) {
 		}
 		_, err := ResolveDependencyOrder(plugins, nil, NewCapabilityVocabulary())
 		assert.Error(t, err)
+	})
+
+	t.Run("rejects a plugin that provides a server-owned service", func(t *testing.T) {
+		// Regression (holomush-et5lz): the duplicate-provider guard used the ""
+		// host sentinel as its skip condition (existing != ""), so a plugin
+		// declaring Provides of a host-owned service slipped past the guard and
+		// silently overwrote the host's ownership in svcProvider — corrupting
+		// load-order edges and broker/service routing. A host/plugin collision
+		// MUST be a hard DUPLICATE_SERVICE_PROVIDER error, same as plugin/plugin.
+		plugins := []*DiscoveredPlugin{
+			{Manifest: &Manifest{Name: "usurper", Provides: []string{"holomush.world.v1.WorldService"}}},
+		}
+		serverServices := []string{"holomush.world.v1.WorldService"}
+		_, err := ResolveDependencyOrder(plugins, serverServices, NewCapabilityVocabulary())
+		errutil.AssertErrorCode(t, err, "DUPLICATE_SERVICE_PROVIDER")
 	})
 
 	t.Run("handles diamond dependency without error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- The duplicate-service-provider guard in `ResolveDependencyOrder` (`internal/plugin/dependency.go`) used the `""` host sentinel as its skip condition (`seen && existing != ""`). That `existing != ""` clause excused exactly the host-vs-plugin collision: a plugin declaring `Provides: [<server-owned service>]` slipped past the guard and **silently overwrote the host's ownership** in `svcProvider`, corrupting load-order edges (`addEdge`) and broker/service routing.
- Fix: drop the `existing != ""` clause so the guard fires on **any** prior provider. Host collisions surface a `(server)` provider in the `DUPLICATE_SERVICE_PROVIDER` diagnostic. Chose a hard error (not host-wins) — consistent with the existing plugin/plugin guard and PR #4426's fail-fast posture; a core service is never an implicit plugin override target.
- Pre-existing defect surfaced by PR #4426 review (x28e9.3); the guard was lifted verbatim from the original `ResolveDependencyOrder`, not introduced by that PR. Deferred out of #4426 scope.

Verified safe: at resolve time the only server-internal service is `holomush.world.v1.WorldService`; no real plugin manifest provides a host service (plugin `Provides` register *after* resolve), so no current plugin load breaks.

## Test Plan

- [x] New red→green regression test: `TestResolveDependencyOrder/rejects_a_plugin_that_provides_a_server-owned_service` asserts `DUPLICATE_SERVICE_PROVIDER` via `errutil.AssertErrorCode`
- [x] Full `internal/plugin/...` suite green (1583 tests)
- [x] `task pr-prep` fast lane: pass (lint, fmt, license, unit, build)
- [ ] CI `Integration Test` + `E2E Test`

Resolves holomush-et5lz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)