### PR TITLE
docs(plugin): Lua parity sub-spec 3 — spec, plan, 3 ADRs (holomush-eykuh.2)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,9 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Extract HostCapabilities port; relocate host.v1 servers to runtime-neutral package](holomush-l5bqb-extract-hostcapabilities-port-relocate-host-v1-servers-runti.md) | 2026-06-12 | Accepted | `holomush-l5bqb` |
+| [Split Lua bridge by proto ownership: codegen host caps, descriptor-driven plugin services](holomush-ws2mi-split-lua-bridge-by-proto-ownership-codegen-host-caps-descri.md) | 2026-06-12 | Accepted | `holomush-ws2mi` |
+| [Per-plugin bufconn server for host-established Lua plugin identity](holomush-elqw4-per-plugin-bufconn-server-host-established-lua-plugin-identi.md) | 2026-06-12 | Accepted | `holomush-elqw4` |
 | [Domain-primary carving axis for host capability services](holomush-nbscl-domain-primary-carving-axis-host-capability-services.md) | 2026-06-12 | Accepted | `holomush-nbscl` |
 | [Dedicated holomush.plugin.host.v1 namespace; WorldService kept as coexisting domain service](holomush-e9go5-dedicated-holomush-plugin-host-v1-namespace-worldservice-kep.md) | 2026-06-12 | Accepted | `holomush-e9go5` |
 | [Ambient runtime substrate below the capability model; retire the Log RPC](holomush-cryy2-ambient-runtime-substrate-below-capability-model-retire-log.md) | 2026-06-12 | Accepted | `holomush-cryy2` |

--- a/docs/adr/holomush-elqw4-per-plugin-bufconn-server-host-established-lua-plugin-identi.md
+++ b/docs/adr/holomush-elqw4-per-plugin-bufconn-server-host-established-lua-plugin-identi.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-elqw4; do not edit manually; use `/adr update holomush-elqw4` -->
+
+# Per-plugin bufconn server for host-established Lua plugin identity
+
+**Date:** 2026-06-12
+**Status:** Accepted
+**Decision:** holomush-elqw4
+**Deciders:** Sean Brandt
+
+## Context
+
+The binary plugin runtime establishes plugin identity by constructing a dedicated *grpc.Server per plugin via newPluginHostServiceServer(host, pluginName), baking the ABAC subject into hostCapabilityBase at wiring time — never accepting it from the wire (INV-PLUGIN-22). The Lua runtime needed an equivalent unforgeable-identity path when gaining its own host-capability gRPC server (sub-spec 3, holomush-eykuh.2).
+
+## Decision
+
+Each Lua plugin VM gets its own bufconn.Listener + *grpc.Server with pluginName baked into hostCapabilityBase at construction time, mirroring newPluginHostServiceServer (reusing internal/plugin.NewInProcessConn). Identity is connection-scoped and host-established at wiring time; the in-process boundary is strictly stronger than binary (a plugin cannot enumerate other connections).
+
+## Rationale
+
+Connection-scoped identity prevents any plugin from claiming another plugin's ABAC subject — the forgery surface eliminated by ec22.1 for binary is eliminated symmetrically for Lua. Reuses the existing hostCapabilityBase identity model with zero new identity mechanisms; ABAC subject derivation and emit actor-vouching come free by reusing the same hostcap servers.
+
+## Alternatives Considered
+
+Shared server + plugin-name metadata header — REJECTED: plugin-name would be wire-supplied and forgeable, letting a plugin send any name in the header and bypass ABAC subject derivation (violates INV-PLUGIN-22).
+
+## Consequences
+
+Positive: INV-PLUGIN-22 holds for Lua by construction, not policy; no new auth-token mechanism; exact symmetry with binary. Negative: one *grpc.Server per Lua plugin VM (footprint scales with plugin count). Neutral: in-process bufconn boundary means plugins cannot observe each other's connections.

--- a/docs/adr/holomush-l5bqb-extract-hostcapabilities-port-relocate-host-v1-servers-runti.md
+++ b/docs/adr/holomush-l5bqb-extract-hostcapabilities-port-relocate-host-v1-servers-runti.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-l5bqb; do not edit manually; use `/adr update holomush-l5bqb` -->
+
+# Extract HostCapabilities port; relocate host.v1 servers to runtime-neutral package
+
+**Date:** 2026-06-12
+**Status:** Accepted
+**Decision:** holomush-l5bqb
+**Deciders:** Sean Brandt
+
+## Context
+
+Nine host.v1 server impls lived inside internal/plugin/goplugin/host_capability_servers.go, embedding hostCapabilityBase{ host *goplugin.Host }. INV-PLUGIN-49 requires both runtimes to consume the SAME server implementations, not merely the same proto contract. The lua runtime does not import goplugin (clean sibling layering) and holds a parallel backing on hostfunc.Functions. Surfaced at plan-time for sub-spec 3 (holomush-eykuh.2).
+
+## Decision
+
+Define a method-narrow HostCapabilities port (only the operations the 9+3 servers actually call, derived from the s.host.*/b.host.* call inventory). Relocate all host.v1 server impls to a runtime-neutral package internal/plugin/hostcap/. Provide two adapters: goplugin.Host (binary) and a new hostfunc.Functions-backed adapter (Lua). Both runtimes construct the same hostcap servers through their adapter. The dispatch-token concern stays adapter-specific (binary wires emitTokenStore; Lua supplies connection-scoped identity via core.ActorFromContext).
+
+## Rationale
+
+INV-PLUGIN-49 at the server level (not just contract level) requires a single handler body — ports & adapters is the minimal change that achieves it. A method-narrow port keeps the decoupling real rather than nominal (no full goplugin.Host surface leaks into hostcap). Behavior-preserving for binary: the existing goplugin host-capability tests pass unchanged after relocation. Asymmetry exists only where a forgery surface exists, honoring the plugin-runtime-symmetry rule.
+
+## Alternatives Considered
+
+Second server impl wrapping hostfunc.Functions (Lua-specific) — REJECTED: exactly the runtime-specific capability surface INV-PLUGIN-49 forbids; duplicates handler logic across two drift-prone impls. Lua runtime imports goplugin and reuses servers directly — REJECTED: wrong dependency direction (sibling lua → goplugin) that violates the clean layering keeping the two runtimes independently testable/deployable.
+
+## Consequences
+
+Positive: INV-PLUGIN-49 holds at the server-impl level; a future third runtime needs only a new adapter, not new server impls; hostcap depends only on the port. Negative: ~14-method interface extracted from goplugin.Host (wide refactor surface); two private Host methods (identityRegistrySnapshot, ownedResourceTypes) promoted to the interface. Neutral: three new servers (Session/Property/World) are added in the same move — they are the first Lua consumers with no prior binary impl to displace.

--- a/docs/adr/holomush-ws2mi-split-lua-bridge-by-proto-ownership-codegen-host-caps-descri.md
+++ b/docs/adr/holomush-ws2mi-split-lua-bridge-by-proto-ownership-codegen-host-caps-descri.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-ws2mi; do not edit manually; use `/adr update holomush-ws2mi` -->
+
+# Split Lua bridge by proto ownership: codegen host caps, descriptor-driven plugin services
+
+**Date:** 2026-06-12
+**Status:** Accepted
+**Decision:** holomush-ws2mi
+**Deciders:** Sean Brandt
+
+## Context
+
+Lua plugins need a typed call surface to both host.v1 capabilities (host-owned, committed proto) and third-party plugin services (provider-owned, discovered at runtime). A single reflective bridge (dynamicpb everywhere) was the original design; a consumer-side codegen approach was also evaluated (holomush-eykuh.2, sub-spec 3).
+
+## Decision
+
+Split the bridge by proto ownership. HOST CAPABILITIES: build-time codegen over host.v1 descriptors producing concrete typed Go marshalers + the generated typed client stubs. PLUGIN SERVICES: load-time descriptor-driven dynamicpb tables built from the provider's registered FileDescriptors. Both Lua surfaces present the identical namespace.Method{...} call shape; unknown methods fail at load, not first call.
+
+## Rationale
+
+Host.v1 protos are committed and host-owned — codegen is safe and drift-proof (proto changes break the build immediately). Third-party plugin proto is physically unavailable at host build time, so reflective marshaling is the only correct option, not a degraded one. Lua is non-compiled, so consumer-side codegen yields no real type enforcement while regressing the "drop a script, no build step" value proposition. Uniform call shape preserves dev-ex parity regardless of which bridge backs the call.
+
+## Alternatives Considered
+
+Single reflective dynamicpb bridge for all calls — REJECTED: stringly-typed host-cap calls; proto drift not caught at build time; wastes the committed host.v1 contracts as a real type boundary. Consumer-side codegen generating Lua stubs — REJECTED: illusory typing for a non-compiled runtime; breaks the no-build-step value prop; cannot cover arbitrary third-party services unknown at host build.
+
+## Consequences
+
+Positive: host-cap proto drift caught at build time; Lua no-build-step preserved; binary consumers of plugin services keep full static typing (.pb.go import), no regression. Negative: two marshaling paths (codegen + dynamicpb) to maintain/test; a codegen step added to the host build. Neutral: both paths converge on the same per-plugin bufconn transport — the split is in marshaling only, not transport or identity.

--- a/docs/superpowers/plans/2026-06-12-lua-parity-host-brokered-consumption.md
+++ b/docs/superpowers/plans/2026-06-12-lua-parity-host-brokered-consumption.md
@@ -1,0 +1,921 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Lua Parity Layer — Host-Brokered Consumption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Lua plugins one host-brokered mechanism to consume both `host.v1` capabilities and other plugins' services — the same contracts and `BrokerProxy` binary uses — making the proto contract the single source both runtimes consume.
+
+**Architecture:** Ports & adapters. Relocate the `host.v1` server impls behind a runtime-neutral `HostCapabilities` port (Phase 0); the Lua host stands up a per-plugin in-process gRPC server (bufconn) registering those same servers via a `hostfunc.Functions`-backed adapter, and consumes them from Lua through a codegen'd typed bridge (host caps) plus a load-time descriptor-driven bridge that reuses `BrokerProxy` (plugin services).
+
+**Tech Stack:** Go, gRPC, `google.golang.org/grpc/test/bufconn`, `google.golang.org/protobuf/reflect/protoreflect` + `dynamicpb`, gopher-lua (`github.com/yuin/gopher-lua`), the existing `internal/plugin/{goplugin,lua,hostfunc}` packages and `pkg/proto/holomush/plugin/host/v1`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-lua-parity-host-brokered-consumption-design.md`
+**Bead:** `holomush-eykuh.2` (closes `holomush-eykuh.6`; follow-on `holomush-eykuh.9`).
+
+**PR boundaries:** Phase 0 lands as its own PR first (behavior-preserving binary refactor — bakes before net-new code rides on it). Phases 1–4 land as the second PR.
+
+---
+
+## File Structure
+
+| Path | Responsibility | Phase |
+| --- | --- | --- |
+| `internal/plugin/hostcap/capabilities.go` | the `HostCapabilities` port interface (extracted from server call sites) | 0 |
+| `internal/plugin/hostcap/servers.go` | relocated `hostCapabilityBase` + 9 existing server impls (moved from `goplugin`) | 0 |
+| `internal/plugin/hostcap/register.go` | `RegisterCapabilities(server, base, set)` shared registration helper + the `CapabilitySet` enum | 0 |
+| `internal/plugin/hostcap/property.go` | new `propertyServer` (`PropertyService`) | 0 |
+| `internal/plugin/hostcap/session.go` | new `sessionServer` + `sessionAdminServer` (`SessionService`/`SessionAdminService`) | 0 |
+| `internal/plugin/hostcap/world.go` | new `worldServer` (`WorldQueryService`) | 0 |
+| `internal/plugin/goplugin/host_service.go` | refactor `newPluginHostServiceServer` to call `hostcap.RegisterCapabilities`; `*Host` satisfies the port | 0 |
+| `internal/plugin/lua/hostcap_adapter.go` | `hostfunc.Functions`-backed adapter implementing `HostCapabilities` | 1 |
+| `internal/plugin/lua/bufconn_endpoint.go` | per-plugin bufconn `*grpc.Server` + `ClientConn` lifecycle on `lua.Host` | 1 |
+| `internal/plugin/luabridge/bridge.go` | bridge entry: registers generated host-cap tables + descriptor-driven plugin-service tables into a VM | 2,3 |
+| `internal/plugin/luabridge/marshal.go` | Lua table ↔ proto message marshaling (shared by both bridge halves) | 2,3 |
+| `internal/plugin/luabridge/gen/main.go` | `go:generate` generator: emits typed host-cap Lua bindings from `host.v1` descriptors | 2 |
+| `internal/plugin/luabridge/bindings_gen.go` | generated typed host-cap bindings (DO NOT hand-edit) | 2 |
+| `internal/plugin/luabridge/pluginsvc.go` | load-time descriptor-driven plugin-service table builder + `BrokerProxy` loopback | 3 |
+| `test/integration/pluginparity/parity_test.go` | cross-runtime INV-PLUGIN-49 + gate INV-PLUGIN-44/45 + identity + coexistence | 4 |
+
+---
+
+## Phase 0 — Runtime-neutral host-capability servers (foundation PR)
+
+### Task 1: Extract the `HostCapabilities` port; make `*goplugin.Host` satisfy it
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/capabilities.go`
+- Modify: `internal/plugin/goplugin/host_capability_servers.go` (change `hostCapabilityBase.host` type)
+- Test: `internal/plugin/hostcap/capabilities_test.go`
+
+The interface is extracted from the *complete, grounded* inventory of operations the 9 servers call (`rg 's\.host\.\w+|b\.host\.\w+' host_capability_servers.go`). The full set:
+
+| Call site today | Port method | Notes |
+| --- | --- | --- |
+| `s.host.FocusCoordinator()` | `FocusCoordinator() focus.Coordinator` | already an accessor |
+| `s.host.HistoryReader()` | `HistoryReader() plugins.HistoryReader` | already an accessor |
+| `s.host.ReadbackDecryptor()` | `ReadbackDecryptor() plugins.ReadbackDecryptor` | already an accessor |
+| `s.host.GameSettings()/PlayerSettings()/CharacterSettings()` | same three | already accessors |
+| `s.host.mu.RLock(); s.host.engine` | `AccessEngine() types.AccessPolicyEngine` | **accessor locks internally** — the port MUST NOT expose `mu` |
+| `s.host.mu.RLock(); s.host.auditor` | `Auditor() pluginauthz.Auditor` | internal lock |
+| `s.host.mu.RLock(); s.host.eventEmitter` | `EventEmitter() plugins.PluginIntentEmitter` | internal lock |
+| `s.host.mu.RLock(); s.host.commandQuerier` | `CommandQuerier() *commandquery.Querier` | internal lock |
+| `s.host.mu.RLock(); s.host.tokenStore` (Evaluate:502, EmitEvent:356, RequestEmitToken:420, actorFromToken:840) | `LookupActor(ctx, pluginName) (core.Actor, string, error)` + `IssueEmitToken(ctx, pluginName, actor) (string, error)` | **do NOT expose `*emitTokenStore`** — expose the two operations the servers need. Binary adapter wires the token store; Lua adapter: `LookupActor`→`core.ActorFromContext`, `IssueEmitToken`→unsupported (no Lua forgery surface) |
+| `s.host.identityRegistrySnapshot()` (private) | `IdentityRegistrySnapshot() plugins.IdentityRegistry` | promote to exported interface method; Lua adapter may return nil |
+| `s.host.ownedResourceTypes(name)` (private) | `OwnedResourceTypes(pluginName string) []string` | promote to exported |
+| new (Tasks 3–5) | `PropertyDefinition(name string) (PropertyDefinition, bool)`, `WorldQuerier(pluginName string) WorldQuerier`, `WorldMutator() WorldMutator`, `SessionAccess() session.Access`, `SessionAdmin() SessionAdmin` | backings for the 3 new servers (see below) |
+
+Type aliases the port uses (declare in `capabilities.go`): `type PropertyDefinition = property.Definition`, `type WorldMutator = world.Mutator`, and a local `WorldQuerier interface { SubjectID() string; GetLocation(...); GetCharacter(...); GetCharactersByLocation(...); GetObject(...) }` matching `*hostfunc.WorldQuerierAdapter` (`adapter.go:18-61`). `SessionAdmin` covers the admin surface core `session.Access` lacks — `BroadcastSystemMessage(ctx, msg) error` and `DisconnectSession(ctx, sessionID, reason) error` (grounded: the `hostfunc.SessionAccess` shim interface in `cap_session.go`); the **binary adapter may return an `Unimplemented`-equivalent for `SessionAdmin` ops (no binary consumer)**, the Lua adapter wires them.
+
+- [ ] **Step 1: Write the failing test** — `internal/plugin/hostcap/capabilities_test.go`
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap_test
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/plugin/goplugin"
+	"github.com/holomush/holomush/internal/plugin/hostcap"
+)
+
+// TestHostStructSatisfiesHostCapabilitiesPort pins that the binary Host
+// implements the runtime-neutral port — the compile-time assertion that keeps
+// the two runtimes single-source (INV-PLUGIN-49).
+func TestHostStructSatisfiesHostCapabilitiesPort(t *testing.T) {
+	var _ hostcap.HostCapabilities = (*goplugin.Host)(nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestHostStructSatisfiesHostCapabilitiesPort ./internal/plugin/hostcap/`
+Expected: FAIL — package `hostcap` does not exist / `HostCapabilities` undefined.
+
+- [ ] **Step 3: Define the port** — `internal/plugin/hostcap/capabilities.go`
+
+Define a method-narrow interface. Promote the two private `*Host` methods (`identityRegistrySnapshot`, `ownedResourceTypes`) to exported interface methods. Example shape (enumerate every operation the relocated servers call — derive the full set mechanically from compile errors in Task 2):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package hostcap holds the runtime-neutral holomush.plugin.host.v1 capability
+// server implementations. Both the binary (goplugin) and Lua runtimes consume
+// these same servers through the HostCapabilities port, satisfying INV-PLUGIN-49
+// at the server level (one handler body, no runtime-specific surface).
+package hostcap
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/settings"
+)
+
+// HostCapabilities is the narrow port the capability servers depend on instead
+// of a concrete *goplugin.Host. Each runtime supplies an adapter. Methods are
+// exactly what servers.go + property.go + session.go + world.go call — no more.
+type HostCapabilities interface {
+	// AccessEngine returns the ABAC engine for Evaluate + capability checks.
+	AccessEngine() types.AccessPolicyEngine
+	// Auditor returns the plugin-authz auditor (nil ⇒ no audit sink).
+	Auditor() pluginauthz.Auditor
+	// LookupActor recovers the vouched actor for a dispatch identity. The binary
+	// adapter reads the host-issued emit token from ctx metadata; the Lua adapter
+	// reads core.ActorFromContext(ctx) (connection-scoped, no token store).
+	// pluginName is the host-established calling-plugin identity.
+	LookupActor(ctx context.Context, pluginName string) (core.Actor, string, error)
+	// SessionAccess returns the session read/update surface.
+	SessionAccess() session.Access
+	// GameSettings / PlayerSettings / CharacterSettings back GetSetting/SetSetting.
+	GameSettings() settings.GameSettings
+	PlayerSettings() settings.PlayerSettingsStore
+	CharacterSettings() settings.CharacterSettingsStore
+	// PropertyDefinition resolves a registry property by name (property.go).
+	PropertyDefinition(name string) (PropertyDefinition, bool)
+	// WorldQuerier returns the ABAC-subject-stamped world read adapter for the
+	// named plugin; WorldMutator the write surface.
+	WorldQuerier(pluginName string) WorldQuerier
+	WorldMutator() WorldMutator
+	SessionAdmin() SessionAdmin
+	// IssueEmitToken mints a host dispatch token (binary RequestEmitToken path).
+	// Lua adapter returns an unsupported error (no Lua forgery surface).
+	IssueEmitToken(ctx context.Context, pluginName string, actor core.Actor) (string, error)
+	// EventEmitter / CommandQuerier / IdentityRegistrySnapshot / FocusCoordinator /
+	// HistoryReader / ReadbackDecryptor — see the inventory table above; each is a
+	// port method whose binary adapter locks h.mu internally.
+	EventEmitter() plugins.PluginIntentEmitter
+	CommandQuerier() *commandquery.Querier
+	IdentityRegistrySnapshot() plugins.IdentityRegistry
+	FocusCoordinator() focus.Coordinator
+	HistoryReader() plugins.HistoryReader
+	ReadbackDecryptor() plugins.ReadbackDecryptor
+	// OwnedResourceTypes returns the ABAC resource types the plugin owns.
+	OwnedResourceTypes(pluginName string) []string
+}
+```
+
+> The method set above is the **complete** inventory from the grounded table; verify by compiling `goplugin` in Task 2 with `hostCapabilityBase.host` typed as `HostCapabilities` — zero residual `s.host.<field>` reads should remain. The `mu`-guarded snapshot pattern (`s.host.mu.RLock(); x := s.host.engine; s.host.mu.RUnlock()`) becomes a single `s.host.AccessEngine()` call whose binary-adapter body does the locking internally.
+
+- [ ] **Step 4: Change the embed type** — `host_capability_servers.go:~38`
+
+```go
+type hostCapabilityBase struct {
+	host       hostcap.HostCapabilities // was: *Host
+	pluginName string
+}
+```
+
+Then make `*Host` satisfy the port. Two parts:
+
+1. **Add accessor methods on `*Host`** for every field previously read directly, each locking internally:
+
+```go
+func (h *Host) AccessEngine() types.AccessPolicyEngine { h.mu.RLock(); defer h.mu.RUnlock(); return h.engine }
+func (h *Host) Auditor() pluginauthz.Auditor          { h.mu.RLock(); defer h.mu.RUnlock(); return h.auditor }
+func (h *Host) EventEmitter() plugins.PluginIntentEmitter { h.mu.RLock(); defer h.mu.RUnlock(); return h.eventEmitter }
+func (h *Host) CommandQuerier() *commandquery.Querier { h.mu.RLock(); defer h.mu.RUnlock(); return h.commandQuerier }
+// LookupActor + IssueEmitToken read h.tokenStore (the binary forgery defense).
+func (h *Host) LookupActor(ctx context.Context, pluginName string) (core.Actor, string, error) { /* move actorFromToken body here, reading h.tokenStore */ }
+func (h *Host) IssueEmitToken(ctx context.Context, pluginName string, actor core.Actor) (string, error) { /* current RequestEmitToken token-mint body */ }
+// Promote the two private methods to exported (rename call sites):
+func (h *Host) IdentityRegistrySnapshot() plugins.IdentityRegistry { /* was identityRegistrySnapshot */ }
+func (h *Host) OwnedResourceTypes(pluginName string) []string       { /* was ownedResourceTypes */ }
+```
+
+2. **`hostCapabilityBase.actorFromToken`** (`host_capability_servers.go:830`) is NOT renamed onto `*Host` — it stays a `hostCapabilityBase` helper but its body changes to delegate to the port: `return b.host.LookupActor(ctx, b.pluginName)`. The direct `s.host.mu.RLock(); ts := s.host.tokenStore` reads in `evalServer.Evaluate`, `emitServer.EmitEvent`, and `emitServer.RequestEmitToken` become `b.host.LookupActor(...)` / `b.host.IssueEmitToken(...)` calls. (This is why the port exposes the two token *operations*, not the `*emitTokenStore` — the Lua adapter has no token store.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `task test -- -run TestHostStructSatisfiesHostCapabilitiesPort ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full goplugin suite — behavior preservation**
+
+Run: `task test -- ./internal/plugin/goplugin/`
+Expected: PASS (no behavior change; servers now reach `*Host` via the port).
+
+- [ ] **Step 7: Commit**
+
+Commit per `references/vcs-preamble.md`: `refactor(plugin): extract HostCapabilities port from host.v1 servers (holomush-eykuh.2)`.
+
+### Task 2: Relocate the 9 servers + `hostCapabilityBase` into `hostcap`; add `RegisterCapabilities`
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/servers.go` (moved bodies), `internal/plugin/hostcap/register.go`
+- Modify: `internal/plugin/goplugin/host_capability_servers.go` (delete moved code), `internal/plugin/goplugin/host_service.go` (call the helper)
+- Test: `internal/plugin/hostcap/register_test.go`
+
+- [ ] **Step 1: Write the failing test** — `register_test.go`
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap_test
+
+import (
+	"testing"
+
+	"google.golang.org/grpc"
+
+	"github.com/holomush/holomush/internal/plugin/hostcap"
+)
+
+// TestRegisterCapabilitiesRegistersBinaryDefaultSet asserts the helper wires the
+// binary default capability set onto a server without panicking and that the
+// set excludes Session/Property/World (no binary consumer; spec §1).
+func TestRegisterCapabilitiesRegistersBinaryDefaultSet(t *testing.T) {
+	srv := grpc.NewServer()
+	base := hostcap.NewBase(stubHostCaps(t), "test-plugin")
+	hostcap.RegisterCapabilities(srv, base, hostcap.BinaryDefaultSet)
+	info := srv.GetServiceInfo()
+	if _, ok := info["holomush.plugin.host.v1.SessionService"]; ok {
+		t.Fatal("binary default set must not register SessionService")
+	}
+	if _, ok := info["holomush.plugin.host.v1.EvalService"]; !ok {
+		t.Fatal("binary default set must register EvalService")
+	}
+}
+```
+
+(`stubHostCaps(t)` returns a zero-value adapter satisfying `HostCapabilities`; generate with mockery or a hand stub in `register_test.go`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestRegisterCapabilitiesRegistersBinaryDefaultSet ./internal/plugin/hostcap/`
+Expected: FAIL — `RegisterCapabilities`/`NewBase`/`BinaryDefaultSet` undefined.
+
+- [ ] **Step 3: Move the server bodies** verbatim into `hostcap/servers.go` (the 9 `*Server` types + `actorFromToken`→`LookupActor` usage + helpers), changing only the package clause to `package hostcap` and the embed (already `hostcap.HostCapabilities`). Export `hostCapabilityBase` as needed via `NewBase`:
+
+```go
+func NewBase(host HostCapabilities, pluginName string) hostCapabilityBase {
+	return hostCapabilityBase{host: host, pluginName: pluginName}
+}
+```
+
+- [ ] **Step 4: Write `register.go`** — the shared registration:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap
+
+import (
+	"google.golang.org/grpc"
+
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
+// CapabilitySet selects which host.v1 services a per-plugin server registers.
+type CapabilitySet int
+
+const (
+	// BinaryDefaultSet is the 9 services binary registers today (no
+	// Session/Property/World — they have no binary consumer; spec §1).
+	BinaryDefaultSet CapabilitySet = iota
+	// LuaDefaultSet adds Session/Property/World, which Lua consumes.
+	LuaDefaultSet
+)
+
+// RegisterCapabilities registers the host.v1 capability servers for the given
+// set onto srv. Single source for both runtimes (INV-PLUGIN-49); the only
+// per-runtime difference is the set + the adapter inside base.
+func RegisterCapabilities(srv *grpc.Server, base hostCapabilityBase, set CapabilitySet) {
+	hostv1.RegisterFocusServiceServer(srv, &focusServer{hostCapabilityBase: base})
+	hostv1.RegisterEmitServiceServer(srv, &emitServer{hostCapabilityBase: base})
+	hostv1.RegisterEvalServiceServer(srv, &evalServer{hostCapabilityBase: base})
+	hostv1.RegisterSettingsServiceServer(srv, &settingsServer{hostCapabilityBase: base})
+	hostv1.RegisterStreamHistoryServiceServer(srv, &streamHistoryServer{hostCapabilityBase: base})
+	hostv1.RegisterStreamSubscriptionServiceServer(srv, &streamSubscriptionServer{hostCapabilityBase: base})
+	hostv1.RegisterAuditServiceServer(srv, &auditServer{hostCapabilityBase: base})
+	hostv1.RegisterCommandRegistryServiceServer(srv, &commandRegistryServer{hostCapabilityBase: base})
+	hostv1.RegisterKVServiceServer(srv, &kvServer{hostCapabilityBase: base})
+	if set == LuaDefaultSet {
+		hostv1.RegisterSessionServiceServer(srv, &sessionServer{hostCapabilityBase: base})
+		hostv1.RegisterSessionAdminServiceServer(srv, &sessionAdminServer{hostCapabilityBase: base})
+		hostv1.RegisterPropertyServiceServer(srv, &propertyServer{hostCapabilityBase: base})
+		hostv1.RegisterWorldQueryServiceServer(srv, &worldServer{hostCapabilityBase: base})
+	}
+}
+```
+
+(The Session/Property/World registrations reference servers created in Tasks 3–5; until then, guard them behind those tasks or land Task 2 with only the 9 and add the `LuaDefaultSet` branch in Task 5. Recommended: land Tasks 3–5 first as separate files, then this branch compiles.)
+
+- [ ] **Step 5: Refactor `goplugin/host_service.go`** — `newPluginHostServiceServer` becomes:
+
+```go
+func newPluginHostServiceServer(host *Host, pluginName string) func([]grpc.ServerOption) *grpc.Server {
+	return func(opts []grpc.ServerOption) *grpc.Server {
+		server := grpc.NewServer(opts...)
+		hostcap.RegisterCapabilities(server, hostcap.NewBase(host, pluginName), hostcap.BinaryDefaultSet)
+		return server
+	}
+}
+```
+
+- [ ] **Step 6: Run both suites**
+
+Run: `task test -- ./internal/plugin/hostcap/ ./internal/plugin/goplugin/`
+Expected: PASS. Then `task test:int -- ./test/integration/...` smoke for the binary plugin path.
+
+- [ ] **Step 7: Commit** — `refactor(plugin)!: relocate host.v1 servers to hostcap pkg behind the port (holomush-eykuh.2)`.
+
+### Task 3: Implement `propertyServer` (`PropertyService`)
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/property.go`
+- Modify: `api/proto/holomush/plugin/host/v1/property.proto` (the doc-comment already claims `propertyServer` exists — now it does; no schema change)
+- Test: `internal/plugin/hostcap/property_test.go`
+
+`GetProperty`/`SetProperty` map to the existing `world_write.go` logic: `property.Definition.Get(ctx, querier, entityType, entityID)` and `.Set(ctx, querier, mutator, subjectID, entityType, entityID, value)`. The server reaches these via the port (`PropertyDefinition`, `WorldQuerier`, `WorldMutator`).
+
+- [ ] **Step 1: Write the failing test** — `property_test.go`
+
+```go
+// Verifies the new PropertyService server reads through the same
+// property.Definition.Get path the Lua holomush.get_property shim uses.
+func TestPropertyServerGetPropertyReadsViaDefinition(t *testing.T) {
+	caps := newFakeHostCaps(t) // stub: PropertyDefinition("name") → fake def returning "Town Square"
+	srv := &propertyServer{hostCapabilityBase: hostcap.NewBase(caps, "core-objects")}
+	resp, err := srv.GetProperty(context.Background(), &hostv1.GetPropertyRequest{
+		EntityType: "location", EntityId: validULID, Property: "name",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Town Square", resp.GetValue())
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestPropertyServerGetPropertyReadsViaDefinition ./internal/plugin/hostcap/`
+Expected: FAIL — `propertyServer` undefined.
+
+- [ ] **Step 3: Implement** — `property.go`
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap
+
+import (
+	"context"
+
+	"github.com/samber/oops"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
+type propertyServer struct {
+	hostv1.UnimplementedPropertyServiceServer
+	hostCapabilityBase
+}
+
+func (s *propertyServer) GetProperty(ctx context.Context, req *hostv1.GetPropertyRequest) (*hostv1.GetPropertyResponse, error) {
+	def, ok := s.host.PropertyDefinition(req.GetProperty())
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "unknown property")
+	}
+	entityID, err := ulid.Parse(req.GetEntityId()) // property.Definition.Get takes ulid.ULID (registry.go:57)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid entity id")
+	}
+	querier := s.host.WorldQuerier(s.pluginName)
+	val, err := def.Get(ctx, querier, req.GetEntityType(), entityID)
+	if err != nil {
+		errutil.LogErrorContext(ctx, "property.get failed", err, "plugin", s.pluginName)
+		return nil, status.Errorf(codes.Internal, "internal error")
+	}
+	return &hostv1.GetPropertyResponse{Value: val}, nil
+}
+
+func (s *propertyServer) SetProperty(ctx context.Context, req *hostv1.SetPropertyRequest) (*hostv1.SetPropertyResponse, error) {
+	def, ok := s.host.PropertyDefinition(req.GetProperty())
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "unknown property")
+	}
+	entityID, err := ulid.Parse(req.GetEntityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid entity id")
+	}
+	querier := s.host.WorldQuerier(s.pluginName)
+	if err := def.Set(ctx, querier, s.host.WorldMutator(), querier.SubjectID(), req.GetEntityType(), entityID, req.GetValue()); err != nil {
+		errutil.LogErrorContext(ctx, "property.set failed", err, "plugin", s.pluginName)
+		return nil, status.Errorf(codes.Internal, "internal error")
+	}
+	return &hostv1.SetPropertyResponse{}, nil
+}
+```
+
+(Per `.claude/rules/grpc-errors.md`: log internally via `errutil.LogErrorContext`, return `status.Errorf(codes.Internal, "internal error")` — no `%v` leak, `Errorf` static-string is wrapcheck-allowlisted.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestPropertyServer ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 5: Add the `PropertyService` registration** to `RegisterCapabilities`' `LuaDefaultSet` branch (Task 2 Step 4).
+
+- [ ] **Step 6: Commit** — `feat(plugin): implement host.v1 PropertyService server (holomush-eykuh.2)`.
+
+### Task 4: Implement `sessionServer` + `sessionAdminServer` (`SessionService`/`SessionAdminService`)
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/session.go`
+- Test: `internal/plugin/hostcap/session_test.go`
+
+Map RPCs across two port surfaces. `SessionService` (reads + whisper) → `session.Access` (grounded, `session.go:284`): `FindByName`→`FindByCharacterName`, `ListActive`→`ListActive`, `SetLastWhispered`→`UpdateLastWhispered`. `SessionAdminService` (broadcast/disconnect) → the `SessionAdmin` port method (`BroadcastSystemMessage`, `DisconnectSession`), because core `session.Access` has **no** broadcast/disconnect — those live on the `hostfunc.SessionAccess` shim surface (`cap_session.go`). The **binary adapter returns `Unimplemented` for `SessionAdminService` ops (no binary consumer)**; the Lua adapter wires them via `hostfunc`. Split read RPCs (`SessionService`) from admin RPCs (`SessionAdminService`) per the two proto services.
+
+- [ ] **Step 1: Write the failing test** — `session_test.go`
+
+```go
+// Verifies SessionService.FindByName resolves through session.Access.FindByCharacterName.
+func TestSessionServerFindByNameResolvesViaAccess(t *testing.T) {
+	caps := newFakeHostCaps(t) // session.Access stub: FindByCharacterName("alice") → &session.Info{ID:"s1",...}
+	srv := &sessionServer{hostCapabilityBase: hostcap.NewBase(caps, "core-communication")}
+	resp, err := srv.FindByName(context.Background(), &hostv1.FindByNameRequest{Name: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, "s1", resp.GetSession().GetId())
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestSessionServerFindByName ./internal/plugin/hostcap/`
+Expected: FAIL — `sessionServer` undefined.
+
+- [ ] **Step 3: Implement** — `session.go` (read service shown; admin service mirrors with the mutate RPCs):
+
+```go
+type sessionServer struct {
+	hostv1.UnimplementedSessionServiceServer
+	hostCapabilityBase
+}
+
+func (s *sessionServer) FindByName(ctx context.Context, req *hostv1.FindByNameRequest) (*hostv1.FindByNameResponse, error) {
+	info, err := s.host.SessionAccess().FindByCharacterName(ctx, req.GetName())
+	if err != nil {
+		errutil.LogErrorContext(ctx, "session.find_by_name failed", err, "plugin", s.pluginName)
+		return nil, status.Errorf(codes.Internal, "internal error")
+	}
+	if info == nil {
+		return &hostv1.FindByNameResponse{}, nil // not-found ⇒ empty session
+	}
+	return &hostv1.FindByNameResponse{Session: sessionInfoToProto(info)}, nil
+}
+
+func (s *sessionServer) ListActive(ctx context.Context, _ *hostv1.ListActiveRequest) (*hostv1.ListActiveResponse, error) {
+	infos, err := s.host.SessionAccess().ListActive(ctx)
+	if err != nil {
+		errutil.LogErrorContext(ctx, "session.list_active failed", err, "plugin", s.pluginName)
+		return nil, status.Errorf(codes.Internal, "internal error")
+	}
+	out := make([]*hostv1.SessionInfo, 0, len(infos))
+	for _, i := range infos {
+		out = append(out, sessionInfoToProto(i))
+	}
+	return &hostv1.ListActiveResponse{Sessions: out}, nil
+}
+
+// sessionInfoToProto maps the host session.Info to the wire SessionInfo.
+func sessionInfoToProto(i *session.Info) *hostv1.SessionInfo {
+	return &hostv1.SessionInfo{
+		Id: i.ID, CharacterId: i.CharacterID.String(), CharacterName: i.CharacterName,
+		LocationId: locationIDString(i), GridPresent: i.GridPresent, LastWhispered: i.LastWhispered,
+	}
+}
+```
+
+(`sessionAdminServer` implements `SetLastWhispered`→`UpdateLastWhispered`, `Broadcast`, `Disconnect`→`DeleteByCharacter`. Confirm `session.Info` field names against `internal/session/session.go` `type Info struct` when wiring `sessionInfoToProto`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestSessionServer ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): implement host.v1 SessionService/SessionAdminService servers (holomush-eykuh.2)`.
+
+### Task 5: Implement `worldServer` (`WorldQueryService`) + enable `LuaDefaultSet`
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/world.go`
+- Modify: `internal/plugin/hostcap/register.go` (the `LuaDefaultSet` branch now compiles — all 4 servers exist)
+- Test: `internal/plugin/hostcap/world_test.go`
+
+Map `QueryLocation`/`QueryCharacter`/`QueryLocationCharacters`/`QueryObject` to `WorldQuerier(pluginName)` (`GetLocation`/`GetCharacter`/`GetCharactersByLocation`/`GetObject`), which stamps `plugin:<name>` as the ABAC subject (grounded: `adapter.go` `WorldQuerierAdapter`).
+
+- [ ] **Step 1: Write the failing test** — `world_test.go`
+
+```go
+// Verifies WorldQueryService.QueryLocation reads through the plugin-subject-stamped querier.
+func TestWorldServerQueryLocationStampsPluginSubject(t *testing.T) {
+	caps := newFakeHostCaps(t) // WorldQuerier("core-scenes").GetLocation(...) records the subjectID it used
+	srv := &worldServer{hostCapabilityBase: hostcap.NewBase(caps, "core-scenes")}
+	_, err := srv.QueryLocation(context.Background(), &hostv1.QueryLocationRequest{LocationId: validULID})
+	require.NoError(t, err)
+	assert.Equal(t, "plugin:core-scenes", caps.lastWorldSubject)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestWorldServerQueryLocation ./internal/plugin/hostcap/`
+Expected: FAIL — `worldServer` undefined.
+
+- [ ] **Step 3: Implement** `world.go` (QueryLocation shown; the other three mirror with their request/response types), parsing the ULID with the existing helper, returning `status.Errorf(codes.NotFound, "not found")` on `world.ErrNotFound`, `codes.Internal` otherwise.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestWorldServer ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole foundation suite**
+
+Run: `task test -- ./internal/plugin/hostcap/ ./internal/plugin/goplugin/` then `task lint`
+Expected: PASS — Phase 0 (foundation PR) is complete and behavior-preserving for binary.
+
+- [ ] **Step 6: Commit** — `feat(plugin): implement host.v1 WorldQueryService server + enable LuaDefaultSet (holomush-eykuh.2)`.
+
+> **Land Phase 0 as its own PR** (`task pr-prep`, review, merge) before starting Phase 1.
+
+---
+
+## Phase 1 — Per-plugin Lua bufconn endpoint + adapter (bridge PR)
+
+### Task 6: `hostfunc.Functions`-backed `HostCapabilities` adapter
+
+**Files:**
+
+- Create: `internal/plugin/lua/hostcap_adapter.go`
+- Test: `internal/plugin/lua/hostcap_adapter_test.go`
+
+The adapter wraps `*hostfunc.Functions` (which already holds `engine`, `auditor`, `sessionAccess`, `propertyRegistry`, `worldMutator`, settings ops, etc.) and satisfies `hostcap.HostCapabilities`. `LookupActor` reads `core.ActorFromContext(ctx)` (grounded: `hostfunc/stdlib_settings.go:76`) — the connection-scoped identity equivalent, no token store. `IdentityRegistry`-style methods may return zero values (Lua has no emit-token forgery surface).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestLuaAdapterSatisfiesHostCapabilities pins the compile-time contract.
+func TestLuaAdapterSatisfiesHostCapabilities(t *testing.T) {
+	var _ hostcap.HostCapabilities = (*luaHostCapAdapter)(nil)
+}
+
+// TestLuaAdapterLookupActorUsesContextActor verifies Lua identity comes from
+// core.ActorFromContext, not a dispatch token (spec §0).
+func TestLuaAdapterLookupActorUsesContextActor(t *testing.T) {
+	a := newLuaHostCapAdapter(newTestFunctions(t))
+	ctx := core.WithActor(context.Background(), core.Actor{Kind: core.ActorKindPlugin, ID: "echo-bot"})
+	actor, subj, err := a.LookupActor(ctx, "echo-bot")
+	require.NoError(t, err)
+	assert.Equal(t, "echo-bot", actor.ID)
+	assert.Equal(t, "plugin:echo-bot", subj)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestLuaAdapter ./internal/plugin/lua/`
+Expected: FAIL — `luaHostCapAdapter` undefined.
+
+- [ ] **Step 3: Implement** the adapter — each method delegates to the corresponding `Functions` field/accessor; `LookupActor` uses `core.ActorFromContext`. (Add exported accessors on `hostfunc.Functions` where fields are unexported, e.g. `func (f *Functions) Engine() types.AccessPolicyEngine { return f.engine }`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestLuaAdapter ./internal/plugin/lua/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): hostfunc.Functions adapter for HostCapabilities port (holomush-eykuh.2)`.
+
+### Task 7: Per-plugin bufconn endpoint lifecycle on `lua.Host`
+
+**Files:**
+
+- Create: `internal/plugin/lua/bufconn_endpoint.go`
+- Modify: `internal/plugin/lua/host.go` (`luaPlugin` struct gains a `*pluginEndpoint`; `Load` creates it, `Close`/unload tears it down)
+- Test: `internal/plugin/lua/bufconn_endpoint_test.go`
+
+The endpoint is created **once per plugin at Load** (not per VM — VMs are created/destroyed per `DeliverEvent`). It builds a `*grpc.Server` via `hostcap.RegisterCapabilities(srv, hostcap.NewBase(adapter, pluginName), hostcap.LuaDefaultSet)`, wraps it with `plugins.NewInProcessConn(srv)`, and stores the resulting `grpc.ClientConnInterface` on the plugin for the bridge to capture.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestPluginEndpointServesHostCapsOverBufconn stands up an endpoint and calls a
+// host.v1 cap over the in-process conn, asserting the round trip works.
+func TestPluginEndpointServesHostCapsOverBufconn(t *testing.T) {
+	adapter := newLuaHostCapAdapter(newTestFunctions(t)) // KV-backed
+	ep, err := newPluginEndpoint(adapter, "echo-bot")
+	require.NoError(t, err)
+	defer ep.Close()
+	client := hostv1.NewKVServiceClient(ep.Conn())
+	_, err = client.Set(context.Background(), &hostv1.SetRequest{Key: "k", Value: "v"})
+	require.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestPluginEndpointServesHostCaps ./internal/plugin/lua/`
+Expected: FAIL — `newPluginEndpoint` undefined.
+
+- [ ] **Step 3: Implement** `bufconn_endpoint.go`:
+
+```go
+type pluginEndpoint struct {
+	conn *plugins.InProcessConn
+}
+
+func newPluginEndpoint(adapter hostcap.HostCapabilities, pluginName string) (*pluginEndpoint, error) {
+	srv := grpc.NewServer()
+	hostcap.RegisterCapabilities(srv, hostcap.NewBase(adapter, pluginName), hostcap.LuaDefaultSet)
+	conn, err := plugins.NewInProcessConn(srv)
+	if err != nil {
+		return nil, oops.In("lua").With("plugin", pluginName).Wrap(err)
+	}
+	return &pluginEndpoint{conn: conn}, nil
+}
+
+// Conn returns the in-process client conn. *InProcessConn already satisfies
+// grpc.ClientConnInterface directly (it implements Invoke/NewStream/Close —
+// verified internal/plugin/inprocess_conn.go:62,67,73), so no accessor on the
+// struct is needed; the generated clients take it as-is.
+func (e *pluginEndpoint) Conn() grpc.ClientConnInterface { return e.conn }
+func (e *pluginEndpoint) Close() error                   { return e.conn.Close() }
+```
+
+- [ ] **Step 4: Wire lifecycle in `host.go`** — add `endpoint *pluginEndpoint` to `luaPlugin`; in `Load` (after manifest parse) call `newPluginEndpoint(h.hostCapAdapter, name)` and store it; in `Close`/unload call `p.endpoint.Close()`. Guard nil (`h.hostFuncs == nil` ⇒ no endpoint).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `task test -- -run TestPluginEndpoint ./internal/plugin/lua/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit** — `feat(plugin): per-plugin Lua bufconn endpoint serving host.v1 caps (holomush-eykuh.2)`.
+
+---
+
+## Phase 2 — Host-capability bridge (codegen typed bindings)
+
+### Task 8: Codegen generator for typed host-cap Lua bindings
+
+**Files:**
+
+- Create: `internal/plugin/luabridge/marshal.go`, `internal/plugin/luabridge/gen/main.go`, `internal/plugin/luabridge/doc.go` (with `//go:generate go run ./gen`)
+- Create (generated): `internal/plugin/luabridge/bindings_gen.go`
+- Test: `internal/plugin/luabridge/marshal_test.go`, `internal/plugin/luabridge/bindings_gen_test.go`
+
+The generator reads the `host.v1` service descriptors (via the generated `hostv1` package's `proto.FileDescriptor`s) and emits, per service, a Go function that registers a `namespace.Method{…}` Lua table whose functions: read the Lua table arg → build the typed `*hostv1.<Method>Request` field-by-field → call `hostv1.New<Svc>ServiceClient(conn).<Method>` → marshal the typed response into a Lua table. A drift gate (sha256, like `schemas/plugin.schema.json`) keeps `bindings_gen.go` honest.
+
+- [ ] **Step 1: Write the failing test (marshaling primitive first)** — `marshal_test.go`
+
+```go
+// TestProtoToLuaTableMapsScalarFields round-trips a typed message into a Lua table.
+func TestProtoToLuaTableMapsScalarFields(t *testing.T) {
+	L := lua.NewState(); defer L.Close()
+	tbl := luabridge.ProtoToLuaTable(L, &hostv1.GetPropertyResponse{Value: "Town Square"})
+	assert.Equal(t, "Town Square", L.GetField(tbl, "value").String())
+}
+
+// TestLuaTableToProtoBuildsTypedRequest builds a typed request from a Lua table.
+func TestLuaTableToProtoBuildsTypedRequest(t *testing.T) {
+	L := lua.NewState(); defer L.Close()
+	arg := L.NewTable()
+	L.SetField(arg, "entity_type", lua.LString("location"))
+	L.SetField(arg, "entity_id", lua.LString(validULID))
+	L.SetField(arg, "property", lua.LString("name"))
+	var req hostv1.GetPropertyRequest
+	require.NoError(t, luabridge.LuaTableToProto(arg, &req))
+	assert.Equal(t, "location", req.GetEntityType())
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run 'TestProtoToLuaTable|TestLuaTableToProto' ./internal/plugin/luabridge/`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Implement `marshal.go`** — `ProtoToLuaTable` / `LuaTableToProto` via `protoreflect` (walk `msg.ProtoReflect().Descriptor().Fields()`; map scalar/string/bool/message/repeated). This is the shared marshaler both bridge halves use. Also add a `luabridge`-local `luaContext(L *lua.LState) context.Context` helper (the `hostfunc.luaContext` at `cap_session.go:193` is package-private to `hostfunc`; the generated bindings in `package luabridge` need their own copy) and `pushBridgeError(L, err)` (gRPC `status` → `nil, "<message>"`, mirroring `hostfunc.pushError`).
+
+- [ ] **Step 4: Run to verify the marshaler passes**
+
+Run: `task test -- -run 'TestProtoToLuaTable|TestLuaTableToProto' ./internal/plugin/luabridge/`
+Expected: PASS.
+
+- [ ] **Step 5: Write `gen/main.go`** — emit `bindings_gen.go`. Representative generated output (what the generator MUST produce for `KVService`):
+
+```go
+// Code generated by luabridge/gen. DO NOT EDIT.
+package luabridge
+
+func registerKV(L *lua.LState, conn grpc.ClientConnInterface, pluginName string) {
+	tbl := L.NewTable()
+	client := hostv1.NewKVServiceClient(conn)
+	L.SetField(tbl, "Get", L.NewFunction(func(L *lua.LState) int {
+		var req hostv1.GetRequest
+		if err := LuaTableToProto(L.CheckTable(1), &req); err != nil {
+			return pushBridgeError(L, err)
+		}
+		resp, err := client.Get(luaContext(L), &req)
+		if err != nil {
+			return pushBridgeError(L, err) // gRPC status → nil, "<msg>"
+		}
+		L.Push(ProtoToLuaTable(L, resp)); L.Push(lua.LNil); return 2
+	}))
+	// … Set, Delete …
+	L.SetGlobal("kv", tbl)
+}
+
+// registeredHostCapBindings maps CAPABILITY TOKEN (the vocab token a manifest
+// declares as `requires: - capability: <token>`) → registrar. Keyed by token,
+// NOT service name, because the manifest gate is RequiredCapabilities() (capability
+// kind), not RequiredServiceNames() (service kind). Tokens are the capability_vocab.go
+// set: kv, session, session.admin, property, world.query, world.mutation, focus,
+// eval, emit, settings, stream.history, stream.subscription, audit, command-registry.
+var registeredHostCapBindings = map[string]func(*lua.LState, grpc.ClientConnInterface, string){
+	"kv": registerKV,
+	// … all capability tokens that have a host.v1 service …
+}
+```
+
+> The generator derives the token for each service from the `capability_vocab.go` mapping (e.g. `KVService`→`kv`, `SessionService`→`session`, `WorldQueryService`→`world.query`). If the canonical token↔service map does not yet exist as a single source, add it to `capability_vocab.go` and have both the resolver and this generator read it (avoids a second mapping that could drift).
+
+- [ ] **Step 6: Generate + verify** — Run: `go generate ./internal/plugin/luabridge/` then `task test -- ./internal/plugin/luabridge/`
+Expected: `bindings_gen.go` written; PASS. Add a sha256 drift gate for `bindings_gen.go` mirroring the existing `schemas/plugin.schema.json` gate (grounded: that gate runs in `task pr-prep`; follow its `Taskfile.yaml` target pattern — regenerate, `git diff --exit-code` the generated file — so CI fails on un-regenerated drift).
+
+- [ ] **Step 7: Commit** — `feat(plugin): codegen typed Lua bindings for host.v1 capabilities (holomush-eykuh.2)`.
+
+### Task 9: Bridge injection into the VM (coexisting, fixture-gated)
+
+**Files:**
+
+- Create: `internal/plugin/luabridge/bridge.go`
+- Modify: `internal/plugin/lua/host.go` (`DeliverEvent` injects the bridge for plugins using the new path)
+- Test: `internal/plugin/luabridge/bridge_test.go`
+
+Coexistence (spec §5): the new bridge MUST NOT double-inject a global the legacy `cap_*.go` already injects. In this sub-spec the new path is **opt-in** — only the fixture plugin (Phase 4) routes through it. Gate on an explicit per-plugin flag (e.g. a manifest marker or a host-set allowlist used only by the test harness); production plugins keep the legacy injection untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestBridgeRegistersDeclaredHostCapsOnly injects the bridge for a plugin
+// declaring only the `kv` CAPABILITY and asserts `kv` is present, `session` absent.
+func TestBridgeRegistersDeclaredHostCapsOnly(t *testing.T) {
+	L := lua.NewState(); defer L.Close()
+	// declared = capability tokens (manifest RequiredCapabilities()), not service names.
+	luabridge.RegisterHostCaps(L, conn, "echo-bot", []string{"kv"})
+	assert.Equal(t, lua.LTTable, L.GetGlobal("kv").Type())
+	assert.Equal(t, lua.LTNil, L.GetGlobal("session").Type())
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestBridgeRegistersDeclaredHostCapsOnly ./internal/plugin/luabridge/`
+Expected: FAIL — `RegisterHostCaps` undefined.
+
+- [ ] **Step 3: Implement `bridge.go`** — `RegisterHostCaps(L, conn, pluginName, declaredCaps []string)` iterates `declaredCaps` (capability tokens), looks up `registeredHostCapBindings[token]`, calls the registrar (gated by declaration = INV-PLUGIN-44/45 at the shared path).
+
+- [ ] **Step 4: Wire `DeliverEvent`** — after `h.hostFuncs.Register(...)`, if the plugin opts into the new path, call `luabridge.RegisterHostCaps(L, p.endpoint.Conn(), name, p.manifest.RequiredCapabilities())`. **Use `RequiredCapabilities()`, NOT `RequiredServiceNames()`** — host capabilities are declared as `requires: - capability: <token>` (`DependencyCapability` kind); `RequiredServiceNames()` (`manifest.go:150`) filters to `DependencyService` and would return an empty slice for a correctly-declared host-cap consumer, injecting zero bindings and silently defeating the gate. `RequiredServiceNames()` is still correct for the plugin→plugin path (Task 10), which consumes `service:` deps.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `task test -- -run TestBridge ./internal/plugin/luabridge/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit** — `feat(plugin): inject codegen'd host-cap bridge into Lua VMs, declaration-gated (holomush-eykuh.2)`.
+
+---
+
+## Phase 3 — Plugin→plugin consumption
+
+### Task 10: Load-time descriptor-driven plugin-service tables + `BrokerProxy` loopback
+
+**Files:**
+
+- Create: `internal/plugin/luabridge/pluginsvc.go`
+- Test: `internal/plugin/luabridge/pluginsvc_test.go`
+
+For each `requires: service: <Name>` a Lua plugin declares, build a `namespace.Method{…}` Lua table at load time from the provider's registered `protoreflect.ServiceDescriptor`; each function marshals the Lua table → `dynamicpb.Message`, invokes the method over a loopback conn whose server end is the **existing** `BrokerProxy` to the provider, and marshals the dynamic response back. Validate method existence at build (fail-early, spec §2).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestPluginServiceTableInvokesViaBrokerProxy builds a table for a fake provider
+// service and asserts a call reaches the provider through BrokerProxy.
+func TestPluginServiceTableInvokesViaBrokerProxy(t *testing.T) {
+	provider := newFakeProvider(t) // registers a 1-RPC service + its descriptor
+	L := lua.NewState(); defer L.Close()
+	require.NoError(t, luabridge.RegisterPluginService(L, provider.Conn(), provider.Descriptor(), "echo-bot"))
+	// call echo.Echo{message="hi"} from Lua, assert provider saw "hi"
+	require.NoError(t, L.DoString(`local r = echo.Echo{message="hi"}; assert(r.reply == "hi")`))
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestPluginServiceTable ./internal/plugin/luabridge/`
+Expected: FAIL — `RegisterPluginService` undefined.
+
+- [ ] **Step 3: Implement `pluginsvc.go`** — descriptor-walk to synthesize the table; `dynamicpb.NewMessage(methodDesc.Input())` for requests; invoke via `conn.Invoke(ctx, "/"+svc+"/"+method, req, resp)`; reuse `marshal.go` for table↔dynamicpb. The `conn` is the loopback to `BrokerProxy` (built by the host at load, mirroring `goplugin/host.go`'s `NewBrokerProxy(svc.Conn, pluginName)`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestPluginServiceTable ./internal/plugin/luabridge/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): load-time descriptor-driven Lua plugin-service bridge via BrokerProxy (holomush-eykuh.2)`.
+
+---
+
+## Phase 4 — Invariant binding + coexistence tests
+
+### Task 11: Cross-runtime parity test — bind INV-PLUGIN-49
+
+**Files:**
+
+- Create: `test/integration/pluginparity/parity_test.go` (build tag `//go:build integration`)
+- Modify: `docs/architecture/invariants.yaml` (`INV-PLUGIN-49` → `binding: bound`, `asserted_by`), then `go run ./cmd/inv-render`
+
+Use `kv` (no dispatch-token requirement, unlike `eval`/`emit`) so both runtimes reach the same `kvServer` handler.
+
+- [ ] **Step 1: Write the test** — same `kvServer` reached by a Lua consumer (bufconn) and a binary consumer (broker); assert identical result + host-derived subject. Annotate:
+
+```go
+// Verifies: INV-PLUGIN-49
+func TestKVCapabilityIsSingleSourceAcrossRuntimes(t *testing.T) { /* … */ }
+```
+
+- [ ] **Step 2: Run** — Run: `task test:int -- ./test/integration/pluginparity/`
+Expected: PASS.
+
+- [ ] **Step 3: Bind the invariant** — set `binding: bound` + `asserted_by: [test/integration/pluginparity/parity_test.go]`; `go run ./cmd/inv-render`; `task fmt`.
+
+- [ ] **Step 4: Verify binding** — Run: `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestBoundInvariantsAreGenuinelyAsserted' ./test/meta/`
+Expected: PASS. Then `bd close holomush-eykuh.6`.
+
+- [ ] **Step 5: Commit** — `test(plugin): bind INV-PLUGIN-49 cross-runtime single-source (holomush-eykuh.2, closes holomush-eykuh.6)`.
+
+### Task 12: Gate tests — bind INV-PLUGIN-44 / INV-PLUGIN-45
+
+**Files:**
+
+- Modify: `test/integration/pluginparity/parity_test.go`
+- Modify: `docs/architecture/invariants.yaml` (44, 45 → bound)
+
+- [ ] **Step 1: Write the tests** — (a) a declared cap/service is reachable from Lua; (b) an **undeclared** one is not reachable (gate); (c) the shared resolver/registry gate denies Lua and binary identically. Annotate `// Verifies: INV-PLUGIN-44` and `// Verifies: INV-PLUGIN-45`.
+
+- [ ] **Step 2: Run** — Run: `task test:int -- ./test/integration/pluginparity/`
+Expected: PASS.
+
+- [ ] **Step 3: Bind** 44 + 45; `go run ./cmd/inv-render`; `task fmt`; re-run the meta binding tests (Task 11 Step 4).
+
+- [ ] **Step 4: Commit** — `test(plugin): bind INV-PLUGIN-44/45 declaration-gated consumption (holomush-eykuh.2)`.
+
+### Task 13: Identity/anti-forgery + coexistence
+
+**Files:**
+
+- Modify: `test/integration/pluginparity/parity_test.go`
+- Test: `internal/plugin/lua/host_test.go` (coexistence)
+
+- [ ] **Step 1: Write the anti-forgery test** — assert the ABAC subject the host server observes is `plugin:<fixtureName>` regardless of any value the Lua code attempts to supply (no wire-supplied subject; INV-PLUGIN-22).
+
+- [ ] **Step 2: Write the coexistence test** — a plugin on the legacy `cap_*.go` path still has its globals injected unchanged when the new bridge exists (no regression; spec §5).
+
+- [ ] **Step 3: Run** — Run: `task test:int -- ./test/integration/pluginparity/` and `task test -- ./internal/plugin/lua/`
+Expected: PASS.
+
+- [ ] **Step 4: Full gate** — Run: `task pr-prep`
+Expected: green (Phase 1–4 bridge PR complete).
+
+- [ ] **Step 5: Commit** — `test(plugin): Lua identity anti-forgery + legacy-shim coexistence (holomush-eykuh.2)`.
+
+---
+
+## Notes for the implementer
+
+- **Search precedence** (`.claude/rules/search-tools.md`): `mcp__probe__search_code`/`extract_code` for Go symbols; `rg` for text; `ast-grep` for structural. Read with offset/limit.
+- **gRPC errors** (`.claude/rules/grpc-errors.md`): never `status.Errorf(codes.Internal, "...: %v", err)`; log via `errutil.LogErrorContext`, return `status.Errorf(codes.Internal, "internal error")`.
+- **Logging** (`.claude/rules/logging.md`): `*Context` slog variants whenever a `ctx` is in scope.
+- **Runtime symmetry** (`.claude/rules/plugin-runtime-symmetry.md`): the whole point — any gate at the shared `hostcap`/resolver path applies to both runtimes; the only runtime-specific code is the adapter (`LookupActor` token-vs-context) where a real forgery surface differs.
+- **`//nolint`**: line-scoped only with a reason; never widen `.golangci.yaml`.
+- **Schema/codegen drift**: `bindings_gen.go` is generated — `go generate ./internal/plugin/luabridge/`, never hand-edit; add the sha256 gate.
+- **Run `task test:int`** after any `plugin.yaml`/`requires` fixture change — unit resolver tests stay green while only the integration suite exercises injection (memory `5eead5f0`, the core-aliases lesson).
+<!-- adr-capture: sha256=394df9f785a2a6e6; session=cli; ts=2026-06-12T13:12:55Z; adrs=holomush-elqw4,holomush-ws2mi,holomush-l5bqb -->

--- a/docs/superpowers/specs/2026-06-12-lua-parity-host-brokered-consumption-design.md
+++ b/docs/superpowers/specs/2026-06-12-lua-parity-host-brokered-consumption-design.md
@@ -1,0 +1,344 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Lua Parity Layer — Host-Brokered Consumption of Capabilities and Plugin Services — Design
+
+> Sub-spec 3 of epic `holomush-eykuh` (Plugin capability & dependency architecture).
+> Bead: `holomush-eykuh.2`. Depends on sub-spec 1 (`holomush-oeb4d`, foundation —
+> typed deps + unified resolver) and sub-spec 2 (`holomush-eykuh.1`, the
+> `holomush.plugin.host.v1` capability decomposition).
+
+## Overview
+
+Binary plugins consume **both** host capabilities and other plugins' services through
+**one** mechanism: the hashicorp/go-plugin grpcbroker. For each declared dependency the
+host resolves a provider and serves it on a broker channel the plugin dials back over
+real gRPC (`internal/plugin/goplugin/host.go`, the broker-proxy loop ~666–694). Host
+capabilities (the
+`holomush.plugin.host.v1` services landed in sub-spec 2) and plugin-provided services are
+uniform — both are just broker IDs.
+
+Lua plugins have **no such uniform mechanism**. Host capabilities reach Lua as
+hand-written Go shims (`internal/plugin/hostfunc/cap_*.go`) injected as Lua globals, and
+**Lua has no way at all to consume a plugin-provided service**. Worse, each shim is a
+*parallel, divergent* contract: `cap_session.go` defines its own `SessionInfo` struct, its
+own narrow `SessionAccess` interface, and Lua names (`session.find_by_name`) that do not
+correspond to any `host.v1` RPC. That is precisely the runtime-specific capability surface
+INV-PLUGIN-49 forbids.
+
+This sub-spec gives Lua **one host-brokered consumption mechanism** for both host
+capabilities and plugin services, built on the same `host.v1` contracts and the same
+`BrokerProxy` binary already uses — so the proto contract becomes the single source both
+runtimes consume. It **binds INV-PLUGIN-44, INV-PLUGIN-45, and INV-PLUGIN-49** and closes
+bug `holomush-eykuh.6`.
+
+It does **not** migrate existing Lua plugins onto the new path or delete the legacy shims —
+that is sub-spec 5 (`holomush-eykuh.4`). The two sub-specs meet at a clean seam: **3 builds
+and proves the mechanism; 5 migrates production plugins onto it and removes the old
+surface.**
+
+## RFC2119 Keywords
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are to be
+interpreted as described in RFC 2119 and RFC 8174 (see the root `CLAUDE.md` table).
+
+## Goals
+
+1. Lua plugins **MUST** consume host capabilities (`holomush.plugin.host.v1`) through the
+   same gRPC contracts binary consumes — not a parallel hand-written surface.
+2. The `host.v1` server impls **MUST** be made runtime-neutral (§0): relocated to
+   `internal/plugin/hostcap/` behind a narrow `HostCapabilities` port so a single handler
+   body backs both runtimes (INV-PLUGIN-49 at the server level, not just the contract). The
+   three impls Lua is the first consumer of — Session, Property, World (proto contracts from
+   sub-spec 2, **no server impl yet**; see Background) — **MUST** be implemented here,
+   wrapping the same host-capability logic the legacy
+   `cap_session.go`/`cap_property.go`/`cap_world_query.go` shims call today.
+3. Lua plugins **MUST** be able to consume a plugin-provided service (the plugin→host→plugin
+   direction that has no Lua path today), through the same `BrokerProxy` binary uses.
+4. Plugin identity for both paths **MUST** be host-established and unforgeable — never
+   wire-supplied — preserving INV-PLUGIN-22 / the `PluginSubject` ABAC contract.
+5. The declaration gate (least privilege) **MUST** live at the shared broker/registry path,
+   not in per-runtime code (INV-PLUGIN-45).
+6. The work **MUST** bind INV-PLUGIN-44, INV-PLUGIN-45, INV-PLUGIN-49 with genuine
+   cross-runtime assertions, closing `holomush-eykuh.6`.
+7. Plugin-author developer experience **MUST NOT** regress: Lua's "drop a script, no build
+   step" value proposition is preserved, and the call surface carries no magic strings.
+
+## Non-Goals (deferred)
+
+| Deferred | Owner |
+| --- | --- |
+| Migrating existing Lua plugins onto the new path; deleting `cap_*.go`; gating the unconditional injection | Sub-spec 5 (`holomush-eykuh.4`) |
+| Adding `requires` declarations to plugins that consume host functions without declaring them today | Sub-spec 5 |
+| Generated `.lua` doc/type-stub files for editor/LSP discoverability | `holomush-eykuh.9` (dev-ex follow-on; plugin-SDK scope) |
+| Lua **consuming a server-streaming** plugin RPC | Out of scope — no current consumer; all `host.v1` is unary; `BrokerProxy` already proxies streams generically when one is needed |
+| Least-privilege *enforcement hardening* and plugin-trust security | Sub-spec 4 (`holomush-eykuh.3`) |
+
+## Background — current state (grounded)
+
+### Binary consumption — one broker mechanism
+
+`goplugin/host.go:686` serves the host-capability server (`newPluginHostServiceServer`)
+and, for each `manifest.RequiredServiceNames()`, resolves the provider from `h.registry`,
+wraps it in a `BrokerProxy`, and serves it on a fresh broker ID. The plugin receives
+`requiredServices[svcName] = "broker:N"` in its `InitRequest` and dials back. Host caps and
+plugin services are the same shape.
+
+`BrokerProxy` (`goplugin/broker_proxy.go`) is a **generic, codegen-free** forwarder: a
+`grpc.UnknownServiceHandler` + `ProxyStreams` that forwards any method by name to the
+provider's `ClientConn`. It already handles unary and streaming transparently.
+
+`newPluginHostServiceServer(host, pluginName)` (`goplugin/host_service.go`) builds a
+**dedicated `*grpc.Server` per binary plugin**, registering every `host.v1` capability
+server with `hostCapabilityBase{host, pluginName}` baked in. **Identity is which server
+instance the plugin dials — host-wired per plugin, never read from a request.**
+
+### Lua consumption — divergent shims, no plugin-service path
+
+`hostfunc/capability.go` `InjectRequired(L, requires, pluginName)` registers `Capability`
+modules (`cap_session.go`, `cap_property.go`, …) as Lua globals. Each is a hand-written Go
+translation against a bespoke struct/interface, not the `host.v1` proto. The ABAC subject
+is derived host-side from the captured `pluginName` (`adapter.go:68`
+`access.PluginSubject(a.pluginName)`) — correct and unforgeable, but a *second* contract
+parallel to the proto. There is **no Lua mechanism to call a plugin-provided service.**
+
+### What sub-spec 2 already locked
+
+The `holomush.plugin.host.v1` package exists: **11 proto files declaring 13 services**
+(`session.proto` → `SessionService` + `SessionAdminService`; `stream.proto` →
+`StreamHistoryService` + `StreamSubscriptionService`; the other 9 files one service each:
+`property`, `world`, `emit`, `eval`, `focus`, `kv`, `audit`, `settings`,
+`command_registry`). **Every RPC is unary** (verified: zero `rpc … stream`;
+`QueryStreamHistory` returns a batched response; `AddSessionStream`/`RemoveSessionStream`
+are unary subscription-control).
+
+**Not every service has a Go server impl yet.** `host_capability_servers.go` implements
+**9** server types (`focusServer`, `emitServer`, `evalServer`, `settingsServer`,
+`streamHistoryServer`, `streamSubscriptionServer`, `auditServer`, `commandRegistryServer`,
+`kvServer`), and `newPluginHostServiceServer` (`host_service.go:31`) registers exactly
+those 9 — with an explicit comment that **Session, Property, and World are deliberately NOT
+registered because they have no binary consumer in sub-spec 2.** Lua *is* their consumer
+(today via `cap_session.go`/`cap_property.go`/`cap_world_query.go`), so **implementing the
+`sessionServer`/`propertyServer`/`worldServer` types is this sub-spec's job** (see Goal 2,
+§0, §2). They wrap the same host capability logic the legacy shims call. All 12 server
+impls (the 9 existing + these 3) relocate to the runtime-neutral `internal/plugin/hostcap/`
+package behind the `HostCapabilities` port (§0).
+
+The existing servers derive the ABAC subject + emit actor-vouching (the `holomush-ec22.1`
+token gate) from `hostCapabilityBase.pluginName`; the new three MUST do the same.
+
+## Design
+
+The mechanism is a foundational refactor (§0) plus three components and a codegen step.
+§0 makes single-source true at the *server* level; components 1 and 3 mirror binary
+exactly; component 2 is the only new runtime machinery.
+
+### §0 — Runtime-neutral host-capability servers (the `HostCapabilities` port)
+
+INV-PLUGIN-49 requires both runtimes to consume the **same server implementations**, not
+merely the same proto contract. Today they cannot: the 9 `host.v1` server impls in
+`internal/plugin/goplugin/host_capability_servers.go` embed
+`hostCapabilityBase{ host *goplugin.Host }` — welded to the concrete binary-plugin `Host`
+(reaching `host.engine`, `host.tokenStore`, `host.auditor`, `host.sessionAccess`, the
+settings stores, focus coordinator, history reader, …). The Lua runtime does **not** import
+`goplugin` (clean sibling layering) and holds a *parallel* backing on `hostfunc.Functions`
+(`engine`, `auditor`, `sessionAccess`, `propertyRegistry`, `worldMutator`, `kvStore`,
+`settingsOps`, `historyReader`, …) — the same logical dependencies held twice. A second
+server impl wrapping `hostfunc.Functions` is exactly the runtime-specific surface
+INV-PLUGIN-49 forbids; having `lua` import `goplugin` is the wrong dependency direction.
+
+The resolution is **ports & adapters**:
+
+1. Define a narrow `HostCapabilities` port — the set of host operations the 9 servers (plus
+   the 3 new ones in §2) actually call (access engine, auditor, dispatch-token store,
+   session access, property registry, world query/mutator, settings stores, focus
+   coordinator, history reader, stream registry, command querier, KV store, event emitter).
+   The interface MUST be **method-narrow** (only what the servers call), not a mirror of the
+   whole `goplugin.Host` struct.
+2. Move the 9 server impls + `hostCapabilityBase` into a **runtime-neutral package**,
+   `internal/plugin/hostcap/`, depending only on the port (not on `goplugin`).
+3. Provide two adapters: `goplugin.Host` already exposes the needed operations (a thin
+   adapter or direct interface-satisfaction), and a **new `hostfunc.Functions`-backed
+   adapter** for the Lua runtime. Both construct the same `hostcap` servers.
+
+Result: **one** set of `host.v1` server impls, two thin adapters; INV-PLUGIN-49 holds at the
+server level by construction. The dispatch-token concern stays adapter-specific — the binary
+adapter wires the `emitTokenStore` forgery defense; the Lua adapter supplies the
+connection-scoped identity equivalent (the token surface exists only where a forgery surface
+does; §4 / `.claude/rules/plugin-runtime-symmetry.md`).
+
+This refactor is **behavior-preserving for binary**: the binary path keeps the same servers
+reaching the same host operations, now through the port. It is verified by the existing
+`goplugin` host-capability tests continuing to pass unchanged (plus a relocation smoke test).
+
+### §1 — Per-plugin bufconn endpoint (mirror of binary)
+
+For each Lua plugin VM, the host stands up a per-plugin `*grpc.Server` registering the
+`host.v1` capability servers, wrapped on an in-memory bufconn via the **existing**
+`internal/plugin.NewInProcessConn(srv)` helper (`internal/plugin/inprocess_conn.go` — it
+already serves any `*grpc.Server` on a bufconn and returns a `grpc.ClientConnInterface`;
+the spec reuses it rather than building parallel bufconn infrastructure). The plugin's Lua
+code is handed only the resulting in-process `ClientConn`.
+
+The server registers the **`hostcap` servers** (§0), constructed with the Lua adapter as
+their `HostCapabilities` port and `pluginName` baked into `hostCapabilityBase`. Its
+**registration set differs** from binary's: binary's omits Session/Property/World (no binary
+consumer); the Lua server registers the capabilities a Lua plugin actually consumes,
+**including the `sessionServer`/`propertyServer`/`worldServer` added in §2**. The handler
+bodies are the single-source `hostcap` impls; only the registration set and the adapter are
+per-runtime. (Whether registration becomes manifest-gated for the *binary* server too is a
+§4 / sub-spec 4 concern, not changed here.) A shared
+`hostcap.RegisterCapabilities(server, base, set)` helper factors the common registration so
+the two runtimes cannot drift; `goplugin`'s `newPluginHostServiceServer` is refactored to
+call it. Final file layout is a plan-stage decision within `internal/plugin/hostcap/`.
+
+- Identity is **connection-scoped and host-established at wiring time**. The plugin cannot
+  enumerate or forge another plugin's connection (in-process; it holds only its own
+  `ClientConn`) — a stronger boundary than binary's integer broker IDs.
+- Because Lua now lands on the **same** `hostCapabilityBase` servers, the ABAC subject
+  (`access.PluginSubject(name)`) and emit actor-vouching are inherited with **no new
+  subject/token code**.
+- `host.v1` services that have no consumer in this sub-spec remain registered as today;
+  registering them is harmless and keeps the per-plugin server identical to binary's.
+
+The bufconn `Listener` + `*grpc.Server` per plugin is the deliberate choice over a single
+shared server, precisely because a shared listener could not bind per-plugin identity
+host-side without a forgeable metadata header. Per-plugin servers are cheap and reproduce
+binary's identity model verbatim. If a profile ever shows the in-memory pipe copy matters,
+bufconn is replaceable by a custom in-memory `grpc.ClientConnInterface` behind the same
+stubs — a transparent later optimization, out of scope here.
+
+### §2 — The Lua↔proto bridge (the only new machinery)
+
+The bridge turns a Lua call into a proto request, invokes the unary RPC over the per-plugin
+`ClientConn`, and turns the proto response back into Lua values. It is **unary-only**
+(all `host.v1` is unary). It splits by **proto ownership**:
+
+**Host capabilities — build-time codegen, strongly typed.** A `go:generate` generator reads
+the `host.v1` service descriptors and emits typed Go marshalers: each constructs the
+concrete `*hostv1.<Method>Request` field-by-field (no map keys, no magic strings) and calls
+the already-generated typed client stub (`hostv1.New<Svc>ServiceClient(conn).<Method>`),
+then marshals the typed response into a Lua table. The emitted code registers
+`namespace.Method{…}`-shaped Lua tables (e.g. `session.FindByName{…}`). Strong typing on the
+Go side, drift-proof (regenerated, never hand-synced), and genuinely the **single source**:
+binary and Lua both consume the same generated stubs from the same descriptors.
+
+**Plugin services — load-time descriptor-driven, typed-shaped surface.** A provider's proto
+is third-party and not imported by the host, so there is no Go struct to marshal into and
+(Lua being non-compiled) no consumer-side type enforcement to gain. The host **does** hold
+the provider's `FileDescriptor` at load time (the provider must register it for the broker
+to route). When a Lua plugin declares `requires: service: <Name>` and the provider is
+resolved, the bridge builds `namespace.Method{…}`-shaped Lua tables for that service from
+the descriptors, marshaling Lua tables ↔ `dynamicpb.Message`. Call sites carry **no magic
+strings**; the reflective marshaling is invisible to the author. Binary consumers keep full
+static typing (they import the provider's `.pb.go`); this is the achievable ceiling for a
+non-compiled consumer of a contract it does not own.
+
+Both surfaces present the **identical** `namespace.Method{…}` ergonomic shape, so a plugin
+author cannot tell which is codegen'd and which is descriptor-driven — uniform dev-ex, no
+build step on the Lua side.
+
+**Error mapping.** gRPC `status` errors map to the established Lua convention
+(`hostfunc/helpers.go` `pushError` → `nil, "<message>"`, the 2-return pattern). Internal
+error text is not leaked past the boundary (per `.claude/rules/grpc-errors.md`); the bridge
+surfaces the status code/message the host servers already shape.
+
+**Load-time validation (fail early).** Tables are built (and validated against descriptors)
+at load. An unknown method or a malformed/unsatisfiable `requires: service` fails at **load
+time**, not at first call — recovering most of static typing's safety at the boundary that
+matters. This is consistent with the foundation's fail-fast resolver (`holomush-oeb4d`).
+
+### §3 — Plugin→plugin transport (reuse `BrokerProxy`)
+
+A Lua plugin's call to a required plugin service dials a loopback `ClientConn` whose server
+end is the **same** `BrokerProxy` binary uses to reach that provider. One generic
+byte-forwarder, both runtimes, both directions. No new proxy code; the §2 plugin-service
+binding produces the request bytes, `BrokerProxy` forwards them to the provider.
+
+### §4 — The declaration gate (shared path, least privilege)
+
+The gate that decides whether a plugin may reach a capability or service is the **resolver +
+registry** the foundation already established (`ResolveDependencyOrder`,
+`manifest.RequiredServiceNames()` / `RequiredCapabilities()`), shared by both runtimes
+(INV-PLUGIN-45). Lua's per-plugin server (§1) registers/serves **only** what the manifest
+declares and the resolver satisfied; an undeclared capability or service is never reachable
+from Lua, exactly as for binary (INV-PLUGIN-44). No per-runtime gating logic is introduced.
+
+### §5 — Coexistence with the legacy shims (the 3↔5 seam)
+
+The legacy `cap_*.go` injection is **left intact and untouched.** The new bridge is
+exercised in this sub-spec through a **test fixture**, not by rerouting production plugins —
+because the old shim and the new bridge cannot both own the same Lua global, so rerouting a
+real plugin necessarily means deleting its old injection, which is sub-spec 5's gating job.
+In sub-spec 3 the two surfaces coexist; sub-spec 5 migrates and removes the old one.
+
+## Invariants
+
+Sub-spec 3 **binds** three invariants left `pending` by the foundation/decomposition:
+
+| Invariant | Summary (registry) | How this sub-spec binds it |
+| --- | --- | --- |
+| INV-PLUGIN-44 | Both runtimes obtain every declared dependency through the one host gRPC broker, gated by declaration, authorized as `PluginSubject`; neither receives an undeclared capability/service. | Lua now consumes via the per-plugin bufconn server + `BrokerProxy` (§1, §3); fixture asserts a declared cap and a declared service are reachable and an **undeclared** one is not. |
+| INV-PLUGIN-45 | The declaration gate MUST live at the broker/registry common path shared by both runtimes; per-runtime gating is forbidden. | §4 — Lua reuses the foundation resolver/registry gate; fixture asserts the same gate denies Lua and binary identically. |
+| INV-PLUGIN-49 | A capability's RPC contract MUST be the single source both runtimes consume; no runtime-specific capability surface. | §2 host-cap codegen makes the proto the literal shared source; cross-runtime test asserts a Lua consumer and a binary consumer reach the **same** `host.v1` handler. Closes `holomush-eykuh.6`. |
+
+No **new** invariant ids are minted by this sub-spec. (If the per-plugin-identity property of
+§1 warrants its own registry entry rather than resting on INV-PLUGIN-22, that is a
+reviewer-time decision; default is to bind the three above.)
+
+## Testing strategy
+
+- **Fixture Lua plugin** that consumes (a) a unary host capability and (b) a fixture
+  plugin-provided service, over the new path. Build-tag-gated where it needs the integration
+  harness; bridge marshaling is unit-testable in isolation.
+- **New-server tests:** the `sessionServer`/`propertyServer`/`worldServer` implemented here
+  are exercised by a Lua consumer (these three have no binary consumer, so their first
+  consumption is the Lua path) — asserting parity with the behavior the legacy
+  `cap_session.go`/`cap_property.go`/`cap_world_query.go` shims produce.
+- **Cross-runtime parity test (binds INV-PLUGIN-49):** uses a capability that **already has a
+  binary consumer/server** so both runtimes genuinely reach the *same* handler — `eval`
+  (`Evaluate`), `settings` (`GetSetting`), or `kv` are good candidates (read-only, simple).
+  The same `host.v1` handler is reached by a Lua consumer (bufconn) and a binary consumer
+  (broker); both observe identical behavior and the host-derived subject. Carries
+  `// Verifies: INV-PLUGIN-49`. (Session/Property/World cannot serve this test until a binary
+  consumer exists — they prove the single-source *implementation* via the new-server tests
+  above instead.)
+- **Gate tests (bind INV-PLUGIN-44/45):** a declared dependency is reachable; an
+  **undeclared** capability/service is not reachable from Lua; the shared gate denies Lua and
+  binary identically.
+- **Identity/anti-forgery:** assert the ABAC subject seen by the host server is
+  `plugin:<fixtureName>` regardless of any value the Lua code attempts to supply.
+- **Bridge marshaling units:** round-trip Lua table ↔ typed `host.v1` message (codegen path)
+  and Lua table ↔ `dynamicpb.Message` (descriptor path); gRPC `status` → `pushError` mapping;
+  load-time rejection of an unknown method / unsatisfiable `requires`.
+- **Coexistence:** the legacy `cap_*.go` injection still works unchanged (no regression).
+- Per CLAUDE.md, run `task test:int` after any `plugin.yaml`/`requires` fixture change —
+  the unit resolver test stays green while only the integration suite exercises injection
+  (per the `core-aliases` lesson, memory `5eead5f0`).
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Per-plugin bufconn server adds N in-process servers/goroutines. | Servers are cheap; this reproduces binary's per-plugin model exactly. Custom in-memory `ClientConn` is a documented later optimization behind the same interface. |
+| New codegen step (host-cap bridge) is build machinery that can drift. | Mirrors the existing generated-stub discipline; a `go:generate` + drift gate (as with `schemas/plugin.schema.json`, memory `12d49499`) keeps it honest. Generator output is the only artifact; never hand-edit. |
+| Descriptor-driven plugin→plugin marshaling is one reflective seam. | Honest and unavoidable (third-party proto, non-compiled consumer); load-time validation recovers fail-early; binary keeps full static typing. |
+| In-process gRPC marshaling overhead on capability calls. | Capability calls are not inner-loop (session/property/emit already touch DB/bus); the mandate explicitly discounts pre-measured perf; optimization escape hatch preserved. |
+| Rerouting a production plugin would collide with its legacy injection. | Out of scope by the §5 seam — sub-spec 3 proves via fixture only; sub-spec 5 owns migration. |
+| Implementing `sessionServer`/`propertyServer`/`worldServer` adds server-impl scope sub-spec 2 deferred. | Bounded: the host capability logic already exists (the legacy shims' backing interfaces — `SessionAccess`, property/world adapters); the new servers wrap it behind the `host.v1` contract. The proto contracts already exist; this is impl, not redesign. |
+| §0 relocation of the 9 existing servers + `hostCapabilityBase` into `hostcap` behind a port is a non-trivial refactor of working binary code. | Behavior-preserving by construction (same servers, same host ops, now via a method-narrow interface `goplugin.Host` already satisfies); guarded by the existing `goplugin` host-capability tests passing unchanged. The interface is extracted from actual call sites, not speculative. Land §0 as its own commit/bead before the Lua-consumer work so a regression is isolatable. |
+
+## References
+
+- Epic: `holomush-eykuh` · this bead: `holomush-eykuh.2` · closes `holomush-eykuh.6` ·
+  follow-on `holomush-eykuh.9`
+- Sub-spec 1 (foundation): `docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md`
+- Sub-spec 2 (decomposition): `docs/superpowers/specs/2026-06-11-plugin-host-capability-decomposition-design.md`
+- Runtime symmetry: `.claude/rules/plugin-runtime-symmetry.md`
+- gRPC error handling: `.claude/rules/grpc-errors.md`
+- Grounding: `goplugin/host.go:686`, `goplugin/broker_proxy.go`, `goplugin/host_service.go`,
+  `hostfunc/capability.go`, `hostfunc/cap_session.go`, `hostfunc/adapter.go`,
+  `api/proto/holomush/plugin/host/v1/*.proto`
+<!-- adr-capture: sha256=d2adb37e8e840a22; session=cli; ts=2026-06-12T13:12:55Z; adrs=holomush-elqw4,holomush-ws2mi,holomush-l5bqb -->


### PR DESCRIPTION
Docs-first PR for **sub-spec 3** of the plugin capability epic (`holomush-eykuh`): the Lua parity layer — giving Lua plugins one host-brokered mechanism to consume both `host.v1` capabilities and plugin-provided services, making the proto contract the single source both runtimes consume. Binds INV-PLUGIN-44/45/49 (closes `holomush-eykuh.6`).

## Contents
- **Spec** `docs/superpowers/specs/2026-06-12-lua-parity-host-brokered-consumption-design.md` — bufconn transport, per-plugin connection-scoped identity, codegen (host caps) + descriptor-driven (plugin services) bridge split, and the §0 `HostCapabilities` ports-&-adapters refactor. design-reviewer **READY** (3 rounds).
- **Plan** `docs/superpowers/plans/2026-06-12-lua-parity-host-brokered-consumption.md` — 13 tasks / 5 phases. plan-reviewer **READY** (2 rounds; 4 Criticals caught + fixed). Phase 0 = behavior-preserving binary refactor (PR1); Phases 1–4 = Lua bridge (PR2).
- **3 ADRs** — `holomush-elqw4` (per-plugin bufconn identity), `holomush-ws2mi` (bridge split by proto ownership), `holomush-l5bqb` (HostCapabilities port).

## Why docs-first
The implementer subagents for PR1/PR2 read canonical spec/plan/ADRs from `main`. Landing these first keeps dispatch prompts simple.

bd: epic `holomush-eykuh.2` materialized into 13 child tasks (`eykuh.2.1`…`.13`) + dependency graph; first ready task `eykuh.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)