### PR TITLE
docs(plugin): sub-spec 4 — least-privilege enforcement & plugin-trust security (holomush-eykuh.3)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,10 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Stamp dispatch context host-side; never accept a wire subject](holomush-wvrtc-stamp-dispatch-context-host-side-never-accept-wire-subject.md) | 2026-06-12 | Accepted | `holomush-wvrtc` |
+| [Capability access is a default-deny ABAC decision, not a set check](holomush-syhc2-capability-access-is-default-deny-abac-decision-not-set-chec.md) | 2026-06-12 | Accepted | `holomush-syhc2` |
+| [access: and scope: are valid only on capability entries, not service entries](holomush-u1sdq-access-and-scope-are-valid-only-capability-entries-not-servi.md) | 2026-06-12 | Accepted | `holomush-u1sdq` |
+| [Scope enforcement uses typed co-located extractors, not reflective broker introspection](holomush-afyzh-scope-enforcement-uses-typed-co-located-extractors-not-refle.md) | 2026-06-12 | Accepted | `holomush-afyzh` |
 | [Extract HostCapabilities port; relocate host.v1 servers to runtime-neutral package](holomush-l5bqb-extract-hostcapabilities-port-relocate-host-v1-servers-runti.md) | 2026-06-12 | Accepted | `holomush-l5bqb` |
 | [Split Lua bridge by proto ownership: codegen host caps, descriptor-driven plugin services](holomush-ws2mi-split-lua-bridge-by-proto-ownership-codegen-host-caps-descri.md) | 2026-06-12 | Accepted | `holomush-ws2mi` |
 | [Per-plugin bufconn server for host-established Lua plugin identity](holomush-elqw4-per-plugin-bufconn-server-host-established-lua-plugin-identi.md) | 2026-06-12 | Accepted | `holomush-elqw4` |

--- a/docs/adr/holomush-afyzh-scope-enforcement-uses-typed-co-located-extractors-not-refle.md
+++ b/docs/adr/holomush-afyzh-scope-enforcement-uses-typed-co-located-extractors-not-refle.md
@@ -1,0 +1,38 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-afyzh; do not edit manually; use `/adr update holomush-afyzh` -->
+
+# Scope enforcement uses typed co-located extractors, not reflective broker introspection
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-afyzh
+**Deciders:** Sean Brandt
+
+## Context
+
+scope: instance narrowing must extract the concrete resource of a call (e.g. which location a world.mutation touches) to compare against the dispatch-context attribute. Two topologies were candidates: a reflective broker interceptor parsing request fields via proto reflection, or typed accessor functions co-located with each scope-eligible handler in the in-tree host.v1 servers.
+
+## Decision
+
+Each scope-eligible capability method carries a typed ScopedResourceFn extractor registered in the CapabilityDescriptor. The shared host.v1 interceptor denies any scoped call whose method lacks a wired extractor (fail-closed). A CI meta-test enumerates every scope-eligible method and fails the build if any lacks an extractor. Binds INV-PLUGIN-52.
+
+## Rationale
+
+- Reflective extraction in the broker fails OPEN on a missing field-mapping — the worst failure mode for a security gate.
+- Typed extractors are co-located with handlers; they cannot drift, and the compiler catches type mismatches.
+- All host.v1 servers are in-tree, so the meta-test has complete visibility; out-of-tree plugins cannot introduce unguarded scope-eligible methods.
+- Three-way fail-closed (runtime deny + CI meta-test + INV-PLUGIN-52) ensures no silent un-enforcement across refactors.
+
+## Alternatives Considered
+
+- **Unified reflective broker interceptor:** single interception point, but relocates per-method extraction into a reflective seam + out-of-band field-mapping registry that drifts and fails open. Rejected.
+- **Typed co-located ScopedResource extractor (chosen):** typed, drift-proof, fail-closed by default, exhaustively meta-testable because host.v1 is in-tree.
+
+## Consequences
+
+Positive: no silent fail-open — a missing extractor denies, never leaks unscoped; extractor completeness is a build-time guarantee not a review concern; no proto-reflection fragility in the security path. Negative: every new scope-eligible method must register an extractor (omission is a deny/outage, not a silent hole); the CapabilityDescriptor must stay current. Neutral: the descriptor is also the single host-owned source for M1 action/resource and M2 operation class — one table serves all three mechanisms.

--- a/docs/adr/holomush-syhc2-capability-access-is-default-deny-abac-decision-not-set-chec.md
+++ b/docs/adr/holomush-syhc2-capability-access-is-default-deny-abac-decision-not-set-chec.md
@@ -1,0 +1,38 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-syhc2; do not edit manually; use `/adr update holomush-syhc2` -->
+
+# Capability access is a default-deny ABAC decision, not a set check
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-syhc2
+**Deciders:** Sean Brandt
+
+## Context
+
+After sub-specs 1-3, a plugin's manifest declaration was both necessary and sufficient to reach a host capability — the consumption path had no policy decision. Operators had no lever to narrow or deny a declared capability without editing the plugin manifest.
+
+## Decision
+
+Capability/service consumption is authorized by a default-deny ABAC decision keyed on the host-stamped plugin:<name> subject. The existing pluginauthz machinery (subject derivation, engine, single-audit-event) is reused via a sibling capability-access entitlement path that substitutes the owned-type predicate with a declaration+resolver-satisfied check. Binds INV-PLUGIN-50.
+
+## Rationale
+
+- Declaration stays necessary (resolver gates reach) but is no longer sufficient — operator policy may deny, enabling defense in depth.
+- Reusing pluginauthz preserves INV-PLUGIN-26 (one shared decision point, both runtimes); no second engine.
+- A sibling entitlement path avoids breaking the EVALUATE_UNENTITLED_TYPE owned-type predicate, which would deny host-capability resources (location/kv/session) that are not plugin-owned.
+- Static checks (declaration re-check + access: class) run before the policy Evaluate (cheap-before-expensive).
+
+## Alternatives Considered
+
+- **Declaration-as-sufficient (status quo):** zero overhead, but no operator control and any vulnerability in a declared capability is fully exploitable. Rejected.
+- **Default-deny capability-access entitlement (chosen):** operators can deny by policy; reuses engine/subject/audit; declaration is the floor, policy the ceiling. Note: reusing pluginauthz.Evaluate verbatim was rejected because its owned-type gate denies all host-capability resources — hence the sibling path.
+
+## Consequences
+
+Positive: operators gain a compensating control without touching the manifest; all denials audited (INV-PLUGIN-25); default policy permits declared caps so existing plugins are unaffected. Negative: per-call Evaluate adds latency (mitigated by static short-circuit); the capability-access entitlement predicate must stay in sync with resolver satisfaction. Neutral: declaration remains the necessary floor.

--- a/docs/adr/holomush-u1sdq-access-and-scope-are-valid-only-capability-entries-not-servi.md
+++ b/docs/adr/holomush-u1sdq-access-and-scope-are-valid-only-capability-entries-not-servi.md
@@ -1,0 +1,39 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-u1sdq; do not edit manually; use `/adr update holomush-u1sdq` -->
+
+# access: and scope: are valid only on capability entries, not service entries
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-u1sdq
+**Deciders:** Sean Brandt
+
+## Context
+
+The per-entry least-privilege parameters access: (operation class) and scope: (instance) needed a validity boundary. Manifests declare both host capabilities (capability:) and provider-plugin services (service:). The host owns the capability servers and can enforce host-authored scope; it owns neither the provider's method classification nor its resource model for plugin services.
+
+## Decision
+
+access: and scope: are valid only on capability: requires entries. Either parameter on a service: entry is a hard manifest error at load. The host cannot honor a scope/access promise on a provider-owned service. Binds INV-PLUGIN-53.
+
+## Rationale
+
+- The host can enforce what it promises: host.v1 servers are in-tree and host-owned, so the typed extractor and interceptor always run.
+- Rejecting these params on service: entries at load prevents the 'declared but not enforced' smell — the worst outcome for a least-privilege feature.
+- Provider-side scope is still fully supported via the provider's own policies keyed on the DispatchContext the host propagates across the broker.
+- The growth path for a service needing host-enforced scope is promotion to a host capability.
+
+## Alternatives Considered
+
+- **scope: legal on service: with provider-side enforcement:** uniform syntax, but one keyword means two strengths (host-guaranteed vs advisory) — the privilege gradient the symmetry mandate abolishes. Rejected.
+- **scope: via operator policy only, no keyword:** simpler schema, but removes the instance ceiling from the plugin's own auditable contract (invisible at plugin info). Rejected.
+- **Capability-only, hard error on service: (chosen):** host enforces only what it owns; no ambiguity; provider scope still supported via its own policies.
+
+## Consequences
+
+Positive: no ambiguity between guaranteed and advisory scope; hard errors surface at load not silently at runtime; the contract auditable at plugin info is also the enforced contract. Negative: a provider service with real cross-plugin scope needs must be promoted to a host capability; authors may be surprised scope: on a service entry errors. Neutral: provider-side scope via host.Evaluate + DispatchContext is unaffected.

--- a/docs/adr/holomush-wvrtc-stamp-dispatch-context-host-side-never-accept-wire-subject.md
+++ b/docs/adr/holomush-wvrtc-stamp-dispatch-context-host-side-never-accept-wire-subject.md
@@ -1,0 +1,39 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-wvrtc; do not edit manually; use `/adr update holomush-wvrtc` -->
+
+# Stamp dispatch context host-side; never accept a wire subject
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-wvrtc
+**Deciders:** Sean Brandt
+
+## Context
+
+Plugin-mediated authorization decisions (scope checks, command-registry enumeration) require a host-vouched acting-character subject and attributes. Before this design, command-registry RPCs derived the ABAC subject from wire-supplied `character_id`, enabling subject spoofing identical to the class ADR holomush-qeypl closed for host.Evaluate. The fix had to be symmetric across both binary and Lua runtimes (plugin-runtime-symmetry).
+
+## Decision
+
+The host stamps a `DispatchContext` (host-vouched subject + attributes) onto the delivery context.Context once, before any plugin code runs, via an unexported key in pluginauthz. All downstream paths — binary broker, Lua bufconn, and legacy in-VM hostfuncs — inherit it; neither runtime can set or observe it. Binds INV-PLUGIN-51.
+
+## Rationale
+
+- Closes the same subject-spoofing class as holomush-qeypl with one primitive, one guarantee.
+- An unexported context key is a structural unforgeable guarantee, not a bypassable runtime check.
+- Absent dispatch context fails closed (deny) across both runtimes identically.
+- Serves as the shared input for M3 scope anchoring and M4 command-registry fix, making the sub-spec cohesive.
+
+## Alternatives Considered
+
+- **Wire-supplied character_id as subject (status quo):** simple field read, but any plugin with command-registry can enumerate any character by forging the ID. Rejected.
+- **Per-call token auth (binary only):** reuses the EmitEvent token, but cannot extend to Lua hostfuncs — a runtime privilege gradient the symmetry rule forbids. Rejected.
+- **Host-stamped DispatchContext (chosen):** structurally unforgeable, symmetric, doubles as the M3/M4 spine.
+
+## Consequences
+
+Positive: spoofing is structurally impossible regardless of plugin type; both runtimes reach the same guarantee; timer/startup emits fail closed rather than leak. Negative: calls without an acting character cannot use scope-gated capabilities; the stamp must be threaded through every host delivery entry point or INV-PLUGIN-51 is silently violated. Neutral: the wire character_id field disposition (keep-but-ignore vs remove) is a bounded proto-compat follow-up.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -322,6 +322,10 @@ invariants.
 | `INV-PLUGIN-47` | Every host-brokered capability function MUST map to exactly one capability-scoped service in holomush.plugin.host.v1; no host.v1 service MUST span two capability domains, and the PluginHostService god-service MUST NOT exist after the decomposition. | — | bound |
 | `INV-PLUGIN-48` | Ambient runtime substrate (log, new_request_id, stdlib, config) MUST NOT be modeled as a capability: it MUST NOT appear in holomush.plugin.host.v1 and MUST NOT be a valid requires capability token. | — | bound |
 | `INV-PLUGIN-49` | A capability's RPC contract MUST be the single source both runtimes consume; there MUST NOT be a runtime-specific capability surface (the union resolves today's Lua/binary asymmetry). Generalizes INV-COMMAND-2 to the whole host-capability surface. | — | bound |
+| `INV-PLUGIN-50` | A plugin's consumption of a host capability or plugin service MUST be authorized by a default-deny ABAC decision keyed on the host-stamped plugin:<name> subject. Manifest declaration is necessary but not sufficient; an operator policy MAY deny a declared capability. | — | pending |
+| `INV-PLUGIN-51` | Any character subject or dispatch attribute used in a plugin-mediated authorization decision MUST be host-vouched (derived from the host delivery context) and MUST NOT originate from plugin- or wire-supplied data. Covers the command-registry RPCs and scope: anchoring. | — | pending |
+| `INV-PLUGIN-52` | Every scope-eligible capability method MUST resolve its scoped resource through a wired extractor; a method missing its extractor MUST fail closed (deny), never forward unscoped. No silent fail-open. | — | pending |
+| `INV-PLUGIN-53` | The per-entry least-privilege parameters (access:, scope:) are valid only on a capability: requires entry; either on a service: entry MUST be a hard manifest error at load. | — | pending |
 
 ### `INV-EVENTBUS`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3807,6 +3807,32 @@ invariants:
     binding: bound
     asserted_by:
       - "test/integration/pluginparity/parity_test.go"
+  - id: INV-PLUGIN-50
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
+    summary: "A plugin's consumption of a host capability or plugin service MUST be authorized by a default-deny ABAC decision
+      keyed on the host-stamped plugin:<name> subject. Manifest declaration is necessary but not sufficient; an operator policy
+      MAY deny a declared capability."
+    binding: pending
+  - id: INV-PLUGIN-51
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
+    summary: "Any character subject or dispatch attribute used in a plugin-mediated authorization decision MUST be host-vouched
+      (derived from the host delivery context) and MUST NOT originate from plugin- or wire-supplied data. Covers the command-registry
+      RPCs and scope: anchoring."
+    binding: pending
+  - id: INV-PLUGIN-52
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
+    summary: "Every scope-eligible capability method MUST resolve its scoped resource through a wired extractor; a method
+      missing its extractor MUST fail closed (deny), never forward unscoped. No silent fail-open."
+    binding: pending
+  - id: INV-PLUGIN-53
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
+    summary: "The per-entry least-privilege parameters (access:, scope:) are valid only on a capability: requires entry; either
+      on a service: entry MUST be a hard manifest error at load."
+    binding: pending
   - id: INV-COMMAND-1
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/docs/superpowers/plans/2026-06-12-plugin-least-privilege-trust.md
+++ b/docs/superpowers/plans/2026-06-12-plugin-least-privilege-trust.md
@@ -843,51 +843,25 @@ Expected: PASS.
 - Regenerate: `docs/architecture/invariants.md` via `go run ./cmd/inv-render`
 - Test: `test/meta/invariant_registry_test.go` (drift + binding gates)
 
-- [ ] **Step 1: Add four entries** to `invariants.yaml` (scope `PLUGIN`, `origin_spec` = this spec). 50/51/52 ship `binding: bound` with `asserted_by` pointing at the tests written above (Task 7 → 50, Tasks 12/13 → 51, Task 11 → 52). 53 binds to the manifest-validation test (Task 2/4).
+> NOTE: INV-PLUGIN-50…53 are **already registered as `binding: pending`** in
+> `invariants.yaml` (added at spec finalization, in the docs PR, because the
+> spec under `docs/superpowers/specs/` references them and the orphan meta-test
+> requires registry presence). This task only **flips them to `bound`** and adds
+> `asserted_by` once the asserting tests exist. The registry entry shape is
+> `scope: INV-PLUGIN` + `origin_spec` + `summary` + `binding` (no `boundary`
+> field — match the existing INV-PLUGIN-49 entry).
+
+- [ ] **Step 1: Flip each entry to `bound`** in `invariants.yaml` and add its `asserted_by`. Map: INV-PLUGIN-50 → `internal/plugin/pluginauthz/capability_test.go` (Task 7); INV-PLUGIN-51 → `internal/plugin/goplugin/host_service_command_test.go` + `internal/plugin/hostfunc/commands_test.go` (Tasks 12/13); INV-PLUGIN-52 → `internal/plugin/hostcap/descriptor_completeness_test.go` (Task 11); INV-PLUGIN-53 → `internal/plugin/manifest_test.go` (Tasks 2/4).
 
 ```yaml
+  # change `binding: pending` -> `binding: bound` and append asserted_by, e.g.:
   - id: INV-PLUGIN-50
-    scope: PLUGIN
-    boundary: PLUGIN
-    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
-    summary: >
-      Plugin consumption of a host capability is authorized by a default-deny ABAC
-      decision keyed on the host-stamped plugin:<name> subject; manifest declaration
-      is necessary but not sufficient.
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
+    summary: "A plugin's consumption of a host capability ... necessary but not sufficient ..."
     binding: bound
     asserted_by:
-      - internal/plugin/pluginauthz/capability_test.go
-  - id: INV-PLUGIN-51
-    scope: PLUGIN
-    boundary: PLUGIN
-    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
-    summary: >
-      Any character subject or dispatch attribute used in a plugin-mediated
-      authorization decision is host-vouched and never derived from plugin/wire data.
-    binding: bound
-    asserted_by:
-      - internal/plugin/goplugin/host_service_command_test.go
-      - internal/plugin/hostfunc/commands_test.go
-  - id: INV-PLUGIN-52
-    scope: PLUGIN
-    boundary: PLUGIN
-    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
-    summary: >
-      Every scope-eligible capability method resolves its scoped resource through a
-      wired extractor; a missing extractor fails closed. No silent fail-open.
-    binding: bound
-    asserted_by:
-      - internal/plugin/hostcap/descriptor_completeness_test.go
-  - id: INV-PLUGIN-53
-    scope: PLUGIN
-    boundary: PLUGIN
-    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
-    summary: >
-      The per-entry least-privilege parameters (access:, scope:) are valid only on a
-      capability requires entry; either on a service entry is a hard manifest error.
-    binding: bound
-    asserted_by:
-      - internal/plugin/manifest_test.go
+      - "internal/plugin/pluginauthz/capability_test.go"
 ```
 
 - [ ] **Step 2: Regenerate + verify**

--- a/docs/superpowers/plans/2026-06-12-plugin-least-privilege-trust.md
+++ b/docs/superpowers/plans/2026-06-12-plugin-least-privilege-trust.md
@@ -1,0 +1,918 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Least-Privilege Enforcement & Plugin-Trust Security Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a plugin's capability grant fine-grained and policy-governed — a default-deny ABAC decision keyed on the host-vouched `plugin:<name>` subject, narrowed by `access:` (operation) and `scope:` (instance), and close the PR #4430 command-registry subject-spoofing finding symmetrically.
+
+**Architecture:** One spine — a host-vouched `DispatchContext` stamped on the delivery `context.Context` — feeds four mechanisms. A host-owned `CapabilityDescriptor` table classifies every host.v1 method (action/resource/operation-class/scopes/extractor). One `hostcap` `grpc.UnaryServerInterceptor`, installed on both runtimes' host.v1 servers, runs static checks (declaration + `access:` class) then a per-call `pluginauthz` capability-access `Evaluate` (operator policy + `scope:` condition). The command-registry RPCs and their Lua twins switch from wire `character_id` to `DispatchContext.Subject`.
+
+**Tech Stack:** Go, gRPC (interceptors + bufconn), gopher-lua, the existing `pluginauthz` ABAC core, the foundation resolver/`CapabilityVocabulary`, `invariants.yaml` + `cmd/inv-render`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md`
+
+**Conventions every task follows:**
+
+- Tests before implementation (TDD). Run `task test -- ./internal/plugin/...` (or the named package) per change; `task test:int` after any `plugin.yaml`/`requires` fixture change.
+- Errors via `oops` with a `Code(...)`; logs via `*Context` slog variants / `errutil.LogErrorContext`.
+- Never bare `grep`; use `rg` / probe. Line-scoped `//nolint` only.
+- Commit after each green task with a conventional-commit message ending in the `Co-Authored-By` byline.
+- VCS is jj-colocated; commit per `references/vcs-preamble.md` (`jj commit -m "..."`).
+
+---
+
+## File structure
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `internal/plugin/dependency_type.go` | Add `Access` field to `Dependency` + `dependencyYAML` | 1 |
+| `internal/plugin/manifest.go` | Validate `access:`/`scope:` capability-only (INV-PLUGIN-53); `RequiredCapabilities` already present | 2 |
+| `schemas/plugin.schema.json` | Regenerated artifact (drift-gated) | 1 |
+| `internal/plugin/hostcap/descriptor.go` | **New** — `CapabilityDescriptor` table (host-owned, per-method) | 3, 4 |
+| `internal/plugin/pluginauthz/dispatch.go` | **New** — `DispatchContext` + `WithDispatch`/`DispatchForHost` | 5 |
+| `internal/plugin/goplugin/host.go`, `internal/plugin/lua/host.go` | Stamp `DispatchContext` on the host-level delivery ctx (where the actor is on ctx) | 6 |
+| `internal/plugin/pluginauthz/capability.go` | **New** — `EvaluateCapabilityAccess` sibling path (no OwnedTypes gate) | 7 |
+| `internal/plugin/hostcap/interceptor.go` | **New** — the one capability interceptor (declaration + `access:` + policy + `scope:`) | 8, 9, 10 |
+| `internal/plugin/goplugin/host_service.go`, `internal/plugin/lua/bufconn_endpoint.go` | Install the interceptor on both runtimes' host.v1 servers (the two `grpc.NewServer` + `hostcap.RegisterCapabilities` sites) | 9 |
+| `internal/plugin/hostcap/descriptor_completeness_test.go` | **New** — scope-extractor completeness meta-test (INV-PLUGIN-52) | 11 |
+| `internal/plugin/hostcap/servers.go` | `ListCommands`/`GetCommandHelp` use `DispatchContext.Subject` | 12 |
+| `internal/plugin/hostfunc/commands.go` | Lua `list_commands`/`get_command_help` use `DispatchContext.Subject` | 13 |
+| `docs/architecture/invariants.yaml` + `invariants.md` | Register + bind INV-PLUGIN-50…53 | 14 |
+
+---
+
+## Phase 1: Manifest plumbing — `access:` field + capability-only validation
+
+### Task 1: Add the `Access` field to `Dependency`
+
+**Files:**
+
+- Modify: `internal/plugin/dependency_type.go:24-32` (struct) + the `dependencyYAML` mirror in the same file
+- Test: `internal/plugin/dependency_type_test.go`
+
+- [ ] **Step 1: Write the failing test** — round-trips `access:` through YAML.
+
+```go
+func TestDependencyAccessRoundTrips(t *testing.T) {
+	var d Dependency
+	err := yaml.Unmarshal([]byte("capability: kv\naccess: read\n"), &d)
+	require.NoError(t, err)
+	assert.Equal(t, KindCapability, d.Kind)
+	assert.Equal(t, "kv", d.Name)
+	assert.Equal(t, "read", d.Access)
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestDependencyAccessRoundTrips ./internal/plugin/`
+Expected: FAIL — `d.Access undefined`.
+
+- [ ] **Step 3: Add the field** to `Dependency` and its YAML mirror.
+
+```go
+type Dependency struct {
+	Kind     DependencyKind
+	Name     string
+	Version  string // semver constraint; services only
+	Optional bool
+	// Scope and Access carry least-privilege parameters; semantics are sub-spec 4
+	// (this work). Valid only on capability entries (INV-PLUGIN-53).
+	Scope  string
+	Access string // "" | "read" | "write"
+}
+```
+
+Add `Access string \`yaml:"access,omitempty"\`` to the `dependencyYAML` struct and copy it in the `UnmarshalYAML` mapping alongside `Scope`.
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `task test -- -run TestDependencyAccessRoundTrips ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate the JSON schema + commit**
+
+Run: `go generate ./internal/plugin/...` then `task lint` (drift gate). Confirm `schemas/plugin.schema.json` updated.
+Commit: `feat(plugin): add access field to manifest Dependency (holomush-eykuh.3)`.
+
+### Task 2: Validate `access:`/`scope:` are capability-only and well-formed (INV-PLUGIN-53)
+
+**Files:**
+
+- Modify: `internal/plugin/manifest.go` — extend `Validate()` (line 419) with a per-`Requires`-entry check
+- Test: `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write the failing tests** — service entry with `scope:`/`access:` errors; bad `access:` enum errors; capability entry with `access: read` validates.
+
+```go
+func TestManifestRejectsLeastPrivilegeParamsOnServiceEntry(t *testing.T) {
+	for _, tc := range []struct{ name, yamlFrag, code string }{
+		{"scope on service", "requires:\n  - service: holomush.scene.v1.SceneService\n    scope: own-location\n", "LEAST_PRIVILEGE_PARAM_ON_SERVICE"},
+		{"access on service", "requires:\n  - service: holomush.scene.v1.SceneService\n    access: read\n", "LEAST_PRIVILEGE_PARAM_ON_SERVICE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := validBaseManifest(t, tc.yamlFrag) // helper: name/version/type + frag
+			errutil.AssertErrorCode(t, m.Validate(), tc.code)
+		})
+	}
+}
+
+func TestManifestRejectsUnknownAccessValue(t *testing.T) {
+	m := validBaseManifest(t, "requires:\n  - capability: kv\n    access: delete\n")
+	errutil.AssertErrorCode(t, m.Validate(), "INVALID_ACCESS_VALUE")
+}
+
+func TestManifestAcceptsAccessReadOnCapability(t *testing.T) {
+	m := validBaseManifest(t, "requires:\n  - capability: kv\n    access: read\n")
+	require.NoError(t, m.Validate())
+}
+```
+
+- [ ] **Step 2: Run them, verify they fail**
+
+Run: `task test -- -run 'TestManifestRejectsLeastPrivilege|TestManifestRejectsUnknownAccess|TestManifestAcceptsAccessRead' ./internal/plugin/`
+Expected: FAIL — no such validation yet.
+
+- [ ] **Step 3: Add validation** inside `Validate()`, iterating `m.Requires`.
+
+```go
+var validAccess = map[string]bool{"": true, "read": true, "write": true}
+
+for _, d := range m.Requires {
+	if d.Kind == KindService && (d.Scope != "" || d.Access != "") {
+		return oops.Code("LEAST_PRIVILEGE_PARAM_ON_SERVICE").
+			With("plugin", m.Name).With("service", d.Name).
+			Errorf("access:/scope: are valid only on capability entries (INV-PLUGIN-53)")
+	}
+	if !validAccess[d.Access] {
+		return oops.Code("INVALID_ACCESS_VALUE").
+			With("plugin", m.Name).With("access", d.Access).
+			Errorf("access must be one of: read, write")
+	}
+}
+```
+
+(`scope:` token-vs-vocabulary validation is Task 4, once the descriptor exists.)
+
+- [ ] **Step 4: Run them, verify they pass**
+
+Run: `task test -- -run 'TestManifestRejectsLeastPrivilege|TestManifestRejectsUnknownAccess|TestManifestAcceptsAccessRead' ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): validate access/scope capability-only (INV-PLUGIN-53, holomush-eykuh.3)`.
+
+---
+
+## Phase 2: The `CapabilityDescriptor` table
+
+### Task 3: Define the descriptor types + the table for read-only capabilities
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/descriptor.go`
+- Test: `internal/plugin/hostcap/descriptor_test.go`
+
+- [ ] **Step 1: Write the failing test** — the table classifies a known method.
+
+```go
+func TestDescriptorClassifiesEvalMethods(t *testing.T) {
+	d, ok := Descriptors["eval"]
+	require.True(t, ok, "eval capability has a descriptor")
+	m, ok := d.Methods["Evaluate"]
+	require.True(t, ok)
+	assert.Equal(t, ClassRead, m.Class)
+	assert.Empty(t, m.Scopes, "eval is not scope-eligible")
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestDescriptorClassifiesEvalMethods ./internal/plugin/hostcap/`
+Expected: FAIL — `Descriptors undefined`.
+
+- [ ] **Step 3: Define the types + the read-only slice of the table.**
+
+```go
+// OperationClass is the read/write class of a host.v1 method (M2).
+type OperationClass int
+
+const (
+	ClassRead OperationClass = iota
+	ClassWrite
+)
+
+// ScopedResourceFn extracts the ABAC resource id a request touches, for the
+// scope condition (M3). Returns "" when no resource is in play.
+type ScopedResourceFn func(req any) (resourceID string, ok bool)
+
+// MethodDescriptor is the host-owned per-method classification.
+type MethodDescriptor struct {
+	Action   string           // ABAC action, e.g. "write"
+	Resource string           // ABAC resource type, e.g. "location"
+	Class    OperationClass   // read | write (M2)
+	Scopes   []string         // supported scope tokens (M3); empty => not scope-eligible
+	Extract  ScopedResourceFn // required iff len(Scopes) > 0 (M3, INV-PLUGIN-52)
+}
+
+// CapabilityDescriptor is the host-owned table for one capability token.
+type CapabilityDescriptor struct {
+	Token   string
+	Methods map[string]MethodDescriptor
+}
+
+// Descriptors is the single host-owned source for M1/M2/M3 per-method metadata,
+// keyed by capability token. It is the per-method companion to the sub-spec-2
+// token->service registry.
+var Descriptors = map[string]CapabilityDescriptor{
+	"eval": {Token: "eval", Methods: map[string]MethodDescriptor{
+		"Evaluate": {Action: "evaluate", Resource: "policy", Class: ClassRead},
+	}},
+	"settings": {Token: "settings", Methods: map[string]MethodDescriptor{
+		"GetSetting": {Action: "read", Resource: "setting", Class: ClassRead},
+		"SetSetting": {Action: "write", Resource: "setting", Class: ClassWrite},
+	}},
+	"kv": {Token: "kv", Methods: map[string]MethodDescriptor{
+		"KVGet":    {Action: "read", Resource: "kv", Class: ClassRead},
+		"KVSet":    {Action: "write", Resource: "kv", Class: ClassWrite},
+		"KVDelete": {Action: "write", Resource: "kv", Class: ClassWrite},
+	}},
+	"command-registry": {Token: "command-registry", Methods: map[string]MethodDescriptor{
+		"ListCommands":   {Action: "list", Resource: "command", Class: ClassRead},
+		"GetCommandHelp": {Action: "read", Resource: "command", Class: ClassRead},
+	}},
+}
+```
+
+> The `Action`/`Resource` values must match the ABAC vocabulary the host
+> capabilities already use; confirm against `internal/access` action/resource
+> constants and the existing `host.Evaluate` usage before finalizing each row.
+> Add the remaining capability rows (focus, emit, audit, stream-history,
+> stream-subscription, session, property, world, log) in Task 4 alongside the
+> scope-eligible entries.
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `task test -- -run TestDescriptorClassifiesEvalMethods ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): host-owned CapabilityDescriptor table (holomush-eykuh.3)`.
+
+### Task 4: Add scope-eligible rows + per-capability scope vocabulary; wire `scope:` manifest validation
+
+**Files:**
+
+- Modify: `internal/plugin/hostcap/descriptor.go` (add world/session/property rows with `Scopes`+`Extract`)
+- Modify: `internal/plugin/manifest.go` (`Validate()` — `scope:` token must be in the capability's descriptor)
+- Modify: `internal/plugin/hostcap/descriptor_test.go`, `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write the failing tests** — a scope-eligible method has an extractor; an unknown scope token on a capability is a manifest error.
+
+```go
+func TestWorldMutationIsScopeEligibleWithExtractor(t *testing.T) {
+	m := Descriptors["world.mutation"].Methods["CreateLocation"] // adjust to a real mutation method
+	assert.Equal(t, ClassWrite, m.Class)
+	assert.Contains(t, m.Scopes, "own-location")
+	require.NotNil(t, m.Extract, "scope-eligible method must carry an extractor")
+}
+
+func TestManifestRejectsUnknownScopeToken(t *testing.T) {
+	m := validBaseManifest(t, "requires:\n  - capability: world.mutation\n    scope: own-galaxy\n")
+	errutil.AssertErrorCode(t, m.Validate(), "UNKNOWN_SCOPE_TOKEN")
+}
+```
+
+- [ ] **Step 2: Run them, verify they fail**
+
+Run: `task test -- -run 'TestWorldMutationIsScopeEligible|TestManifestRejectsUnknownScopeToken' ./internal/plugin/...`
+Expected: FAIL.
+
+- [ ] **Step 3a: Add the scope-eligible descriptor rows** (real method/field names from `api/proto/holomush/plugin/host/v1/*.proto` — confirm via probe).
+
+```go
+"world.mutation": {Token: "world.mutation", Methods: map[string]MethodDescriptor{
+	"CreateLocation": {
+		Action: "write", Resource: "location", Class: ClassWrite,
+		Scopes:  []string{"own-location"},
+		Extract: func(req any) (string, bool) {
+			r, ok := req.(*hostv1.CreateLocationRequest)
+			if !ok { return "", false }
+			return r.GetLocationId(), r.GetLocationId() != ""
+		},
+	},
+	// ... other world.mutation methods, each with its typed Extract
+}},
+```
+
+- [ ] **Step 3b: Add a descriptor lookup helper** for manifest validation (the manifest package must not import `hostcap` if that creates a cycle — expose the scope vocabulary as a small map the manifest validator can consult, e.g. a `ScopeTokens(token string) map[string]bool` function in a leaf package, or pass the vocabulary into `Validate`). Confirm import direction first via `go list -deps`; if `hostcap`→`plugin` would cycle, site the scope-token map in the existing `capability_vocab.go` and have `hostcap` register into it at init.
+
+- [ ] **Step 3c: Add `scope:` token validation** in `Validate()`:
+
+```go
+if d.Kind == KindCapability && d.Scope != "" {
+	if !capabilityScopeTokens(d.Name)[d.Scope] {
+		return oops.Code("UNKNOWN_SCOPE_TOKEN").
+			With("plugin", m.Name).With("capability", d.Name).With("scope", d.Scope).
+			Errorf("capability %q does not support scope %q", d.Name, d.Scope)
+	}
+}
+```
+
+- [ ] **Step 4: Run them, verify they pass**
+
+Run: `task test -- -run 'TestWorldMutationIsScopeEligible|TestManifestRejectsUnknownScopeToken' ./internal/plugin/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): scope-eligible descriptor rows + scope-token validation (holomush-eykuh.3)`.
+
+---
+
+## Phase 3: P0 — the dispatch-context primitive
+
+### Task 5: `DispatchContext` type + context-key accessors
+
+**Files:**
+
+- Create: `internal/plugin/pluginauthz/dispatch.go`
+- Test: `internal/plugin/pluginauthz/dispatch_test.go`
+
+- [ ] **Step 1: Write the failing test** — round-trip + absence is fail-closed (no value).
+
+```go
+func TestDispatchContextRoundTrips(t *testing.T) {
+	dc := DispatchContext{Subject: "character:01ABC", Attributes: map[string]string{"location": "01LOC"}}
+	ctx := WithDispatch(context.Background(), dc)
+	got, ok := DispatchForHost(ctx)
+	require.True(t, ok)
+	assert.Equal(t, dc.Subject, got.Subject)
+	assert.Equal(t, "01LOC", got.Attributes["location"])
+}
+
+func TestDispatchAbsentByDefault(t *testing.T) {
+	_, ok := DispatchForHost(context.Background())
+	assert.False(t, ok, "absent dispatch context must be detectable for fail-closed")
+}
+```
+
+- [ ] **Step 2: Run them, verify they fail**
+
+Run: `task test -- -run 'TestDispatchContext|TestDispatchAbsent' ./internal/plugin/pluginauthz/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement.** (the key is unexported; `WithDispatch` is host-only and `DispatchForHost` is the host-side reader, so a plugin can neither set nor observe it.)
+
+```go
+type DispatchContext struct {
+	Subject    string            // host-vouched ABAC subject (access.CharacterSubject)
+	Attributes map[string]string // host-resolved acting-character attributes (location, ...)
+}
+
+type dispatchKey struct{}
+
+// WithDispatch stamps the host-vouched dispatch context. Host-only; called from
+// DeliverCommand/DeliverEvent before any plugin code runs (INV-PLUGIN-51).
+func WithDispatch(ctx context.Context, dc DispatchContext) context.Context {
+	return context.WithValue(ctx, dispatchKey{}, dc)
+}
+
+// DispatchForHost reads the dispatch context. Exported for the host-side
+// readers in other packages (hostcap interceptor, command-registry servers,
+// Lua hostfuncs). Plugins are not Go callers of this package and cannot set
+// the key (only WithDispatch does), so exporting the reader is safe.
+func DispatchForHost(ctx context.Context) (DispatchContext, bool) {
+	dc, ok := ctx.Value(dispatchKey{}).(DispatchContext)
+	return dc, ok
+}
+```
+
+`DispatchForHost` is the single exported host-side reader; all later tasks (interceptor, command-registry servers, Lua hostfuncs) call it.
+
+- [ ] **Step 4: Run them, verify they pass**
+
+Run: `task test -- -run 'TestDispatchContext|TestDispatchAbsent' ./internal/plugin/pluginauthz/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): DispatchContext primitive in pluginauthz (P0, holomush-eykuh.3)`.
+
+### Task 6: Stamp `DispatchContext` on the delivery context
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host.go` — in `DeliverEvent` (941) and `DeliverCommand` (1020), at the point each already calls `core.ActorFromContext(ctx)` (976 / 1047), stamp the dispatch context onto `ctx` before plugin code runs
+- Modify: `internal/plugin/lua/host.go` — `DeliverEvent` (390) / `DeliverCommand` (484): same stamp at the Lua host's actor-read point, so the in-VM hostfuncs inherit it on `ls.Context()`
+- Test: `internal/plugin/goplugin/host_test.go`, `internal/plugin/lua/host_test.go`
+
+> NOTE: `manager.go`'s `DeliverCommand`/`DeliverEvent` (313/458) are thin
+> delegation wrappers that do **not** read the actor; the stamp belongs at the
+> two host-level delivery points above, where `core.ActorFromContext` is already
+> consulted. A shared helper `pluginauthz.WithDispatch` keeps both identical.
+
+- [ ] **Step 1: Write the failing test** — delivering with an acting character makes the dispatch subject visible to a capability call.
+
+```go
+func TestDeliverStampsDispatchSubjectFromActor(t *testing.T) {
+	charID := ulid.Make()
+	ctx := core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: charID.String()})
+	// Drive a delivery that reaches a capability and capture the ctx seen there;
+	// assert pluginauthz.DispatchForHost(ctx).Subject == access.CharacterSubject(charID.String()).
+	// DispatchForHost is the exported host-side reader from Task 5.
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestDeliverStampsDispatchSubject ./internal/plugin/`
+Expected: FAIL — dispatch not stamped.
+
+- [ ] **Step 3: Stamp in the manager.** Build the `DispatchContext` from the acting actor (subject eager; attributes resolved via the character provider) and thread it.
+
+```go
+// inside DeliverCommand / DeliverEvent, once the acting core.Actor is known:
+if actor, ok := core.ActorFromContext(ctx); ok && actor.Kind == core.ActorCharacter && actor.ID != "" {
+	subject := access.CharacterSubject(actor.ID)
+	attrs, err := m.dispatchAttrs(ctx, subject) // resolves via CharacterProvider.ResolveSubject; "location" etc.
+	if err != nil {
+		errutil.LogErrorContext(ctx, "resolve dispatch attributes failed", err, "subject", subject)
+		attrs = nil // fail-closed at scope time, not here
+	}
+	ctx = pluginauthz.WithDispatch(ctx, pluginauthz.DispatchContext{Subject: subject, Attributes: attrs})
+}
+```
+
+Add `dispatchAttrs` as a thin adapter over the character attribute provider already wired into the manager (string-map projection of `ResolveSubject`’s `map[string]any`, keeping only string-valued keys like `location`).
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `task test -- -run TestDeliverStampsDispatchSubject ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): stamp DispatchContext on delivery ctx (P0, holomush-eykuh.3)`.
+
+---
+
+## Phase 4: M1 — the capability-access entitlement
+
+### Task 7: `EvaluateCapabilityAccess` sibling path (no OwnedTypes gate)
+
+**Files:**
+
+- Create: `internal/plugin/pluginauthz/capability.go`
+- Test: `internal/plugin/pluginauthz/capability_test.go`
+
+- [ ] **Step 1: Write the failing tests** — declared+permitted allows; declared+policy-deny denies; the OwnedTypes gate is NOT applied (a host resource type the plugin does not own still evaluates).
+
+```go
+func TestEvaluateCapabilityAccessAllowsDeclaredPermitted(t *testing.T) {
+	dec, err := EvaluateCapabilityAccess(context.Background(), CapabilityInput{
+		Engine: policytest.AllowAllEngine(), PluginName: "core-objects",
+		Subject: access.PluginSubject("core-objects"),
+		Action:  "read", Resource: "kv:foo", Declared: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, dec.Allowed)
+}
+
+func TestEvaluateCapabilityAccessDeniedByPolicyDespiteDeclaration(t *testing.T) {
+	dec, _ := EvaluateCapabilityAccess(context.Background(), CapabilityInput{
+		Engine: policytest.DenyAllEngine(), PluginName: "core-objects",
+		Subject: access.PluginSubject("core-objects"),
+		Action:  "read", Resource: "kv:foo", Declared: true,
+	})
+	assert.False(t, dec.Allowed) // INV-PLUGIN-50: declaration necessary, not sufficient
+}
+
+func TestEvaluateCapabilityAccessUndeclaredFailsClosed(t *testing.T) {
+	_, err := EvaluateCapabilityAccess(context.Background(), CapabilityInput{
+		Engine: policytest.AllowAllEngine(), PluginName: "core-objects",
+		Subject: access.PluginSubject("core-objects"),
+		Action:  "read", Resource: "kv:foo", Declared: false,
+	})
+	errutil.AssertErrorCode(t, err, "CAPABILITY_NOT_DECLARED")
+}
+```
+
+- [ ] **Step 2: Run them, verify they fail**
+
+Run: `task test -- -run TestEvaluateCapabilityAccess ./internal/plugin/pluginauthz/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** the sibling path — shares subject/engine/audit with `Evaluate`, substitutes the declaration entitlement for the OwnedTypes gate.
+
+```go
+// CapabilityInput is the capability-access decision input. Subject is
+// host-derived (plugin:<name>); Declared is the resolver-proven reach.
+type CapabilityInput struct {
+	Engine     types.AccessPolicyEngine
+	Auditor    Auditor
+	PluginName string
+	Subject    string
+	Action     string
+	Resource   string
+	Declared   bool
+	Context    map[string]any // dispatch attributes for scope conditions (M3)
+}
+
+// EvaluateCapabilityAccess authorizes a plugin's consumption of a host
+// capability. Entitlement is manifest-declaration (Declared), NOT OwnedTypes —
+// host-capability resources are not plugin-owned (INV-PLUGIN-50). Shares the
+// engine call + single audit event with Evaluate (INV-PLUGIN-26).
+func EvaluateCapabilityAccess(ctx context.Context, in CapabilityInput) (Decision, error) {
+	if in.Engine == nil {
+		return Decision{}, oops.Code("EVALUATE_NO_ENGINE").With("plugin", in.PluginName).Errorf("nil engine")
+	}
+	if in.Subject == "" {
+		return Decision{}, oops.Code("EVALUATE_NO_SUBJECT").With("plugin", in.PluginName).Errorf("no subject")
+	}
+	if !in.Declared {
+		return Decision{}, oops.Code("CAPABILITY_NOT_DECLARED").
+			With("plugin", in.PluginName).With("resource", in.Resource).
+			Errorf("capability not declared by plugin")
+	}
+	req, err := types.NewAccessRequest(in.Subject, in.Action, in.Resource, in.Context)
+	if err != nil {
+		return Decision{}, oops.With("plugin", in.PluginName).Wrap(err)
+	}
+	dec, err := in.Engine.Evaluate(ctx, req)
+	if err != nil {
+		errutil.LogErrorContext(ctx, "capability-access engine error", err, "plugin", in.PluginName)
+		return Decision{}, oops.With("plugin", in.PluginName).Wrap(err)
+	}
+	// ... map dec -> Decision{Allowed, MatchedPolicy}; emit one audit event via
+	// in.Auditor (mirror Evaluate's audit block, Name "plugin.capability_access").
+	return toDecision(dec), nil
+}
+```
+
+- [ ] **Step 4: Run them, verify they pass**
+
+Run: `task test -- -run TestEvaluateCapabilityAccess ./internal/plugin/pluginauthz/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): capability-access entitlement path (M1, INV-PLUGIN-50, holomush-eykuh.3)`.
+
+---
+
+## Phase 5–6: M2/M3 — the one capability interceptor
+
+### Task 8: The interceptor — declaration + `access:` static checks
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/interceptor.go`
+- Test: `internal/plugin/hostcap/interceptor_test.go`
+
+- [ ] **Step 1: Write the failing tests** — `access: read` denies a write method; absent declared `access:` permits both classes; an undeclared capability is denied.
+
+```go
+func TestInterceptorAccessReadDeniesWriteMethod(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine: policytest.AllowAllEngine(),
+		DeclaredAccess: func(plugin, capToken string) (string, bool) { return "read", true },
+	})
+	_, err := ic(ctxWithDispatch(t), &hostv1.KVSetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/KVSet",
+	}, okHandler)
+	errutil.AssertErrorCode(t, err, "ACCESS_CLASS_DENIED")
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestInterceptorAccessReadDeniesWriteMethod ./internal/plugin/hostcap/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the static half** — parse `FullMethod` → capability token + method, look up the descriptor, deny if declared `access:` does not cover the method `Class`. (Map the gRPC service name → capability token via the sub-spec-2 token↔service registry.)
+
+```go
+func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, h grpc.UnaryHandler) (any, error) {
+		capToken, method, ok := d.classify(info.FullMethod) // service->token + method name
+		if !ok { return h(ctx, req) }                       // not a gated host.v1 method
+		md, ok := Descriptors[capToken].Methods[method]
+		if !ok {
+			return nil, oops.Code("UNCLASSIFIED_CAPABILITY_METHOD").With("method", info.FullMethod).
+				Errorf("no descriptor entry") // fail-closed
+		}
+		declAccess, declared := d.DeclaredAccess(d.pluginName, capToken)
+		if !declared {
+			return nil, oops.Code("CAPABILITY_NOT_DECLARED").With("capability", capToken).Errorf("undeclared")
+		}
+		if declAccess == "read" && md.Class == ClassWrite {
+			return nil, oops.Code("ACCESS_CLASS_DENIED").With("capability", capToken).With("method", method).
+				Errorf("declared access: read does not cover write method")
+		}
+		// policy + scope half added in Task 10:
+		return h(ctx, req)
+	}
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `task test -- -run TestInterceptorAccessReadDeniesWriteMethod ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): capability interceptor static checks (M2, holomush-eykuh.3)`.
+
+### Task 9: Install the interceptor on both runtimes' servers
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host_service.go:28-31` — `newPluginHostServiceServer` already calls `grpc.NewServer(opts...)` then `hostcap.RegisterCapabilities`; thread the interceptor into `opts` (this is the binary host.v1 server, **not** `broker_proxy.go`, which is the separate plugin→plugin proxy)
+- Modify: `internal/plugin/lua/bufconn_endpoint.go` — the Lua per-plugin `grpc.NewServer` (`newPluginEndpoint`); thread the interceptor as a `ServerOption`
+- Test: `internal/plugin/hostcap/interceptor_test.go` + a cross-runtime parity test
+
+- [ ] **Step 1: Write the failing test** — both servers reject an undeclared capability identically (parity).
+
+```go
+func TestInterceptorInstalledOnBothRuntimes(t *testing.T) {
+	// Stand up the binary broker server and the Lua bufconn server, each with a
+	// plugin declaring NO capabilities; assert a KVGet call is denied
+	// CAPABILITY_NOT_DECLARED on BOTH. (INV-PLUGIN-45/49 parity.)
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test:int -- -run TestInterceptorInstalledOnBothRuntimes ./internal/plugin/...`
+Expected: FAIL — interceptor not installed.
+
+- [ ] **Step 3: Thread the interceptor** as a `grpc.ChainUnaryInterceptor(ic)` `ServerOption` at both `grpc.NewServer` sites. Construct one `ic` per plugin (closes over `pluginName` + the plugin's resolved declared-capability/access set from the foundation resolver).
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `task test:int -- -run TestInterceptorInstalledOnBothRuntimes ./internal/plugin/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): install capability interceptor on both runtimes (INV-PLUGIN-45/49, holomush-eykuh.3)`.
+
+### Task 10: The interceptor — policy + `scope:` (M1 policy + M3)
+
+**Files:**
+
+- Modify: `internal/plugin/hostcap/interceptor.go`
+- Test: `internal/plugin/hostcap/interceptor_test.go`
+
+- [ ] **Step 1: Write the failing tests** — operator deny blocks a declared cap; `scope: own-location` permits matching location, denies mismatch; absent dispatch fails a scoped call closed.
+
+```go
+func TestInterceptorScopeOwnLocationPermitsMatch(t *testing.T) { /* dispatch.location == resource location => allow */ }
+func TestInterceptorScopeOwnLocationDeniesMismatch(t *testing.T) { /* differ => SCOPE_DENIED */ }
+func TestInterceptorScopedCallFailsClosedWithoutDispatch(t *testing.T) { /* no DispatchContext => deny */ }
+```
+
+- [ ] **Step 2: Run them, verify they fail**
+
+Run: `task test -- -run 'TestInterceptorScope' ./internal/plugin/hostcap/`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the policy+scope half** after the static checks in the interceptor.
+
+```go
+dc, haveDispatch := pluginauthz.DispatchForHost(ctx) // host-side accessor
+var scopeAttrs map[string]any
+if len(md.Scopes) > 0 {
+	if !haveDispatch {
+		return nil, oops.Code("SCOPE_NO_DISPATCH").With("method", method).Errorf("scoped call without dispatch context")
+	}
+	if md.Extract == nil {
+		return nil, oops.Code("SCOPE_NO_EXTRACTOR").With("method", method).Errorf("scope-eligible method missing extractor") // fail-closed, INV-PLUGIN-52
+	}
+	scopeAttrs = map[string]any{"dispatch.location": dc.Attributes["location"]}
+}
+resourceID := capToken
+if md.Extract != nil {
+	if id, ok := md.Extract(req); ok { resourceID = md.Resource + ":" + id }
+}
+dec, err := pluginauthz.EvaluateCapabilityAccess(ctx, pluginauthz.CapabilityInput{
+	Engine: d.Engine, Auditor: d.Auditor, PluginName: d.pluginName,
+	Subject: access.PluginSubject(d.pluginName), Action: md.Action, Resource: resourceID,
+	Declared: true, Context: scopeAttrs,
+})
+if err != nil { return nil, err }
+if !dec.Allowed {
+	return nil, oops.Code("SCOPE_DENIED").With("capability", capToken).With("method", method).Errorf("denied by policy/scope")
+}
+return h(ctx, req)
+```
+
+The scope condition (`resource.location == dispatch.location`) is expressed as the operator/host policy for the capability's resource type, consuming the `dispatch.location` context attribute. Ship the default host policy that enforces `own-location` for `world.mutation` as part of this task (under the host's policy seeds), so the compiled condition exists without operator authoring.
+
+- [ ] **Step 4: Run them, verify they pass**
+
+Run: `task test -- -run 'TestInterceptorScope' ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `feat(plugin): interceptor policy + scope enforcement (M1/M3, INV-PLUGIN-50, holomush-eykuh.3)`.
+
+### Task 11: Scope-extractor completeness meta-test (INV-PLUGIN-52)
+
+**Files:**
+
+- Create: `internal/plugin/hostcap/descriptor_completeness_test.go`
+
+- [ ] **Step 1: Write the test** — every scope-eligible method carries an extractor; build fails otherwise.
+
+```go
+// Verifies: INV-PLUGIN-52
+func TestEveryScopeEligibleMethodHasExtractor(t *testing.T) {
+	for token, d := range Descriptors {
+		for name, m := range d.Methods {
+			if len(m.Scopes) > 0 {
+				require.NotNilf(t, m.Extract, "capability %q method %q is scope-eligible but has no extractor (fail-open hazard)", token, name)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run it, verify it passes** (the table is already correct).
+
+Run: `task test -- -run TestEveryScopeEligibleMethodHasExtractor ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 3: Add a runtime fail-closed test** — an interceptor with a deliberately extractor-less scoped descriptor denies (asserts the runtime guard, not just the meta-test).
+
+- [ ] **Step 4: Run it, verify it passes**
+
+- [ ] **Step 5: Commit** — `test(plugin): scope-extractor completeness + runtime fail-closed (INV-PLUGIN-52, holomush-eykuh.3)`.
+
+---
+
+## Phase 7: M4 — the command-registry trust fix
+
+### Task 12: Binary `ListCommands`/`GetCommandHelp` use `DispatchContext.Subject`
+
+**Files:**
+
+- Modify: `internal/plugin/hostcap/servers.go:959-1013`
+- Test: `internal/plugin/goplugin/host_service_command_test.go` (+ a spoof test)
+
+- [ ] **Step 1: Write the failing tests** — a spoofed `character_id` is ignored; the host-vouched dispatch subject is used; absent dispatch fails closed.
+
+```go
+// Verifies: INV-PLUGIN-51
+func TestListCommandsIgnoresWireCharacterIDUsesDispatch(t *testing.T) {
+	dispatchChar := ulid.Make()
+	ctx := pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{
+		Subject: access.CharacterSubject(dispatchChar.String()),
+	})
+	srv := &commandRegistryServer{ /* base with querier */ }
+	// Pass a DIFFERENT character_id on the wire; assert the querier was called
+	// with the dispatch subject, NOT the wire id.
+	_, err := srv.ListCommands(ctx, &hostv1.ListCommandsRequest{CharacterId: ulid.Make().String()})
+	require.NoError(t, err)
+	// assert recorded subject == access.CharacterSubject(dispatchChar.String())
+}
+
+func TestListCommandsFailsClosedWithoutDispatch(t *testing.T) {
+	srv := &commandRegistryServer{ /* ... */ }
+	_, err := srv.ListCommands(context.Background(), &hostv1.ListCommandsRequest{CharacterId: ulid.Make().String()})
+	errutil.AssertErrorCode(t, err, "NO_DISPATCH_SUBJECT")
+}
+```
+
+- [ ] **Step 2: Run them, verify they fail**
+
+Run: `task test -- -run 'TestListCommandsIgnoresWire|TestListCommandsFailsClosed' ./internal/plugin/goplugin/`
+Expected: FAIL — still reads wire id.
+
+- [ ] **Step 3: Switch the subject source** in both methods.
+
+```go
+dc, ok := pluginauthz.DispatchForHost(ctx)
+if !ok || dc.Subject == "" {
+	return nil, oops.Code("NO_DISPATCH_SUBJECT").With("plugin", s.pluginName).
+		Errorf("command-registry call without a host-vouched dispatch subject")
+}
+res, err := q.Available(ctx, dc.Subject) // was access.CharacterSubject(req.GetCharacterId())
+```
+
+Apply the same to `GetCommandHelp` (`q.Help(ctx, dc.Subject, req.GetName())`). Leave the proto field present but no longer read for authorization (final remove-vs-keep is a follow-up proto-compat bead).
+
+- [ ] **Step 4: Run them, verify they pass**
+
+Run: `task test -- -run 'TestListCommandsIgnoresWire|TestListCommandsFailsClosed' ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `fix(plugin): command-registry uses host-vouched dispatch subject (M4, INV-PLUGIN-51, holomush-eykuh.3)`.
+
+### Task 13: Lua `list_commands`/`get_command_help` use `DispatchContext.Subject` (symmetry)
+
+**Files:**
+
+- Modify: `internal/plugin/hostfunc/commands.go`
+- Test: `internal/plugin/hostfunc/commands_test.go` + `internal/plugin/lua/command_parity_test.go`
+
+- [ ] **Step 1: Write the failing tests** — the Lua hostfuncs ignore the supplied character arg and use the dispatch subject; parity test asserts binary + Lua resolve the identical subject.
+
+```go
+// Verifies: INV-PLUGIN-51
+func TestLuaListCommandsIgnoresArgUsesDispatch(t *testing.T) {
+	// hostfunc bound on a ctx carrying DispatchContext.Subject = character X;
+	// Lua calls holomush.list_commands("<character Y>"); assert querier saw X.
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestLuaListCommandsIgnoresArg ./internal/plugin/hostfunc/`
+Expected: FAIL.
+
+- [ ] **Step 3: Switch the Lua shims** to read `pluginauthz.DispatchForHost(ls.Context())` for the subject instead of the Lua-supplied `character_id`; fail closed when absent. Keep the Lua signature (drop the arg from the authz path; argument becomes ignored or removed per the same proto-compat follow-up).
+
+- [ ] **Step 4: Run it + the parity test, verify they pass**
+
+Run: `task test -- -run 'TestLuaListCommandsIgnoresArg|TestCommandRegistryParity' ./internal/plugin/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `fix(plugin): Lua command-registry symmetry with dispatch subject (M4, holomush-eykuh.3)`.
+
+---
+
+## Phase 8: Invariant registration
+
+### Task 14: Register + bind INV-PLUGIN-50…53
+
+**Files:**
+
+- Modify: `docs/architecture/invariants.yaml`
+- Regenerate: `docs/architecture/invariants.md` via `go run ./cmd/inv-render`
+- Test: `test/meta/invariant_registry_test.go` (drift + binding gates)
+
+- [ ] **Step 1: Add four entries** to `invariants.yaml` (scope `PLUGIN`, `origin_spec` = this spec). 50/51/52 ship `binding: bound` with `asserted_by` pointing at the tests written above (Task 7 → 50, Tasks 12/13 → 51, Task 11 → 52). 53 binds to the manifest-validation test (Task 2/4).
+
+```yaml
+  - id: INV-PLUGIN-50
+    scope: PLUGIN
+    boundary: PLUGIN
+    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
+    summary: >
+      Plugin consumption of a host capability is authorized by a default-deny ABAC
+      decision keyed on the host-stamped plugin:<name> subject; manifest declaration
+      is necessary but not sufficient.
+    binding: bound
+    asserted_by:
+      - internal/plugin/pluginauthz/capability_test.go
+  - id: INV-PLUGIN-51
+    scope: PLUGIN
+    boundary: PLUGIN
+    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
+    summary: >
+      Any character subject or dispatch attribute used in a plugin-mediated
+      authorization decision is host-vouched and never derived from plugin/wire data.
+    binding: bound
+    asserted_by:
+      - internal/plugin/goplugin/host_service_command_test.go
+      - internal/plugin/hostfunc/commands_test.go
+  - id: INV-PLUGIN-52
+    scope: PLUGIN
+    boundary: PLUGIN
+    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
+    summary: >
+      Every scope-eligible capability method resolves its scoped resource through a
+      wired extractor; a missing extractor fails closed. No silent fail-open.
+    binding: bound
+    asserted_by:
+      - internal/plugin/hostcap/descriptor_completeness_test.go
+  - id: INV-PLUGIN-53
+    scope: PLUGIN
+    boundary: PLUGIN
+    origin_spec: docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
+    summary: >
+      The per-entry least-privilege parameters (access:, scope:) are valid only on a
+      capability requires entry; either on a service entry is a hard manifest error.
+    binding: bound
+    asserted_by:
+      - internal/plugin/manifest_test.go
+```
+
+- [ ] **Step 2: Regenerate + verify**
+
+Run: `go run ./cmd/inv-render` then `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestProvenanceGuard|TestBoundInvariantsAreGenuinelyAsserted' ./test/meta/`
+Expected: PASS (no drift; all four bound and genuinely asserted).
+
+- [ ] **Step 3: Add `// Verifies: INV-PLUGIN-5N`** annotations immediately above each asserting test (Task 7/11/12/13/2 tests) if not already added when written.
+
+- [ ] **Step 4: Run the full meta suite**
+
+Run: `task test -- ./test/meta/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit** — `docs(arch): register INV-PLUGIN-50..53 (holomush-eykuh.3)`.
+
+---
+
+## Post-implementation checklist
+
+- [ ] `task pr-prep` green (fast lane), and `task pr-prep:full` since this touches plugin int surface (Ginkgo + bufconn).
+- [ ] `task test:int` green (delivery + both-runtime interceptor parity).
+- [ ] `schemas/plugin.schema.json` regenerated and committed (drift gate).
+- [ ] `docs/architecture/invariants.md` regenerated from yaml (never hand-edited).
+- [ ] `.claude/rules/plugin-manifest.md` updated to document `access:`/`scope:` (capability-only) — small docs edit.
+- [ ] Site `extending/` doc: a short "least-privilege: access/scope" section (`plugin info` shows the declared contract).
+- [ ] Sub-spec 5 (`holomush-eykuh.4`) handoff note: production-manifest migration + Lua-injection gating consume these mechanics; nothing here migrates production plugins.
+- [ ] Follow-up bead: final disposition of the wire `character_id` field on the command-registry RPCs (keep-but-ignore vs remove).

--- a/docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
+++ b/docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
@@ -1,0 +1,472 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Least-Privilege Enforcement & Plugin-Trust Security — Design
+
+**Bead:** `holomush-eykuh.3` (sub-spec 4 of epic `holomush-eykuh`)
+**Theme:** `theme:plugin-capability-architecture` (`docs/roadmap.md`)
+**Status:** draft for design review
+**Date:** 2026-06-12
+**Depends on:** sub-specs 1–3 (`holomush-oeb4d`, `holomush-eykuh.1`, `holomush-eykuh.2`)
+
+## Overview
+
+Sub-specs 1–3 landed the **coarse** least-privilege model: a plugin reaches a
+host capability or another plugin's service only if its manifest declares it,
+both runtimes consume through the one broker/registry common path
+(INV-PLUGIN-44/45), and the ABAC subject is host-stamped `plugin:<name>`
+(anti-forgery, INV-PLUGIN-22/26). What those sub-specs **deferred to this one**
+is everything that makes a grant fine-grained and policy-governed: the per-entry
+`access:` and `scope:` parameters' semantics, an actual ABAC decision on
+capability/service access (not a static declaration-set check), and the
+plugin-trust hardening surfaced by the PR #4430 review.
+
+This sub-spec is organized around **one primitive and four mechanisms**:
+
+- **P0 — the dispatch-context primitive.** A host-vouched acting-character
+  subject + attributes stamped onto every brokered call. Everything else
+  consumes it; it is what makes the four mechanisms one cohesive change rather
+  than four bolt-ons.
+- **M1 — the ABAC access gate** (plugin-as-subject; declaration necessary, not
+  sufficient).
+- **M2 — `access:`** (the operation dimension: read vs write within a
+  capability).
+- **M3 — `scope:`** (the instance dimension: which resource instances, anchored
+  to P0).
+- **M4 — the plugin-trust fix** for `CommandRegistryService.ListCommands` /
+  `GetCommandHelp` and their Lua twins (the PR #4430 subject-spoofing finding).
+
+It deliberately does **not** migrate production manifests onto the new gating or
+gate the legacy unconditional Lua injection — that atomic cutover is sub-spec 5
+(`holomush-eykuh.4`). This sub-spec defines and enforces the mechanics and
+proves them with fixtures; sub-spec 5 rolls the fleet onto them.
+
+## RFC2119 Keywords
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in
+this document are to be interpreted as described in RFC 2119 and RFC 8174 (see
+the root `CLAUDE.md` "RFC2119 Keywords" table).
+
+## Goals
+
+- Define the runtime semantics of the `access:` (operation) and `scope:`
+  (instance) per-entry least-privilege parameters the foundation reserved.
+- Turn capability/service access into a **default-deny ABAC decision** keyed on
+  the host-stamped `plugin:<name>` subject, so a declared capability is
+  necessary but not sufficient — operators can deny or narrow by policy.
+- Establish the **dispatch-context primitive**: a host-vouched acting-character
+  subject + attributes that scoped capabilities authorize against and that the
+  command-registry RPCs key on instead of wire-supplied `character_id`.
+- Close the PR #4430 plugin-trust finding symmetrically across both runtimes.
+- Register the new invariants (`INV-PLUGIN-50`…`53`) and bind the relevant
+  `pending` consumption-path entries.
+
+## Non-Goals (deferred / out of scope)
+
+| Deferred concern | Sub-spec / bead |
+| --- | --- |
+| Migrating production manifests onto the new gating; gating the legacy unconditional Lua injection (`hostfunc/functions.go`) | 5 — `holomush-eykuh.4` |
+| Adding `requires` declarations to plugins that consume host functions without declaring them today (e.g. `core-building`) | 5 — `holomush-eykuh.4` |
+| New capability tokens or service decompositions beyond the 14 already defined | (none — taxonomy is sub-spec 2, frozen) |
+| Reflective/descriptor-driven resource extraction in the broker | **rejected by design** (§M3, Alternatives) |
+
+This sub-spec settles the **enforcement mechanics and the trust fix**. It does
+not reopen the model, the vocabulary, or the transport — those are sub-specs 1–3
+and are frozen.
+
+## Background — current state (grounded)
+
+### The gate is currently a declaration check, not an authorization decision
+
+The foundation's resolver/registry (`ResolveDependencyOrder`,
+`manifest.RequiredCapabilities()` / `RequiredServiceNames()`) decides reach by
+**set membership**: declared ⇒ reachable. The per-call ABAC core
+(`internal/plugin/pluginauthz/evaluate.go`) already exists and is the shared
+binary+Lua decision point (INV-PLUGIN-26): it host-derives the subject
+(`ActorSubject` → `access.PluginSubject` / `access.CharacterSubject`), enforces
+the owned-type entitlement (INV-PLUGIN-24), calls the engine, and emits exactly
+one audit event per decision (INV-PLUGIN-25). But it is invoked today only by
+the explicit `host.Evaluate` surface — **not** by the capability/service
+consumption path. The consumption path has no policy decision at all.
+
+### The per-entry parameters are parsed but inert
+
+`internal/plugin/dependency_type.go` already carries `Dependency.Scope` —
+"the foundation parses and round-trips it but does not interpret it." There is
+no `Access` field yet. The manifest schema is struct-as-source-of-truth
+(`internal/plugin/manifest.go` + `dependency_type.go`, `jsonschema:` tags) with
+a generated `schemas/plugin.schema.json` (drift-gated) and the human-facing
+`.claude/rules/plugin-manifest.md`.
+
+### The PR #4430 plugin-trust finding (CodeRabbit RC_3400778392 / 3400778419)
+
+`commandRegistryServer.ListCommands` and `GetCommandHelp`
+(`internal/plugin/hostcap/servers.go:947-1013`) parse `req.GetCharacterId()`
+(wire-supplied) and use it directly as the ABAC subject via
+`access.CharacterSubject(charID)` → `q.Available` / `q.Help`. A plugin holding
+the `command-registry` capability can therefore enumerate command
+visibility/help for **any** character. This is deliberate parity behavior from
+sub-spec 2 (it matches the Lua `list_commands` hostfunc, `hostfunc/commands.go`,
+which also keys on the request `character_id`). It is the same subject-spoofing
+class that ADR `holomush-qeypl` already eliminated for `host.Evaluate` by
+deriving the subject host-side. The fix MUST be symmetric — fixing only the
+binary side would create a runtime privilege gradient
+(`.claude/rules/plugin-runtime-symmetry.md`).
+
+## Design
+
+### P0 — The dispatch-context primitive (the spine)
+
+The host stamps a **`DispatchContext`** onto the `context.Context` of every
+brokered capability/service call:
+
+```text
+DispatchContext {
+    Subject    string            // host-vouched ABAC subject of the acting character (access.CharacterSubject)
+    Attributes map[string]string // host-resolved acting-character attributes (location, ...) for scope checks
+}
+```
+
+Rules:
+
+- It is sourced **only** from the host's own delivery context — the acting
+  `core.Actor` already threaded through `DeliverCommand` / `DeliverEvent`. It
+  MUST NOT be constructed from any plugin- or wire-supplied field
+  (**INV-PLUGIN-51**).
+- For invocations with **no** acting character (timer/startup emits, host
+  background work), `DispatchContext` is **absent**. Any call that requires a
+  character subject (M4) or a `scope:` check (M3) on an absent dispatch context
+  **fails closed** (deny) — never falls back to a wire value or an unscoped
+  grant.
+- The attribute set is host-resolved via the existing ABAC attribute providers
+  for the character subject — the same providers that resolve `location` etc.
+  for a character today (`internal/access/policy/attribute/`). No plugin input
+  participates.
+- `DispatchContext` is carried on the `context.Context` via an unexported
+  context-key in the `pluginauthz` package (the shared decision point both
+  runtimes already depend on), with host-side `WithDispatch(ctx, dc)` /
+  `dispatchFrom(ctx)` accessors. It is stamped **once, on the host delivery
+  context** in `DeliverCommand` / `DeliverEvent`, before any plugin code runs —
+  so every downstream path inherits it: the binary broker call, the sub-spec-3
+  Lua bufconn consumption path, **and** the legacy in-VM Lua hostfuncs (which run
+  on `ls.Context()` = the delivery context). Because the key is unexported from
+  `pluginauthz`, a plugin can neither set nor observe it regardless of path.
+
+P0 is what unifies the sub-spec: M3 resolves `own-location` against
+`DispatchContext.Attributes`; M4 uses `DispatchContext.Subject` as the
+command-registry subject. The same anti-spoofing guarantee (INV-PLUGIN-51)
+covers both.
+
+### M1 — The ABAC access gate (plugin-as-subject)
+
+Capability/service consumption becomes a **default-deny authorization
+decision**, not a set-membership check. Subject is the host-stamped
+`plugin:<name>` (INV-PLUGIN-22). Declaration remains necessary (the resolver
+still gates reach), but is **no longer sufficient**: an operator policy MAY deny
+a declared capability (**INV-PLUGIN-50**).
+
+**The capability descriptor (defined here, not pre-existing).** M1/M2/M3 all need
+per-method metadata that no current sub-spec established: which ABAC `action` a
+method takes, which `resource` type it touches, its operation class
+(`read`/`write`), and whether it is scope-eligible (and if so, its
+`ScopedResource` extractor). This sub-spec **defines** that host-owned table — a
+`CapabilityDescriptor` per host.v1 capability, sited alongside the
+token→service registry from sub-spec 2 (host-owned, in-tree):
+
+```text
+CapabilityDescriptor {
+    Token   string                       // e.g. "world.mutation"
+    Methods map[string]MethodDescriptor  // keyed by gRPC method name
+}
+MethodDescriptor {
+    Action    string                     // ABAC action, e.g. "write"
+    Resource  string                     // ABAC resource type, e.g. "location"
+    Class     OperationClass             // read | write  (M2)
+    Scopes    []string                   // supported scope tokens, e.g. ["own-location"]  (M3); empty ⇒ not scope-eligible
+    Extract   ScopedResourceFn           // typed accessor; required iff Scopes non-empty  (M3, INV-PLUGIN-52)
+}
+```
+
+The descriptor is the single host-owned source for all three dimensions; the
+sub-spec-2 token→service map and this per-method table are the capability
+vocabulary's full definition.
+
+**Why M1 cannot call `pluginauthz.Evaluate` verbatim.** The existing
+`Evaluate` enforces an owned-type entitlement —
+`EVALUATE_UNENTITLED_TYPE` (`internal/plugin/pluginauthz/evaluate.go:196`):
+any resource type not in the plugin's `OwnedTypes` (or the `command`
+carve-out) is denied. Host-capability resources (`location`, `kv`, `session`)
+are **not** any plugin's owned types, so the owned-type predicate would deny
+every capability-access decision. M1 therefore adds a **capability-access
+entitlement** as a sibling path in `pluginauthz` that **shares** the
+subject-derivation, engine invocation, and single-audit-event machinery
+(no second policy engine, no divergent logic — INV-PLUGIN-26) but substitutes
+its entitlement predicate: a capability-access decision is entitled when the
+manifest **declares** the capability and the resolver **satisfied** it (already
+proven at load), not by `OwnedTypes`. The `action`/`resource` fed to the engine
+come from the method's `CapabilityDescriptor` entry.
+
+Per the locked topology, the decision is **split across two common paths**, each
+shared by both runtimes:
+
+| Check | Where | Inputs | Invariant |
+| --- | --- | --- | --- |
+| Declaration reach | **load-time resolver / per-plugin server registration** (foundation + sub-spec 3 §4) | declared set | INV-PLUGIN-45 |
+| `access:` operation-class + operator policy + `scope:` instance condition | **the one `hostcap` capability interceptor** | method name → descriptor; typed request → concrete resource; `DispatchContext` | INV-PLUGIN-49/50 |
+
+**Realization (single common path, static-before-policy).** Per-call enforcement
+is one `grpc.UnaryServerInterceptor` constructed by `hostcap` and installed on
+**both** runtimes' host.v1 servers — the binary broker server and the Lua
+per-plugin bufconn server both register host.v1 services through
+`internal/plugin/hostcap/register.go`, so that interceptor is the genuine common
+path (not two transport-specific gates). It runs the cheap static checks first
+(declaration re-check + `access:` operation-class from the descriptor;
+method-name-only, short-circuit on deny) **before** the policy `Evaluate`
+(operator policy + `scope:` condition, which needs the typed request +
+`DispatchContext`). This honors the cheap-before-expensive intent while keeping
+a single symmetric gate rather than a broker/server split that could diverge by
+runtime.
+
+The split is deliberate: each check sits where its inputs already live. The
+broker check needs only the method name (no request parsing); the
+resource-instance a call touches is known only inside the host.v1 capability
+server, which already holds the typed request and is — by INV-PLUGIN-49 — the
+single source both runtimes consume. Putting the scope decision there keeps it
+typed and symmetric without a reflective broker seam (see Alternatives).
+
+`action` and `resource` for the server-side `Evaluate` come from the called
+method's `CapabilityDescriptor.Methods[<method>]` entry (`Action`, `Resource`)
+defined above — the host-owned per-method table this sub-spec introduces.
+
+### M2 — `access:` (the operation dimension)
+
+A new optional `Dependency.Access` field narrows a capability grant to an
+operation class:
+
+```yaml
+requires:
+  - capability: kv
+    access: read        # KVGet permitted; KVSet / KVDelete denied
+```
+
+- Values are a closed enum: `read`, `write`. Absent ⇒ no operation narrowing
+  (the capability's full method set, subject to M1/M3).
+- The operation class of each method is `CapabilityDescriptor.Methods[<method>].Class`
+  (the host-owned per-method table defined in §M1). Each host.v1 method is
+  classified `read` or `write`.
+- Enforcement is at the **broker/registry common path** (method name is
+  sufficient): if the declared `access:` does not cover the called method's
+  class, the call is denied before forwarding. `access: read` + a `write` method
+  ⇒ deny.
+- `access:` is valid **only on `capability:` entries**. On a `service:` entry it
+  is a **hard manifest error** (same boundary and rationale as `scope:`,
+  INV-PLUGIN-53): the host does not own the provider's method classification, so
+  it cannot enforce the promise, and an inert-but-declared keyword is exactly the
+  "declared but not enforced" smell this design refuses. A provider that wants
+  operation-class narrowing of its own service expresses it in its own policy.
+  (A future sub-spec MAY define provider-declared service operation classes; out
+  of scope here.)
+
+### M3 — `scope:` (the instance dimension)
+
+`scope:` narrows a capability grant to a subset of resource instances, anchored
+to the dispatch context.
+
+```yaml
+requires:
+  - capability: world.mutation
+    scope: own-location   # may mutate only the dispatch character's current location
+```
+
+- The supported scope tokens for a capability are
+  `CapabilityDescriptor.Methods[<method>].Scopes` (the host-owned table from
+  §M1; e.g. `world.mutation` mutation methods → `{own-location}`). A `scope:`
+  token not supported by the capability is a **hard manifest error** at load.
+  The vocabulary is host-owned for the same reason the capability vocabulary is
+  (sub-spec 2): the host implements the server, so it can both define and
+  enforce the scope.
+- A scope token compiles to a **policy condition** comparing a resource
+  attribute against a dispatch-context attribute — `own-location` ⇒
+  `resource.location == DispatchContext.Attributes["location"]`. The condition
+  is evaluated via the capability-access path (§M1) at the host.v1 server-side
+  interceptor.
+- The concrete resource of a call is produced by the descriptor's typed
+  `Extract` (`ScopedResource(req)`) accessor co-located with each scope-eligible
+  handler — never by reflective introspection of the request in the broker. A
+  scope-eligible method (`Scopes` non-empty) MUST carry an `Extract`; the
+  meta-test (INV-PLUGIN-52) fails the build otherwise.
+- `scope:` is valid **only on `capability:` entries.** A `scope:` on a
+  `service:` entry is a hard manifest error (**INV-PLUGIN-53**). Rationale: the
+  host owns neither the provider's request semantics nor its resource model, so
+  it cannot honor the promise; the provider plugin governs its own resources
+  (INV-PLUGIN-24) and enforces per-dispatch scope itself via `host.Evaluate`
+  against the `DispatchContext` the host propagates across the broker. (Growth
+  path: a provider surface that genuinely needs host-enforced cross-plugin
+  scope is promoted to a host capability, at which point `scope:` works for
+  free.)
+- With no `DispatchContext` (P0 absent), a scoped call **fails closed**.
+
+**Fail-closed totality (no silent un-enforcement).** A scope-eligible capability
+method that lacks a wired `ScopedResource` extractor MUST deny at runtime — it
+MUST NOT forward the call unscoped. This is enforced three ways
+(**INV-PLUGIN-52**):
+
+1. **Runtime:** the shared interceptor denies a scoped call whose method has no
+   registered extractor (fail-closed default).
+2. **Meta-test:** a completeness gate enumerates every method of every
+   scope-eligible capability and fails the build if any lacks an extractor —
+   catching the gap at CI, in our own (in-tree, host-owned) servers.
+3. **Invariant:** INV-PLUGIN-52 binds the totality guarantee to that meta-test +
+   a runtime test so a future refactor cannot quietly delete the interceptor.
+
+Because every host capability server is host-owned and in-tree, all three
+guards hold regardless of whether the *consumer* is an out-of-tree plugin: the
+consumer's origin never changes where enforcement runs.
+
+### M4 — The plugin-trust fix (command-registry)
+
+`commandRegistryServer.ListCommands` / `GetCommandHelp`
+(`internal/plugin/hostcap/servers.go`) and the Lua `list_commands` /
+`get_command_help` hostfuncs (`internal/plugin/hostfunc/commands.go`) stop
+deriving the ABAC subject from `req.GetCharacterId()`. Both runtimes use
+**`DispatchContext.Subject`** (P0) — the host-vouched acting character —
+exactly as `host.Evaluate` derives its subject host-side (ADR `holomush-qeypl`).
+
+- The `character_id` request field is **removed from the authorization path**.
+  (The wire field MAY remain for protocol compatibility but MUST NOT be read as
+  the subject; the spec prefers removing it to eliminate the spoofing surface
+  entirely — final disposition is a proto-compat decision at implementation.)
+- A command-registry call on an **absent** `DispatchContext` fails closed (deny)
+  — a plugin cannot enumerate any character's commands outside a dispatch.
+- The change is made at the **shared path** for both runtimes
+  (plugin-runtime-symmetry): the binary server and the Lua hostfunc derive the
+  subject from the same host-stamped context; neither reads a wire subject.
+- **INV-PLUGIN-51** binds the host-vouched-subject guarantee, covering both this
+  fix and the P0/M3 anchoring.
+
+## Invariants (proposed)
+
+To be registered in `docs/architecture/invariants.yaml` on finalization, each
+`binding: pending` until a test asserts it. Highest existing PLUGIN id is
+`INV-PLUGIN-49`; these allocate `50`–`53`.
+
+- **INV-PLUGIN-50 (capability access is a default-deny ABAC decision).** A
+  plugin's consumption of a host capability or plugin service MUST be authorized
+  by a default-deny ABAC decision keyed on the host-stamped `plugin:<name>`
+  subject. Manifest declaration is necessary but not sufficient; an operator
+  policy MAY deny a declared capability.
+- **INV-PLUGIN-51 (host-vouched dispatch subject).** Any character subject or
+  dispatch attribute used in a plugin-mediated authorization decision MUST be
+  host-vouched (derived from the host delivery context) and MUST NOT originate
+  from plugin- or wire-supplied data. Covers the command-registry RPCs and
+  `scope:` anchoring.
+- **INV-PLUGIN-52 (scope enforcement is total).** Every scope-eligible
+  capability method MUST resolve its scoped resource through a wired extractor;
+  a method missing its extractor MUST fail closed (deny), never forward
+  unscoped. No silent fail-open.
+- **INV-PLUGIN-53 (least-privilege parameters are capability-only).** The
+  per-entry least-privilege parameters (`access:`, `scope:`) are valid only on a
+  `capability:` `requires` entry; either on a `service:` entry MUST be a hard
+  manifest error at load. The host owns neither the provider's method
+  classification nor its resource model, so it cannot enforce them on a service.
+
+This sub-spec also **binds** consumption-path entries left `pending` by the
+foundation where the enforcement decision now genuinely asserts them
+(INV-PLUGIN-44/45 gain policy-decision coverage; final binding list is settled
+at implementation against the tests written).
+
+## Testing strategy
+
+- **Manifest validation** (`internal/plugin/manifest_test.go` /
+  `dependency_type_test.go`): `access:` enum validation; `scope:` token validated
+  against the per-capability vocabulary; `access:` **or** `scope:` on a
+  `service:` entry is a hard error (binds INV-PLUGIN-53); generated
+  `schemas/plugin.schema.json` regen + drift gate.
+- **M1 gate** (`pluginauthz` + interceptor tests): a declared capability denied
+  by operator policy is unreachable despite declaration (binds INV-PLUGIN-50); a
+  declared+permitted capability is reachable; the same policy denies Lua and
+  binary identically (parity).
+- **M2 `access:`**: `access: read` permits a read method and denies a write
+  method at the broker path; absent `access:` permits both (subject to M1/M3).
+- **M3 `scope:`**: `scope: own-location` permits a mutation whose resource
+  location equals the dispatch location and denies one that differs; an absent
+  `DispatchContext` fails the scoped call closed; the **completeness meta-test**
+  fails the build when a scope-eligible method lacks an extractor (binds
+  INV-PLUGIN-52); a runtime test asserts fail-closed on a missing extractor.
+- **M4 trust fix**: `ListCommands` / `GetCommandHelp` (binary) and
+  `list_commands` / `get_command_help` (Lua) derive the subject from the
+  host-vouched dispatch context and **ignore** any wire `character_id`; a
+  spoofed `character_id` cannot enumerate another character's commands; absent
+  dispatch fails closed (binds INV-PLUGIN-51); a cross-runtime test asserts both
+  surfaces resolve the identical host-derived subject.
+- **Audit**: each gate decision emits exactly one host-stamped audit event
+  (reuses INV-PLUGIN-25 via `pluginauthz.Evaluate`).
+- Per CLAUDE.md, run `task test:int` after any `plugin.yaml` / `requires`
+  fixture change — the unit resolver test stays green while only the integration
+  suite exercises injection.
+
+## Alternatives considered
+
+- **Unified reflective broker interceptor (one gate for everything).** Rejected:
+  it relocates per-method resource-extraction logic into a reflective broker
+  seam plus an out-of-band field-mapping registry that drifts from the handler
+  and fails **open** on a missing entry — the worst failure mode for a
+  least-privilege feature. The split topology keeps extraction typed and
+  co-located with the handler.
+- **Two-gate plugin-then-character ceiling** (plugin may do no more than the
+  acting character). Rejected as the primary model: too restrictive when a
+  plugin legitimately exceeds the character (e.g. writing scene logs the
+  character cannot directly write). The plugin-subject-with-dispatch-attributes
+  model (P0 + M1) expresses scope without capping the plugin at the character's
+  own grants.
+- **`scope:` enforced by operator policy only, no manifest keyword (YAGNI).**
+  Rejected on **discoverability / least-surprise** grounds: the manifest
+  `requires` list (surfaced by `plugin info`) is the plugin's declared,
+  auditable blast-radius contract. Pushing the instance ceiling into
+  operator-authored policy files removes it from the plugin's own contract,
+  where an auditor of a third-party plugin would look. The host owns the scope
+  vocabulary, so the keyword is host-definable, host-enforceable, and
+  manifest-discoverable — three coincident reasons it belongs on `capability:`
+  entries.
+- **`scope:` legal on `service:` entries with provider-side enforcement.**
+  Rejected: it makes one keyword mean two different strengths
+  (host-guaranteed vs advisory) — the privilege gradient the runtime-symmetry
+  mandate exists to abolish. Provider-side scope is still fully supported, but
+  via the provider's own policies, not a consumer manifest promise.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| A scope-eligible method ships without its extractor → silent unscoped access. | Three-way fail-closed (runtime deny + CI meta-test + INV-PLUGIN-52). All host servers are in-tree, so the meta-test sees them all. |
+| Per-call `Evaluate` on the consumption hot path adds latency. | Capability calls already touch DB/bus (session/property/world); the mandate discounts pre-measured perf. The broker static checks (declaration + `access:`) short-circuit before the policy `Evaluate`. |
+| `DispatchContext` absence handling differs between runtimes → asymmetry. | Absence ⇒ fail-closed is enforced at the shared interceptor / shared hostfunc path, not per-runtime; parity tests assert identical denial. |
+| Removing `character_id` from the wire breaks an out-of-tree caller. | The authorization path stops reading it regardless; the wire field's final disposition (keep-but-ignore vs remove) is a bounded proto-compat decision at implementation. |
+| Operator policy now able to deny a declared capability could brick a plugin silently. | Default policy permits declared capabilities (declaration remains the floor unless an operator writes a deny); denials are audited (INV-PLUGIN-25), so the decision trail is explicit. |
+
+## References
+
+- Epic `holomush-eykuh`; this bead `holomush-eykuh.3`; review follow-on
+  `holomush-eykuh.8`; migration `holomush-eykuh.4`.
+- Sub-spec 1 (foundation):
+  `docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md`
+  (INV-PLUGIN-41–45; `Dependency.Scope` reserved).
+- Sub-spec 2 (decomposition):
+  `docs/superpowers/specs/2026-06-11-plugin-host-capability-decomposition-design.md`
+  (host-owned capability vocabulary; the 14 host.v1 services).
+- Sub-spec 3 (Lua parity):
+  `docs/superpowers/specs/2026-06-12-lua-parity-host-brokered-consumption-design.md`
+  (INV-PLUGIN-44/45/49 bound; shared declaration gate).
+- Per-action plugin authz core: `internal/plugin/pluginauthz/evaluate.go`
+  (INV-PLUGIN-22/24/25/26); host-derived subject ADR `holomush-qeypl`; host
+  `Evaluate` RPC ADR `holomush-dttdj`.
+- Finding site: `internal/plugin/hostcap/servers.go:947-1013`; Lua twins
+  `internal/plugin/hostfunc/commands.go`.
+- Manifest schema: `internal/plugin/manifest.go`,
+  `internal/plugin/dependency_type.go`, `schemas/plugin.schema.json`,
+  `.claude/rules/plugin-manifest.md`.
+- Runtime symmetry: `.claude/rules/plugin-runtime-symmetry.md`.
+- ABAC providers / fail-safe semantics: `.claude/rules/abac-providers.md`,
+  ADR `holomush-iv43`.

--- a/docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
+++ b/docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md
@@ -470,3 +470,4 @@ at implementation against the tests written).
 - Runtime symmetry: `.claude/rules/plugin-runtime-symmetry.md`.
 - ABAC providers / fail-safe semantics: `.claude/rules/abac-providers.md`,
   ADR `holomush-iv43`.
+<!-- adr-capture: sha256=6ed15cd9ff5f6bf3; session=cli; ts=2026-06-13T01:33:03Z; adrs=holomush-wvrtc,holomush-syhc2,holomush-u1sdq,holomush-afyzh -->


### PR DESCRIPTION
Docs-only PR landing the canonical design context for **sub-spec 4** of epic `holomush-eykuh` (plugin capability & dependency architecture), so the implementation subagents can read it from `main`.

## What's here

- **Spec** `docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md` — design-reviewer **READY** (×2).
- **Plan** `docs/superpowers/plans/2026-06-12-plugin-least-privilege-trust.md` — plan-reviewer **READY** (14 tasks, 8 phases).
- **4 ADRs** (`docs/adr/`): `holomush-wvrtc`, `holomush-syhc2`, `holomush-u1sdq`, `holomush-afyzh` + index update.
- **Invariants** `INV-PLUGIN-50..53` registered as `binding: pending` (bound by the implementation in Task 14).

## The design (one spine + four mechanisms)

- **P0 — dispatch-context primitive:** a host-vouched acting-character subject + attributes stamped on the delivery `context.Context` via an unexported `pluginauthz` key; everything else consumes it. (INV-PLUGIN-51)
- **M1 — default-deny ABAC gate:** capability access is an `Evaluate` keyed on `plugin:<name>`; declaration necessary, not sufficient. Sibling entitlement path avoids the `OwnedTypes` gate. (INV-PLUGIN-50)
- **M2 `access:` / M3 `scope:`** — operation- and instance-dimension narrowing, **capability-only** (hard manifest error on `service:`), enforced at one shared `hostcap` interceptor via a host-owned `CapabilityDescriptor` table; scope fail-closed totality. (INV-PLUGIN-52/53)
- **M4 — plugin-trust fix:** `ListCommands`/`GetCommandHelp` + Lua twins switch from wire `character_id` to the host-vouched dispatch subject (the PR #4430 finding), symmetric across runtimes.

## Tracking

Epic `holomush-eykuh.3` with 14 child tasks (`eykuh.3.1`–`.14`); ready roots `.1`/`.3`/`.5`. No production code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)