### PR TITLE
test(plugin): cover usurper+consumer load-order case, bind INV-PLUGIN-46 (holomush-et5lz)

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -318,6 +318,7 @@ invariants.
 | `INV-PLUGIN-43` | An unsatisfied non-optional plugin dependency or a dependency cycle MUST fail the boot; the loader MUST NOT downgrade it to a WARN + priority-sort fallback. `optional: true` entries MAY be skipped. | — | bound |
 | `INV-PLUGIN-44` | Binary and Lua plugins MUST obtain every declared dependency through the one host gRPC broker, gated by the declaration and authorized as PluginSubject; neither runtime MAY receive an undeclared capability or service. Consumption-path facet of plugin-runtime-symmetry; distinct from INV-CRYPTO-34 (emit/fence/audit path). | — | pending |
 | `INV-PLUGIN-45` | The declaration gate that enforces least privilege MUST live at the broker/registry common path shared by both runtimes; per-runtime gating that could diverge is forbidden. | — | pending |
+| `INV-PLUGIN-46` | Each proto service name MUST have exactly one provider across host and plugins; a plugin declaring Provides of a server-owned (host-registered) service MUST be rejected with DUPLICATE_SERVICE_PROVIDER at resolver time, never silently overwriting host ownership. A core service is never an implicit plugin override target. | — | bound |
 
 ### `INV-EVENTBUS`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3752,6 +3752,15 @@ invariants:
     summary: "The declaration gate that enforces least privilege MUST live at the broker/registry common path shared by both
       runtimes; per-runtime gating that could diverge is forbidden."
     binding: pending
+  - id: INV-PLUGIN-46
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md"
+    summary: "Each proto service name MUST have exactly one provider across host and plugins; a plugin declaring Provides
+      of a server-owned (host-registered) service MUST be rejected with DUPLICATE_SERVICE_PROVIDER at resolver time, never
+      silently overwriting host ownership. A core service is never an implicit plugin override target."
+    binding: bound
+    asserted_by:
+      - "internal/plugin/dependency_test.go"
   - id: INV-COMMAND-1
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/internal/plugin/dependency_test.go
+++ b/internal/plugin/dependency_test.go
@@ -6,7 +6,7 @@ package plugins
 import (
 	"testing"
 
-	"github.com/holomush/holomush/pkg/errutil"
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,7 +84,8 @@ func TestResolveDependencyOrder(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("rejects a plugin that provides a server-owned service", func(t *testing.T) {
+	// Verifies: INV-PLUGIN-46
+	t.Run("returns DUPLICATE_SERVICE_PROVIDER when a plugin provides a server-owned service", func(t *testing.T) {
 		// Regression (holomush-et5lz): the duplicate-provider guard used the ""
 		// host sentinel as its skip condition (existing != ""), so a plugin
 		// declaring Provides of a host-owned service slipped past the guard and
@@ -96,7 +97,45 @@ func TestResolveDependencyOrder(t *testing.T) {
 		}
 		serverServices := []string{"holomush.world.v1.WorldService"}
 		_, err := ResolveDependencyOrder(plugins, serverServices, NewCapabilityVocabulary())
-		errutil.AssertErrorCode(t, err, "DUPLICATE_SERVICE_PROVIDER")
+		// Assert the TOP-LEVEL oops code (not chain-walking) so the guard, not a
+		// wrapper, MUST be the outermost failure for this security property.
+		oopsErr, ok := oops.AsOops(err)
+		require.True(t, ok)
+		require.Equal(t, "DUPLICATE_SERVICE_PROVIDER", oopsErr.Code())
+	})
+
+	// Verifies: INV-PLUGIN-46
+	t.Run("rejects a usurper while a legitimate consumer requires the same server service", func(t *testing.T) {
+		// The original bug's stated harm: a plugin providing a host-owned service
+		// corrupts the load-order edge for a legitimate consumer of that service.
+		// With a consumer (A requires S) and a usurper (B provides S) in the same
+		// graph, resolution MUST hard-fail rather than silently re-point A's edge
+		// at B (holomush-et5lz).
+		plugins := []*DiscoveredPlugin{
+			{Manifest: &Manifest{Name: "consumer", Requires: RequireServices("holomush.world.v1.WorldService")}},
+			{Manifest: &Manifest{Name: "usurper", Provides: []string{"holomush.world.v1.WorldService"}}},
+		}
+		serverServices := []string{"holomush.world.v1.WorldService"}
+		_, err := ResolveDependencyOrder(plugins, serverServices, NewCapabilityVocabulary())
+		oopsErr, ok := oops.AsOops(err)
+		require.True(t, ok)
+		require.Equal(t, "DUPLICATE_SERVICE_PROVIDER", oopsErr.Code())
+	})
+
+	t.Run("keeps the host as provider so a server-service consumer gets no plugin edge", func(t *testing.T) {
+		// Positive counterpart to the usurper case: with no usurper, a consumer of
+		// a host service resolves cleanly — host stays the provider (svcProvider
+		// entry "" → no plugin edge), so the consumer orders with no Unsatisfied
+		// entry. Guards the providerName=="" branch of the edge-building loop.
+		plugins := []*DiscoveredPlugin{
+			{Manifest: &Manifest{Name: "consumer", Requires: RequireServices("holomush.world.v1.WorldService")}},
+		}
+		serverServices := []string{"holomush.world.v1.WorldService"}
+		res, err := ResolveDependencyOrder(plugins, serverServices, NewCapabilityVocabulary())
+		require.NoError(t, err)
+		assert.Len(t, res.Ordered, 1)
+		assert.Empty(t, res.Unsatisfied)
+		assert.Empty(t, res.Cycles)
 	})
 
 	t.Run("handles diamond dependency without error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #4427 (the `DUPLICATE_SERVICE_PROVIDER` host/plugin guard fix), addressing the PR-review findings from that change. #4427 merged before its review gate finished; these are the gate's accepted improvements, rebased onto the merged guard.

- **Mixed-graph coverage** (the important finding): adds `rejects a usurper while a legitimate consumer requires the same server service` — a graph where plugin A legitimately *requires* server service S while usurper B *provides* S. This exercises the load-order-edge-corruption path that was the original bug's stated harm (the prior test only covered the isolated usurper). Adds a positive counterpart `keeps the host as provider so a server-service consumer gets no plugin edge` asserting `Ordered`/`Unsatisfied`/`Cycles`.
- **Stronger assertion**: the rejection tests now assert the **top-level** oops code via `oops.AsOops(err)` + `require.Equal` instead of chain-walking `errutil.AssertErrorCode`, per `grpc-errors.md` — so a future wrapper can't mask which guard is the outermost failure for this security property.
- **Invariant registration**: adds `INV-PLUGIN-46` (each proto service has exactly one provider; a plugin providing a host-owned service is rejected at resolver time) to `invariants.yaml` as `binding: bound`, binds it via `// Verifies: INV-PLUGIN-46` on the rejection tests, and regenerates `invariants.md`. Closes the "uncaptured durable guarantee" gap so a future resolver refactor can't silently re-introduce the bug.
- **ACE naming**: renames the rejection subtest to carry its expectation clause.

No production-code change — the guard itself landed in #4427. This is tests + invariant registry only.

## Test Plan

- [x] `task test -- -run TestResolveDependencyOrder ./internal/plugin/` (14 subtests green)
- [x] Invariant meta-tests green (binding/provenance/genuine-assertion guards bind INV-PLUGIN-46)
- [x] `task pr-prep` fast lane: pass
- [ ] CI `Integration Test` + `E2E Test`

Resolves holomush-et5lz (review findings from holomush-tzpzz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)