### PR TITLE
feat(plugin): least-privilege enforcement & plugin-trust security (holomush-eykuh.3)

### DIFF
--- a/.claude/rules/plugin-manifest.md
+++ b/.claude/rules/plugin-manifest.md
@@ -39,6 +39,31 @@ Each plugin in `plugins/<n>/` has a `plugin.yaml` that the loader consumes.
 - `commands: [...]` — telnet/web commands the plugin registers, each with required `capabilities: [{action, resource, scope}]` per the command-capability spec.
 - `policies:` — ABAC policy files this plugin ships.
 
+## Least-privilege parameters on `capability:` requires entries
+
+Two optional fields narrow the host's enforcement of a capability requirement.
+They are valid **only** on `capability:` entries — placing either on a `service:`
+entry is a hard manifest load error (INV-PLUGIN-53):
+
+| Field | Values | Purpose |
+|-------|--------|---------|
+| `access:` | `read` \| `write` | Declares the maximum operation class the plugin needs. The interceptor enforces it: a plugin declaring `access: read` cannot issue write-class host calls. |
+| `scope:` | e.g., `own-location` | Declares the instance-level fence. The interceptor extracts the method's scoped resource and evaluates it against the scope policy; calls whose resource cannot be resolved from the request fail closed (`SCOPE_NO_RESOURCE`, INV-PLUGIN-52). |
+
+**Example — a builder plugin that writes only within its own location:**
+
+```yaml
+requires:
+  - capability: world.mutation
+    access: write
+    scope: own-location
+```
+
+`access:` and `scope:` are enforced by the host interceptor against the
+host-owned `WorldMutationService`. They have no meaning on a `service:` entry
+because the host does not own provider-plugin servers and cannot honor the
+promise at the enforcement layer.
+
 ## DAG validation
 
 The loader resolves dependencies as a DAG: every name in `requires` must appear in some other plugin's `provides`. Cycles error at startup. `holomush.plugin.v1.AttributeResolverService` is auto-registered by the host (do NOT declare in `provides` — causes `SERVICE_ALREADY_REGISTERED`).

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -322,10 +322,10 @@ invariants.
 | `INV-PLUGIN-47` | Every host-brokered capability function MUST map to exactly one capability-scoped service in holomush.plugin.host.v1; no host.v1 service MUST span two capability domains, and the PluginHostService god-service MUST NOT exist after the decomposition. | — | bound |
 | `INV-PLUGIN-48` | Ambient runtime substrate (log, new_request_id, stdlib, config) MUST NOT be modeled as a capability: it MUST NOT appear in holomush.plugin.host.v1 and MUST NOT be a valid requires capability token. | — | bound |
 | `INV-PLUGIN-49` | A capability's RPC contract MUST be the single source both runtimes consume; there MUST NOT be a runtime-specific capability surface (the union resolves today's Lua/binary asymmetry). Generalizes INV-COMMAND-2 to the whole host-capability surface. | — | bound |
-| `INV-PLUGIN-50` | A plugin's consumption of a host capability or plugin service MUST be authorized by a default-deny ABAC decision keyed on the host-stamped plugin:<name> subject. Manifest declaration is necessary but not sufficient; an operator policy MAY deny a declared capability. | — | pending |
-| `INV-PLUGIN-51` | Any character subject or dispatch attribute used in a plugin-mediated authorization decision MUST be host-vouched (derived from the host delivery context) and MUST NOT originate from plugin- or wire-supplied data. Covers the command-registry RPCs and scope: anchoring. | — | pending |
-| `INV-PLUGIN-52` | Every scope-eligible capability method MUST resolve its scoped resource through a wired extractor; a method missing its extractor MUST fail closed (deny), never forward unscoped. No silent fail-open. | — | pending |
-| `INV-PLUGIN-53` | The per-entry least-privilege parameters (access:, scope:) are valid only on a capability: requires entry; either on a service: entry MUST be a hard manifest error at load. | — | pending |
+| `INV-PLUGIN-50` | A plugin's consumption of a host capability or plugin service MUST be authorized by a default-deny ABAC decision keyed on the host-stamped plugin:<name> subject. Manifest declaration is necessary but not sufficient; an operator policy MAY deny a declared capability. | — | bound |
+| `INV-PLUGIN-51` | Any character subject or dispatch attribute used in a plugin-mediated authorization decision MUST be host-vouched (derived from the host delivery context) and MUST NOT originate from plugin- or wire-supplied data. Covers the command-registry RPCs and scope: anchoring. | — | bound |
+| `INV-PLUGIN-52` | Every scope-eligible capability method MUST resolve its scoped resource through a wired extractor; a method missing its extractor MUST fail closed (deny), never forward unscoped. No silent fail-open. | — | bound |
+| `INV-PLUGIN-53` | The per-entry least-privilege parameters (access:, scope:) are valid only on a capability: requires entry; either on a service: entry MUST be a hard manifest error at load. | — | bound |
 
 ### `INV-EVENTBUS`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3813,26 +3813,40 @@ invariants:
     summary: "A plugin's consumption of a host capability or plugin service MUST be authorized by a default-deny ABAC decision
       keyed on the host-stamped plugin:<name> subject. Manifest declaration is necessary but not sufficient; an operator policy
       MAY deny a declared capability."
-    binding: pending
+    binding: bound
+    asserted_by:
+      - "internal/plugin/pluginauthz/capability_test.go"
+      - "internal/plugin/hostcap/interceptor_test.go"
+      - "internal/access/policy/seed_smoke_test.go"
   - id: INV-PLUGIN-51
     scope: INV-PLUGIN
     origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
     summary: "Any character subject or dispatch attribute used in a plugin-mediated authorization decision MUST be host-vouched
       (derived from the host delivery context) and MUST NOT originate from plugin- or wire-supplied data. Covers the command-registry
       RPCs and scope: anchoring."
-    binding: pending
+    binding: bound
+    asserted_by:
+      - "internal/plugin/goplugin/dispatch_test.go"
+      - "internal/plugin/lua/dispatch_test.go"
+      - "internal/plugin/goplugin/host_service_command_test.go"
+      - "internal/plugin/hostfunc/commands_test.go"
   - id: INV-PLUGIN-52
     scope: INV-PLUGIN
     origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
     summary: "Every scope-eligible capability method MUST resolve its scoped resource through a wired extractor; a method
       missing its extractor MUST fail closed (deny), never forward unscoped. No silent fail-open."
-    binding: pending
+    binding: bound
+    asserted_by:
+      - "internal/plugin/hostcap/descriptor_completeness_test.go"
+      - "internal/plugin/hostcap/interceptor_test.go"
   - id: INV-PLUGIN-53
     scope: INV-PLUGIN
     origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"
     summary: "The per-entry least-privilege parameters (access:, scope:) are valid only on a capability: requires entry; either
       on a service: entry MUST be a hard manifest error at load."
-    binding: pending
+    binding: bound
+    asserted_by:
+      - "internal/plugin/manifest_test.go"
   - id: INV-COMMAND-1
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -235,6 +235,14 @@ func (r *Resolver) Resolve(ctx context.Context, req types.AccessRequest) (*types
 // error; callers MUST fail closed on non-nil error and MUST NOT use partial
 // bags for policy evaluation.
 func (r *Resolver) ResolveSubjectAttributes(ctx context.Context, subject, action string) (*types.AttributeBags, error) {
+	return r.resolveSubjectAttributes(ctx, subject, action, false)
+}
+
+// resolveSubjectAttributes is the shared core for ResolveSubjectAttributes and
+// ResolveSubject. When skipEnv is true the environment providers are not called,
+// so a subject-only caller (host dispatch stamping via ResolveSubject) does not
+// fail closed on an unrelated environment-provider error (holomush-eykuh.3).
+func (r *Resolver) resolveSubjectAttributes(ctx context.Context, subject, action string, skipEnv bool) (*types.AttributeBags, error) {
 	// Input validation runs BEFORE entering the resolution scope. Empty
 	// subject is rejected with nil bags — no work has started, so there
 	// is nothing partial to return. Resolve tolerates empty subjects, but
@@ -282,9 +290,14 @@ func (r *Resolver) ResolveSubjectAttributes(ctx context.Context, subject, action
 		}
 	}
 
-	// Resolve environment attributes.
-	if err := r.resolveEnvironment(ctx, bags.Environment); err != nil {
-		errs = append(errs, err)
+	// Resolve environment attributes. Skipped for the subject-only path
+	// (ResolveSubject): that caller consumes only the Subject bag, so coupling
+	// it to environment-provider health would fail dispatch stamping closed on
+	// an unrelated env-provider error (holomush-eykuh.3).
+	if !skipEnv {
+		if err := r.resolveEnvironment(ctx, bags.Environment); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	// Resource providers are intentionally NOT called. The optimistic-permit
@@ -300,14 +313,17 @@ func (r *Resolver) ResolveSubjectAttributes(ctx context.Context, subject, action
 // point for populating DispatchContext.Attributes (notably "location"); see
 // holomush-eykuh.3. It delegates to ResolveSubjectAttributes with an empty
 // action — only the subject bag is consumed — and returns just that bag so the
-// caller never sees the action/environment/resource sub-bags.
+// caller never sees the action/environment/resource sub-bags. Environment
+// providers are NOT consulted on this path (skipEnv): the subject bag is all the
+// caller needs, so an unrelated environment-provider failure must not fail
+// dispatch stamping closed (holomush-eykuh.3).
 //
-// An error (invalid ref, provider failure) is returned to the caller, which
-// MUST treat it as fail-closed (leave Attributes nil). A subject with no
+// A subject-provider failure (or an invalid ref) IS returned to the caller,
+// which MUST treat it as fail-closed (leave Attributes nil). A subject with no
 // registered provider resolves to a bag carrying only the raw "id" — harmless,
 // since the host projects only string-valued keys it cares about.
 func (r *Resolver) ResolveSubject(ctx context.Context, subject string) (map[string]any, error) {
-	bags, err := r.ResolveSubjectAttributes(ctx, subject, "")
+	bags, err := r.resolveSubjectAttributes(ctx, subject, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -294,6 +294,26 @@ func (r *Resolver) ResolveSubjectAttributes(ctx context.Context, subject, action
 	return bags, errors.Join(errs...)
 }
 
+// ResolveSubject resolves the subject attribute bag for a host-vouched ABAC
+// subject (e.g. "character:01ABC"), satisfying
+// pluginauthz.AttributeResolver. It is the plugin hosts' delivery-time entry
+// point for populating DispatchContext.Attributes (notably "location"); see
+// holomush-eykuh.3. It delegates to ResolveSubjectAttributes with an empty
+// action — only the subject bag is consumed — and returns just that bag so the
+// caller never sees the action/environment/resource sub-bags.
+//
+// An error (invalid ref, provider failure) is returned to the caller, which
+// MUST treat it as fail-closed (leave Attributes nil). A subject with no
+// registered provider resolves to a bag carrying only the raw "id" — harmless,
+// since the host projects only string-valued keys it cares about.
+func (r *Resolver) ResolveSubject(ctx context.Context, subject string) (map[string]any, error) {
+	bags, err := r.ResolveSubjectAttributes(ctx, subject, "")
+	if err != nil {
+		return nil, err
+	}
+	return bags.Subject, nil
+}
+
 // validateEntityRef checks that an entity reference is in "type:id" format
 // with both parts non-empty. This ensures all providers receive validated refs
 // and the ABAC fail-closed guarantee is preserved.

--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -11,9 +11,10 @@ type SeedPolicy struct {
 	SeedVersion int
 }
 
-// SeedPolicies returns the complete set of 36 seed policies (27 permit, 9 forbid).
+// SeedPolicies returns the complete set of 37 seed policies (28 permit, 9 forbid).
 // The initial 18 (T22) minus 2 removed command policies, plus 5 gap-fill policies (T22b: G1-G5),
-// 1 phase-2 command policy, and 2 system bootstrap policies.
+// 1 phase-2 command policy, 2 system bootstrap policies, and 1 plugin host-capability
+// scope policy (eykuh.3; world.mutation own-location).
 // Default deny behavior is provided by EffectDefaultDeny (no matching policy = denied).
 // See ADR 087 for rationale on default-deny instead of explicit forbid for system properties.
 //
@@ -306,6 +307,27 @@ func SeedPolicies() []SeedPolicy {
 			Name:        "seed:staff-read-unrestricted-history",
 			Description: "Staff and admins may bypass the per-session temporal floor for history reads (INV-PRIVACY-6); location hard-gate still applies (ADR wxty)",
 			DSLText:     `permit(principal is character, action in ["read_unrestricted_history"], resource) when { "staff" in principal.character.roles || "admin" in principal.character.roles };`,
+			SeedVersion: 1,
+		},
+
+		// --- Plugin host-capability scope policies (eykuh.3; INV-PLUGIN-50) ---
+		//
+		// world.mutation own-location: a plugin (subject plugin:<name>) may write
+		// to a location only when that location is the acting character's dispatch
+		// location. The host-capability interceptor (internal/plugin/hostcap) calls
+		// pluginauthz.EvaluateCapabilityAccess for the scope-eligible CreateExit /
+		// CreateObject methods, passing the extracted location as the resource
+		// (location:<id>) and the host-vouched acting-character location as the
+		// caller action attribute dispatch_location. The `action` namespace is not
+		// schema-registered (no AttributeProvider owns it), so dispatch_location is
+		// a free caller-overlay attribute the engine injects into bags.Action
+		// (engine.go: caller attributes overlay bags.Action). Manifest declaration
+		// is necessary but not sufficient — this default-deny seed is the operator
+		// policy that authorizes the declared capability (INV-PLUGIN-50).
+		{
+			Name:        "seed:plugin-world-mutation-own-location",
+			Description: "Plugins may write to a location only when it is the acting character's dispatch location (world.mutation own-location scope; INV-PLUGIN-50)",
+			DSLText:     `permit(principal is plugin, action in ["write"], resource is location) when { resource.location.id == action.dispatch_location };`,
 			SeedVersion: 1,
 		},
 	}

--- a/internal/access/policy/seed_smoke_test.go
+++ b/internal/access/policy/seed_smoke_test.go
@@ -910,6 +910,67 @@ func TestSeedSmokeAdminRemoteListPresence(t *testing.T) {
 	assert.True(t, decision.IsAllowed(), "admin should list presence at remote location via super-rule; got: %s — %s", decision.Effect(), decision.Reason())
 }
 
+// pluginProvider builds a "plugin"-namespace mock provider with the given
+// subject attributes (e.g. {"name": "builder-bot"}).
+func pluginProvider(subjectAttrs map[string]any) *mockAttributeProvider {
+	return &mockAttributeProvider{
+		namespace:  "plugin",
+		subjectMap: subjectAttrs,
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"name": types.AttrTypeString,
+			},
+		},
+	}
+}
+
+// Verifies: INV-PLUGIN-50
+func TestSeedSmokePluginWorldMutationOwnLocationPermitsMatch(t *testing.T) {
+	locID := "01LOC000WWWWWWWWWWWWWWWWWW"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		pluginProvider(map[string]any{"name": "builder-bot"}),
+		locationProvider(map[string]any{"id": locID, "name": "Workshop"}),
+	})
+
+	// A plugin writing to a location that IS the acting character's dispatch
+	// location → permit (seed:plugin-world-mutation-own-location). The
+	// dispatch_location action attribute is the host-vouched acting-character
+	// location, overlaid onto bags.Action by the engine (as the interceptor
+	// supplies it via CapabilityInput.Context).
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:    access.PluginSubject("builder-bot"),
+		Action:     "write",
+		Resource:   "location:" + locID,
+		Attributes: map[string]any{"dispatch_location": locID},
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(),
+		"plugin should write its own dispatch location; got: %s — %s", decision.Effect(), decision.Reason())
+}
+
+// Verifies: INV-PLUGIN-50
+func TestSeedSmokePluginWorldMutationOwnLocationDeniesMismatch(t *testing.T) {
+	dispatchLoc := "01LOC000XXXXXXXXXXXXXXXXXX"
+	otherLoc := "01LOC000YYYYYYYYYYYYYYYYYY"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		pluginProvider(map[string]any{"name": "builder-bot"}),
+		locationProvider(map[string]any{"id": otherLoc, "name": "Elsewhere"}),
+	})
+
+	// Plugin writing to a location that is NOT the dispatch location → default deny.
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:    access.PluginSubject("builder-bot"),
+		Action:     "write",
+		Resource:   "location:" + otherLoc,
+		Attributes: map[string]any{"dispatch_location": dispatchLoc},
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(),
+		"plugin must NOT write a location other than its dispatch location; got: %s — %s", decision.Effect(), decision.Reason())
+}
+
 func TestSeedSmokePluginDeniedEventsSystemRekeyStream(t *testing.T) {
 	// A plugin principal must NOT read the rekey audit stream.
 	// The broad seed:deny-events-system-read-plugin forbid must fire.

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSeedPoliciesCount(t *testing.T) {
 	seeds := SeedPolicies()
-	// 27 permit + 9 forbid = 36 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history + 1 presence list_presence_same_location)
-	assert.Len(t, seeds, 36, "expected 36 seed policies (27 permit, 9 forbid)")
+	// 28 permit + 9 forbid = 37 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history + 1 presence list_presence_same_location + 1 eykuh.3 plugin world.mutation own-location)
+	assert.Len(t, seeds, 37, "expected 37 seed policies (28 permit, 9 forbid)")
 }
 
 func TestSeedPoliciesAllNamesHaveSeedPrefix(t *testing.T) {
@@ -71,7 +71,7 @@ func TestSeedPoliciesEffectDistribution(t *testing.T) {
 			forbidCount++
 		}
 	}
-	assert.Equal(t, 27, permitCount, "expected 27 permit policies")
+	assert.Equal(t, 28, permitCount, "expected 28 permit policies")
 	assert.Equal(t, 9, forbidCount, "expected 9 forbid policies (+2 phase-5 sub-epic A events.*.system.crypto_totp.* denies + 2 phase-5 sub-epic D events.*.system.crypto_policy.* denies + 2 phase-5 sub-epic E events.*.system.* broad denies)")
 }
 
@@ -122,6 +122,8 @@ func TestSeedPoliciesExpectedNames(t *testing.T) {
 		"seed:deny-events-system-read-plugin",
 		// Phase-5 iwzt history-scope-privacy staff override policy (INV-PRIVACY-6)
 		"seed:staff-read-unrestricted-history",
+		// Plugin host-capability scope policy (eykuh.3; INV-PLUGIN-50)
+		"seed:plugin-world-mutation-own-location",
 	}
 
 	seeds := SeedPolicies()

--- a/internal/plugin/capability_vocab.go
+++ b/internal/plugin/capability_vocab.go
@@ -62,3 +62,29 @@ func DefaultCapabilityVocabulary() *CapabilityVocabulary {
 	}
 	return v
 }
+
+// capabilityScopeTokenRegistry maps a capability token to the set of scope
+// tokens it supports. It is populated at init by the hostcap package (which
+// owns the CapabilityDescriptor table) via RegisterCapabilityScopeTokens —
+// the plugins package MUST NOT import hostcap (cycle), so hostcap registers
+// inward.
+var capabilityScopeTokenRegistry = map[string]map[string]bool{}
+
+// RegisterCapabilityScopeTokens records the scope tokens a capability supports.
+// Called from hostcap's init(). Idempotent-merge: repeated tokens are unioned.
+func RegisterCapabilityScopeTokens(token string, scopes ...string) {
+	set := capabilityScopeTokenRegistry[token]
+	if set == nil {
+		set = map[string]bool{}
+		capabilityScopeTokenRegistry[token] = set
+	}
+	for _, s := range scopes {
+		set[s] = true
+	}
+}
+
+// capabilityScopeTokens returns the supported scope-token set for a capability
+// (nil if the capability declares no scopes / is unknown).
+func capabilityScopeTokens(token string) map[string]bool {
+	return capabilityScopeTokenRegistry[token]
+}

--- a/internal/plugin/dependency_type.go
+++ b/internal/plugin/dependency_type.go
@@ -26,9 +26,10 @@ type Dependency struct {
 	Name     string
 	Version  string // semver constraint; services only
 	Optional bool
-	// Scope carries least-privilege parameters; semantics are sub-spec 4. The
-	// foundation parses and round-trips it but does not interpret it.
-	Scope string
+	// Scope and Access carry least-privilege parameters; semantics are sub-spec 4.
+	// Valid only on capability entries (INV-PLUGIN-53).
+	Scope  string
+	Access string // "" | "read" | "write"
 }
 
 // dependencyYAML is the object form accepted by UnmarshalYAML.
@@ -37,7 +38,8 @@ type dependencyYAML struct {
 	Service    string `yaml:"service"`
 	Version    string `yaml:"version"`
 	Optional   bool   `yaml:"optional"`
-	Scope      string `yaml:"scope"`
+	Scope      string `yaml:"scope,omitempty"`
+	Access     string `yaml:"access,omitempty"`
 }
 
 // UnmarshalYAML accepts either a bare string (treated as a service path, for
@@ -58,7 +60,7 @@ func (d *Dependency) UnmarshalYAML(value *yaml.Node) error {
 		return oops.Code("DEPENDENCY_KIND_AMBIGUOUS").
 			Errorf("a requires entry MUST have exactly one of capability/service")
 	}
-	d.Version, d.Optional, d.Scope = raw.Version, raw.Optional, raw.Scope
+	d.Version, d.Optional, d.Scope, d.Access = raw.Version, raw.Optional, raw.Scope, raw.Access
 	if hasCap {
 		d.Kind, d.Name = DependencyCapability, raw.Capability
 	} else {

--- a/internal/plugin/dependency_type_test.go
+++ b/internal/plugin/dependency_type_test.go
@@ -54,6 +54,15 @@ func TestRequireServicesConstructsServiceDeps(t *testing.T) {
 	assert.Equal(t, "a", deps[0].Name)
 }
 
+func TestDependencyAccessRoundTrips(t *testing.T) {
+	var d Dependency
+	err := yaml.Unmarshal([]byte("capability: kv\naccess: read\n"), &d)
+	require.NoError(t, err)
+	assert.Equal(t, DependencyCapability, d.Kind)
+	assert.Equal(t, "kv", d.Name)
+	assert.Equal(t, "read", d.Access)
+}
+
 func TestVersionSatisfies(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/plugin/goplugin/dispatch.go
+++ b/internal/plugin/goplugin/dispatch.go
@@ -9,27 +9,62 @@ import (
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/pkg/errutil"
 )
 
 // stampDispatch stamps the host-vouched pluginauthz.DispatchContext onto ctx
 // before plugin code runs, so in-process plugin invocations inherit the
-// host-vouched ABAC subject (INV-PLUGIN-51).
+// host-vouched ABAC subject and attributes (INV-PLUGIN-51).
 //
 // Only character actors are vouched: when actor.Kind == core.ActorCharacter
 // and actor.ID is non-empty, the subject is access.CharacterSubject(actor.ID).
 // For any other actor kind (plugin, system, unset) the ctx is returned
 // unchanged — absence is fail-closed at scope-enforcement time.
 //
-// Attributes (the dispatch location backing scope:own-location) are resolved by
-// a follow-up wiring task (holomush-eykuh.3); nil is fail-closed at
-// scope-enforcement time, since the DSL evaluator treats missing attributes as
+// When a dispatch attribute resolver is wired (WithDispatchAttributeResolver),
+// the acting character's attributes (notably "location", backing
+// scope:own-location) are resolved and projected onto the dispatch context. A
+// resolver error or a nil resolver leaves Attributes nil, which is fail-closed
+// at scope-enforcement time: the DSL evaluator treats missing attributes as
 // false for every operator.
-func stampDispatch(ctx context.Context, actor core.Actor) context.Context {
+func (h *Host) stampDispatch(ctx context.Context, actor core.Actor) context.Context {
 	if actor.Kind != core.ActorCharacter || actor.ID == "" {
 		return ctx
 	}
+	subject := access.CharacterSubject(actor.ID)
+
+	var attrs map[string]string
+	if h.dispatchAttrResolver != nil {
+		raw, err := h.dispatchAttrResolver.ResolveSubject(ctx, subject)
+		if err != nil {
+			// Fail-closed: leave attrs nil so scope-enforcement denies rather
+			// than evaluating against a partial bag.
+			errutil.LogErrorContext(ctx, "resolve dispatch attributes failed", err, "subject", subject)
+		} else {
+			attrs = stringAttrs(raw)
+		}
+	}
+
 	return pluginauthz.WithDispatch(ctx, pluginauthz.DispatchContext{
-		Subject:    access.CharacterSubject(actor.ID),
-		Attributes: nil,
+		Subject:    subject,
+		Attributes: attrs,
 	})
+}
+
+// stringAttrs projects the string-valued keys of a resolved attribute bag into
+// a string map suitable for pluginauthz.DispatchContext.Attributes, dropping
+// non-string values (bools, slices, ...). It returns nil — never an empty
+// map — when the input has no string values, so "no attributes" stays == nil
+// and matches the default (no-resolver) behavior.
+func stringAttrs(raw map[string]any) map[string]string {
+	var out map[string]string
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			if out == nil {
+				out = make(map[string]string, len(raw))
+			}
+			out[k] = s
+		}
+	}
+	return out
 }

--- a/internal/plugin/goplugin/dispatch.go
+++ b/internal/plugin/goplugin/dispatch.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package goplugin
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// stampDispatch stamps the host-vouched pluginauthz.DispatchContext onto ctx
+// before plugin code runs, so in-process plugin invocations inherit the
+// host-vouched ABAC subject (INV-PLUGIN-51).
+//
+// Only character actors are vouched: when actor.Kind == core.ActorCharacter
+// and actor.ID is non-empty, the subject is access.CharacterSubject(actor.ID).
+// For any other actor kind (plugin, system, unset) the ctx is returned
+// unchanged — absence is fail-closed at scope-enforcement time.
+//
+// Attributes (the dispatch location backing scope:own-location) are resolved by
+// a follow-up wiring task (holomush-eykuh.3); nil is fail-closed at
+// scope-enforcement time, since the DSL evaluator treats missing attributes as
+// false for every operator.
+func stampDispatch(ctx context.Context, actor core.Actor) context.Context {
+	if actor.Kind != core.ActorCharacter || actor.ID == "" {
+		return ctx
+	}
+	return pluginauthz.WithDispatch(ctx, pluginauthz.DispatchContext{
+		Subject:    access.CharacterSubject(actor.ID),
+		Attributes: nil,
+	})
+}

--- a/internal/plugin/goplugin/dispatch_test.go
+++ b/internal/plugin/goplugin/dispatch_test.go
@@ -76,16 +76,92 @@ func TestDeliverEventStampsHostVouchedDispatchSubjectForCharacterActor(t *testin
 	assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
 }
 
+// newDispatchHost builds a Host with the given options and registers cleanup so
+// the host-owned emitTokenStore sweeper goroutine is stopped (package-level
+// goleak guard in emit_token_store_test.go).
+func newDispatchHost(t *testing.T, opts ...HostOption) *Host {
+	t.Helper()
+	h := NewHost(opts...)
+	t.Cleanup(func() { _ = h.Close(context.Background()) })
+	return h
+}
+
 func TestStampDispatchLeavesNonCharacterActorUnchanged(t *testing.T) {
 	base := context.Background()
+	h := newDispatchHost(t)
 
 	// Plugin actor: not vouched as a character subject.
-	got := stampDispatch(base, core.Actor{Kind: core.ActorPlugin, ID: core.NewULID().String()})
+	got := h.stampDispatch(base, core.Actor{Kind: core.ActorPlugin, ID: core.NewULID().String()})
 	_, ok := pluginauthz.DispatchForHost(got)
 	assert.False(t, ok, "plugin actor must not stamp a dispatch subject")
 
 	// Character actor with empty ID: fail-closed, no stamp.
-	got = stampDispatch(base, core.Actor{Kind: core.ActorCharacter, ID: ""})
+	got = h.stampDispatch(base, core.Actor{Kind: core.ActorCharacter, ID: ""})
 	_, ok = pluginauthz.DispatchForHost(got)
 	assert.False(t, ok, "empty-ID character actor must not stamp a dispatch subject")
+}
+
+// fakeAttrResolver is a test double for pluginauthz.AttributeResolver.
+type fakeAttrResolver struct {
+	attrs map[string]any
+	err   error
+}
+
+func (f fakeAttrResolver) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return f.attrs, f.err
+}
+
+// Verifies: INV-PLUGIN-51
+func TestStampDispatchResolvesCharacterAttributesWhenResolverWired(t *testing.T) {
+	charID := core.NewULID().String()
+	actor := core.Actor{Kind: core.ActorCharacter, ID: charID}
+
+	t.Run("projects string-valued attributes and drops non-strings", func(t *testing.T) {
+		h := newDispatchHost(t, WithDispatchAttributeResolver(fakeAttrResolver{
+			attrs: map[string]any{
+				"location":     "01LOC",
+				"has_location": true,
+				"roles":        []string{"player"},
+			},
+		}))
+		got := h.stampDispatch(context.Background(), actor)
+		dc, ok := pluginauthz.DispatchForHost(got)
+		require.True(t, ok, "character actor must stamp a dispatch subject")
+		assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
+		require.NotNil(t, dc.Attributes, "string attributes must be projected")
+		assert.Equal(t, "01LOC", dc.Attributes["location"], "location attribute projected")
+		_, hasBool := dc.Attributes["has_location"]
+		assert.False(t, hasBool, "non-string attribute (bool) must be dropped")
+		_, hasSlice := dc.Attributes["roles"]
+		assert.False(t, hasSlice, "non-string attribute (slice) must be dropped")
+	})
+
+	t.Run("resolver error is fail-closed with nil attributes", func(t *testing.T) {
+		h := newDispatchHost(t, WithDispatchAttributeResolver(fakeAttrResolver{
+			err: assert.AnError,
+		}))
+		got := h.stampDispatch(context.Background(), actor)
+		dc, ok := pluginauthz.DispatchForHost(got)
+		require.True(t, ok, "subject is still stamped on resolver error")
+		assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
+		assert.Nil(t, dc.Attributes, "resolver error leaves Attributes nil (fail-closed)")
+	})
+
+	t.Run("nil resolver leaves attributes nil", func(t *testing.T) {
+		h := newDispatchHost(t)
+		got := h.stampDispatch(context.Background(), actor)
+		dc, ok := pluginauthz.DispatchForHost(got)
+		require.True(t, ok, "character actor must stamp a dispatch subject")
+		assert.Nil(t, dc.Attributes, "no resolver wired ⇒ Attributes nil (current behavior)")
+	})
+
+	t.Run("resolver returning only non-string attributes yields nil", func(t *testing.T) {
+		h := newDispatchHost(t, WithDispatchAttributeResolver(fakeAttrResolver{
+			attrs: map[string]any{"has_location": false},
+		}))
+		got := h.stampDispatch(context.Background(), actor)
+		dc, ok := pluginauthz.DispatchForHost(got)
+		require.True(t, ok, "character actor must stamp a dispatch subject")
+		assert.Nil(t, dc.Attributes, "no string-valued attributes ⇒ nil, not empty map")
+	})
 }

--- a/internal/plugin/goplugin/dispatch_test.go
+++ b/internal/plugin/goplugin/dispatch_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package goplugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+)
+
+// loadStubBinaryPlugin loads a no-op binary plugin under the given name and
+// returns the grpc mock so tests can inspect the ctx the plugin sees.
+func loadStubBinaryPlugin(t *testing.T, name string) (*Host, *mockGRPCPluginClient) {
+	t.Helper()
+	grpcClient := &mockGRPCPluginClient{}
+	mockClient := &mockPluginClient{
+		protocol: &mockClientProtocol{pluginClient: grpcClient},
+	}
+	factory := &mockClientFactory{client: mockClient}
+	reg, _ := stubRegistryFor(name)
+	host := NewHostWithFactory(factory, WithIdentityRegistry(reg))
+	t.Cleanup(func() { _ = host.Close(context.Background()) })
+
+	tmpDir := t.TempDir()
+	require.NoError(t, createTempExecutable(tmpDir+"/"+name), "create temp executable")
+
+	manifest := &plugins.Manifest{
+		Name:    name,
+		Version: "1.0.0",
+		Type:    plugins.TypeBinary,
+		BinaryPlugin: &plugins.BinaryConfig{
+			Executable: name,
+		},
+	}
+	require.NoError(t, host.Load(context.Background(), manifest, tmpDir), "Load plugin")
+	return host, grpcClient
+}
+
+// Verifies: INV-PLUGIN-51
+func TestDeliverCommandStampsHostVouchedDispatchSubjectForCharacterActor(t *testing.T) {
+	host, grpcMock := loadStubBinaryPlugin(t, "test-plugin")
+
+	charID := core.NewULID().String()
+	ctx := core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: charID})
+
+	_, err := host.DeliverCommand(ctx, "test-plugin", pluginsdk.CommandRequest{})
+	require.NoError(t, err, "DeliverCommand")
+
+	dc, ok := pluginauthz.DispatchForHost(grpcMock.commandCtx)
+	require.True(t, ok, "dispatch context must be stamped on the delivery ctx")
+	assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
+	assert.Nil(t, dc.Attributes, "attributes resolved by a follow-up wiring task")
+}
+
+// Verifies: INV-PLUGIN-51
+func TestDeliverEventStampsHostVouchedDispatchSubjectForCharacterActor(t *testing.T) {
+	host, grpcMock := loadStubBinaryPlugin(t, "test-plugin")
+
+	charID := core.NewULID().String()
+	ctx := core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: charID})
+
+	_, err := host.DeliverEvent(ctx, "test-plugin", pluginsdk.Event{})
+	require.NoError(t, err, "DeliverEvent")
+
+	dc, ok := pluginauthz.DispatchForHost(grpcMock.eventCtx)
+	require.True(t, ok, "dispatch context must be stamped on the delivery ctx")
+	assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
+}
+
+func TestStampDispatchLeavesNonCharacterActorUnchanged(t *testing.T) {
+	base := context.Background()
+
+	// Plugin actor: not vouched as a character subject.
+	got := stampDispatch(base, core.Actor{Kind: core.ActorPlugin, ID: core.NewULID().String()})
+	_, ok := pluginauthz.DispatchForHost(got)
+	assert.False(t, ok, "plugin actor must not stamp a dispatch subject")
+
+	// Character actor with empty ID: fail-closed, no stamp.
+	got = stampDispatch(base, core.Actor{Kind: core.ActorCharacter, ID: ""})
+	_, ok = pluginauthz.DispatchForHost(got)
+	assert.False(t, ok, "empty-ID character actor must not stamp a dispatch subject")
+}

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -204,6 +204,15 @@ func WithAuditLogger(a pluginauthz.Auditor) HostOption {
 	return func(h *Host) { h.auditor = a }
 }
 
+// WithDispatchAttributeResolver configures the host with the resolver used to
+// populate DispatchContext.Attributes (notably "location") at command/event
+// delivery (holomush-eykuh.3). Without it, dispatch Attributes stay nil —
+// fail-closed at scope-enforcement time. The Lua host has the same option
+// (plugin-runtime-symmetry). Satisfied by access/policy/attribute.Resolver.
+func WithDispatchAttributeResolver(r pluginauthz.AttributeResolver) HostOption {
+	return func(h *Host) { h.dispatchAttrResolver = r }
+}
+
 // WithConfigOverrides threads the per-plugin server-provided config override
 // map (plugin name → key → value) into the host so it can be consulted at
 // plugin init time. Populated from PluginSubsystemConfig.PluginConfigOverrides.
@@ -245,6 +254,13 @@ type Host struct {
 	engine            types.AccessPolicyEngine
 	auditor           pluginauthz.Auditor
 	commandQuerier    *commandquery.Querier
+	// dispatchAttrResolver resolves the acting character's host-vouched dispatch
+	// attributes (notably "location") at delivery time, populating
+	// DispatchContext.Attributes (holomush-eykuh.3). Nil leaves Attributes nil,
+	// fail-closed at scope-enforcement time. Wired at construction via
+	// WithDispatchAttributeResolver — the production attribute resolver is built
+	// before the plugin host in setup/subsystem.go.
+	dispatchAttrResolver pluginauthz.AttributeResolver
 	// playerSettings / characterSettings / gameSettings back the plugin-
 	// partitioned GetSetting / SetSetting host RPCs (holomush-iokti.7). They are
 	// late-bound (SetSettingsStores) because the settings stores are assembled in
@@ -984,7 +1000,7 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginsdk.Ev
 		// Stamp the host-vouched dispatch subject onto the delivery ctx before any
 		// plugin code runs, so in-process plugin invocations inherit it
 		// (INV-PLUGIN-51). Only character actors are vouched; see stampDispatch.
-		callCtx = stampDispatch(callCtx, upstream)
+		callCtx = h.stampDispatch(callCtx, upstream)
 	}
 
 	// DeliverEvent has no player context — events are not dispatched on behalf of
@@ -1059,7 +1075,7 @@ func (h *Host) DeliverCommand(ctx context.Context, name string, cmd pluginsdk.Co
 		// Stamp the host-vouched dispatch subject onto the delivery ctx before any
 		// plugin code runs, so in-process plugin invocations inherit it
 		// (INV-PLUGIN-51). Only character actors are vouched; see stampDispatch.
-		callCtx = stampDispatch(callCtx, upstream)
+		callCtx = h.stampDispatch(callCtx, upstream)
 	}
 
 	// Carry the host-vouched owning player of the acting character onto the

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -981,6 +981,10 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginsdk.Ev
 			// re-anchor: ActorSystem may not emit as system identity; use plugin ULID
 			// storedActor already holds the plugin ULID from stampPluginActor above
 		}
+		// Stamp the host-vouched dispatch subject onto the delivery ctx before any
+		// plugin code runs, so in-process plugin invocations inherit it
+		// (INV-PLUGIN-51). Only character actors are vouched; see stampDispatch.
+		callCtx = stampDispatch(callCtx, upstream)
 	}
 
 	// DeliverEvent has no player context — events are not dispatched on behalf of
@@ -1052,6 +1056,10 @@ func (h *Host) DeliverCommand(ctx context.Context, name string, cmd pluginsdk.Co
 			// re-anchor: ActorSystem may not emit as system identity; use plugin ULID
 			// storedActor already holds the plugin ULID from stampPluginActor above
 		}
+		// Stamp the host-vouched dispatch subject onto the delivery ctx before any
+		// plugin code runs, so in-process plugin invocations inherit it
+		// (INV-PLUGIN-51). Only character actors are vouched; see stampDispatch.
+		callCtx = stampDispatch(callCtx, upstream)
 	}
 
 	// Carry the host-vouched owning player of the acting character onto the

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -796,7 +796,7 @@ func (h *Host) Load(ctx context.Context, manifest *plugins.Manifest, dir string)
 	if grpcPlugin.broker != nil {
 		hostBrokerID := nextBrokerID
 		nextBrokerID++
-		go grpcPlugin.broker.AcceptAndServe(hostBrokerID, newPluginHostServiceServer(h, manifest.Name))
+		go grpcPlugin.broker.AcceptAndServe(hostBrokerID, newPluginHostServiceServer(h, manifest))
 		requiredServices[pluginsdk.PluginHostServiceName] = fmt.Sprintf("broker:%d", hostBrokerID)
 	}
 	if len(manifest.RequiredServiceNames()) > 0 && grpcPlugin.broker != nil && h.registry != nil {

--- a/internal/plugin/goplugin/host_capability_servers_test.go
+++ b/internal/plugin/goplugin/host_capability_servers_test.go
@@ -4,9 +4,14 @@
 package goplugin
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	plugins "github.com/holomush/holomush/internal/plugin"
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
 )
 
 // TestHostBrokerServerServesFocusService pins the broker-server contract: the
@@ -16,7 +21,7 @@ import (
 // that a binary plugin can reach each service over the one broker conn.
 func TestHostBrokerServerServesFocusService(t *testing.T) {
 	h := NewHost() // constructor at internal/plugin/goplugin/host.go:280
-	build := newPluginHostServiceServer(h, "test-plugin")
+	build := newPluginHostServiceServer(h, &plugins.Manifest{Name: "test-plugin"})
 	srv := build(nil)
 	t.Cleanup(srv.Stop)
 
@@ -34,4 +39,30 @@ func TestHostBrokerServerServesFocusService(t *testing.T) {
 	// (holomush-eykuh.1, Task 12): only the capability-scoped host.v1 services
 	// are registered on the broker now.
 	require.NotContains(t, info, "holomush.plugin.v1.PluginHostService")
+}
+
+// TestBinaryHostServerDeniesUndeclaredCapability proves the capability
+// interceptor is installed on the binary broker server: a plugin whose manifest
+// declares NO capabilities is denied (fail-closed) when it calls a gated host.v1
+// method (KVService.Get) over the real broker conn. The denial surfaces as a
+// gRPC error carrying the CAPABILITY_NOT_DECLARED reason. The Lua-runtime mirror
+// is internal/plugin/lua.TestLuaHostServerDeniesUndeclaredCapability; both stand
+// up the REAL per-plugin server and dial the ACTUALLY-INSTALLED interceptor, so
+// together they prove the trust gate is identical across runtimes.
+//
+// Verifies: INV-PLUGIN-45
+func TestBinaryHostServerDeniesUndeclaredCapability(t *testing.T) {
+	h := NewHost()
+	// Manifest declares no capability requires — kv is therefore undeclared.
+	build := newPluginHostServiceServer(h, &plugins.Manifest{Name: "no-caps-plugin"})
+	srv := build(nil)
+
+	conn, err := plugins.NewInProcessConn(srv)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := hostv1.NewKVServiceClient(conn)
+	_, err = client.Get(context.Background(), &hostv1.GetRequest{Key: "k"})
+	require.Error(t, err, "undeclared capability call must be denied by the interceptor")
+	assert.Contains(t, err.Error(), "plugin did not declare capability")
 }

--- a/internal/plugin/goplugin/host_service.go
+++ b/internal/plugin/goplugin/host_service.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/hostcap"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 )
@@ -25,10 +26,26 @@ import (
 // registration is hostcap.RegisterCapabilities with the BinaryDefaultSet. That
 // set omits World/Property/Session — they have no binary consumer in this
 // sub-spec — so they are deliberately NOT registered here.
-func newPluginHostServiceServer(host *Host, pluginName string) func([]grpc.ServerOption) *grpc.Server {
+//
+// The server chains the host-capability interceptor (holomush-eykuh.3): one
+// interceptor per plugin, closing over that plugin's declared capability set via
+// hostcap.DeclaredAccessFromManifest. The SAME helper + interceptor are installed
+// on the Lua per-plugin server (internal/plugin/lua/bufconn_endpoint.go), so the
+// declaration + access-class trust gate is identical across runtimes
+// (plugin-runtime-symmetry, INV-PLUGIN-45/49). Engine/Auditor are sourced
+// identically on both runtimes through the hostcap.HostCapabilities port
+// (host.AccessEngine()/Auditor()); the static half (this task) does not read
+// them — Task 10 wires the policy/scope half.
+func newPluginHostServiceServer(host *Host, manifest *plugins.Manifest) func([]grpc.ServerOption) *grpc.Server {
 	return func(opts []grpc.ServerOption) *grpc.Server {
-		server := grpc.NewServer(opts...)
-		hostcap.RegisterCapabilities(server, hostcap.NewBase(host, pluginName), hostcap.BinaryDefaultSet)
+		ic := hostcap.NewCapabilityInterceptor(hostcap.InterceptorDeps{
+			Engine:         host.AccessEngine(),
+			Auditor:        host.Auditor(),
+			PluginName:     manifest.Name,
+			DeclaredAccess: hostcap.DeclaredAccessFromManifest(manifest),
+		})
+		server := grpc.NewServer(append(opts, grpc.ChainUnaryInterceptor(ic))...)
+		hostcap.RegisterCapabilities(server, hostcap.NewBase(host, manifest.Name), hostcap.BinaryDefaultSet)
 		return server
 	}
 }

--- a/internal/plugin/goplugin/host_service_command_test.go
+++ b/internal/plugin/goplugin/host_service_command_test.go
@@ -10,11 +10,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	access "github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/commandquery"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/pkg/errutil"
 	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
 )
+
+// theChar is the dispatch subject's character used across the non-spoof
+// command-registry tests; the wire character_id matches it (it is ignored for
+// authorization regardless — see the spoof tests).
+const theChar = "01HCHAR0000000000000000ZZZ"
+
+// dispatchCtx stamps a host-vouched dispatch subject for theChar onto a fresh
+// ctx, mirroring what DeliverCommand/DeliverEvent do before plugin code runs
+// (INV-PLUGIN-51).
+func dispatchCtx() context.Context {
+	return pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{
+		Subject: access.CharacterSubject(theChar),
+	})
+}
 
 func TestPluginHostServiceListCommandsFiltersByCharacter(t *testing.T) {
 	reg := command.NewRegistry()
@@ -26,7 +43,7 @@ func TestPluginHostServiceListCommandsFiltersByCharacter(t *testing.T) {
 		host:       &Host{commandQuerier: q},
 		pluginName: "test-plugin",
 	}
-	resp, err := srv.ListCommands(context.Background(), &hostv1.ListCommandsRequest{
+	resp, err := srv.ListCommands(dispatchCtx(), &hostv1.ListCommandsRequest{
 		CharacterId: "01HCHAR0000000000000000ZZZ",
 	})
 	require.NoError(t, err)
@@ -36,7 +53,7 @@ func TestPluginHostServiceListCommandsFiltersByCharacter(t *testing.T) {
 
 func TestPluginHostServiceListCommandsFailsClosedWithoutQuerier(t *testing.T) {
 	srv := &pluginHostServiceServer{host: &Host{}, pluginName: "test-plugin"}
-	_, err := srv.ListCommands(context.Background(), &hostv1.ListCommandsRequest{
+	_, err := srv.ListCommands(dispatchCtx(), &hostv1.ListCommandsRequest{
 		CharacterId: "01HCHAR0000000000000000ZZZ",
 	})
 	require.Error(t, err)
@@ -49,7 +66,7 @@ func TestPluginHostServiceGetCommandHelpReturnsDetailForGranted(t *testing.T) {
 	q := commandquery.New(reg, policytest.AllowAllEngine(), command.NewAliasCache())
 
 	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
-	resp, err := srv.GetCommandHelp(context.Background(), &hostv1.GetCommandHelpRequest{
+	resp, err := srv.GetCommandHelp(dispatchCtx(), &hostv1.GetCommandHelpRequest{
 		Name:        "look",
 		CharacterId: "01HCHAR0000000000000000ZZZ",
 	})
@@ -68,7 +85,7 @@ func TestPluginHostServiceGetCommandHelpDeniesUngranted(t *testing.T) {
 	q := commandquery.New(reg, policytest.DenyAllEngine(), command.NewAliasCache())
 
 	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
-	_, err := srv.GetCommandHelp(context.Background(), &hostv1.GetCommandHelpRequest{
+	_, err := srv.GetCommandHelp(dispatchCtx(), &hostv1.GetCommandHelpRequest{
 		Name:        "scene",
 		CharacterId: "01HCHAR0000000000000000ZZZ",
 	})
@@ -77,9 +94,68 @@ func TestPluginHostServiceGetCommandHelpDeniesUngranted(t *testing.T) {
 
 func TestPluginHostServiceGetCommandHelpFailsClosedWithoutQuerier(t *testing.T) {
 	srv := &pluginHostServiceServer{host: &Host{}, pluginName: "test-plugin"}
-	_, err := srv.GetCommandHelp(context.Background(), &hostv1.GetCommandHelpRequest{
+	_, err := srv.GetCommandHelp(dispatchCtx(), &hostv1.GetCommandHelpRequest{
 		Name:        "look",
 		CharacterId: "01HCHAR0000000000000000ZZZ",
 	})
 	require.Error(t, err)
+}
+
+// Verifies: INV-PLUGIN-51
+func TestListCommandsIgnoresWireCharacterIDUsesDispatch(t *testing.T) {
+	reg := command.NewRegistry()
+	require.NoError(t, reg.Register(command.NewTestEntry(command.CommandEntryConfig{Name: "look", PluginName: "core", Source: "core"})))
+	dispatchChar := "01HCHARDISPATCH00000000ZZZ"
+	// Grant the command ONLY for the dispatch subject; the wire id is a DIFFERENT char.
+	eng := policytest.NewGrantEngine()
+	eng.GrantCommandExecution(access.CharacterSubject(dispatchChar), "look")
+	q := commandquery.New(reg, eng, command.NewAliasCache())
+	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
+
+	ctx := pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{Subject: access.CharacterSubject(dispatchChar)})
+	resp, err := srv.ListCommands(ctx, &hostv1.ListCommandsRequest{CharacterId: "01HCHARWIRESPOOF000000ZZZ"}) // different wire id
+	require.NoError(t, err)
+	require.Len(t, resp.GetCommands(), 1, "command list must reflect the DISPATCH subject's grants, not the wire character_id")
+	assert.Equal(t, "look", resp.GetCommands()[0].GetName())
+}
+
+func TestListCommandsFailsClosedWithoutDispatch(t *testing.T) {
+	q := commandquery.New(command.NewRegistry(), policytest.AllowAllEngine(), command.NewAliasCache())
+	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
+	_, err := srv.ListCommands(context.Background(), &hostv1.ListCommandsRequest{CharacterId: "01HCHAR0000000000000000ZZZ"})
+	errutil.AssertErrorCode(t, err, "NO_DISPATCH_SUBJECT")
+}
+
+// Verifies: INV-PLUGIN-51
+func TestGetCommandHelpIgnoresWireCharacterIDUsesDispatch(t *testing.T) {
+	reg := command.NewRegistry()
+	require.NoError(t, reg.Register(command.NewTestEntry(command.CommandEntryConfig{
+		Name: "scene", Help: "scene help", PluginName: "core-scenes", Source: "core-scenes",
+		Capabilities: []command.Capability{{Action: "write", Resource: "scene", Scope: command.ScopeLocal}},
+	})))
+	dispatchChar := "01HCHARDISPATCH00000000ZZZ"
+	// Grant Layer 1 + Layer 2 ONLY for the dispatch subject; the wire id is a DIFFERENT char.
+	eng := policytest.NewGrantEngine()
+	eng.GrantCommandExecution(access.CharacterSubject(dispatchChar), "scene")
+	eng.Grant(access.CharacterSubject(dispatchChar), "write", "scene")
+	q := commandquery.New(reg, eng, command.NewAliasCache())
+	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
+
+	ctx := pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{Subject: access.CharacterSubject(dispatchChar)})
+	resp, err := srv.GetCommandHelp(ctx, &hostv1.GetCommandHelpRequest{
+		Name:        "scene",
+		CharacterId: "01HCHARWIRESPOOF000000ZZZ", // different wire id
+	})
+	require.NoError(t, err, "help detail must reflect the DISPATCH subject's grants, not the wire character_id")
+	assert.Equal(t, "scene", resp.GetName())
+}
+
+func TestGetCommandHelpFailsClosedWithoutDispatch(t *testing.T) {
+	q := commandquery.New(command.NewRegistry(), policytest.AllowAllEngine(), command.NewAliasCache())
+	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
+	_, err := srv.GetCommandHelp(context.Background(), &hostv1.GetCommandHelpRequest{
+		Name:        "look",
+		CharacterId: "01HCHAR0000000000000000ZZZ",
+	})
+	errutil.AssertErrorCode(t, err, "NO_DISPATCH_SUBJECT")
 }

--- a/internal/plugin/goplugin/host_service_command_test.go
+++ b/internal/plugin/goplugin/host_service_command_test.go
@@ -9,28 +9,53 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 
 	access "github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/commandquery"
-	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/pkg/errutil"
 	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
 )
 
-// theChar is the dispatch subject's character used across the non-spoof
-// command-registry tests; the wire character_id matches it (it is ignored for
-// authorization regardless — see the spoof tests).
+// theChar is the dispatch actor's character ULID used across the non-spoof
+// command-registry tests. After the holomush-eykuh.3 fix the binary
+// command-registry handlers derive the ABAC subject from the host-vouched actor
+// recovered via LookupActor (the dispatch token in incoming metadata), NOT from
+// the wire character_id, which is ignored for authorization regardless.
 const theChar = "01HCHAR0000000000000000ZZZ"
 
-// dispatchCtx stamps a host-vouched dispatch subject for theChar onto a fresh
-// ctx, mirroring what DeliverCommand/DeliverEvent do before plugin code runs
-// (INV-PLUGIN-51).
-func dispatchCtx() context.Context {
-	return pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{
-		Subject: access.CharacterSubject(theChar),
-	})
+// wireSpoof is a DIFFERENT character ULID supplied on the wire character_id to
+// prove the handlers never trust it (the proto field is structurally unused).
+const wireSpoof = "01HCHARWIRESPOOF000000ZZZ"
+
+// commandTestServer builds a pluginHostServiceServer backed by a real *Host (so
+// the binary tokenStore is wired) with the supplied command querier. Returning
+// the host lets callers issue dispatch tokens against its tokenStore.
+func commandTestServer(t *testing.T, q *commandquery.Querier) *pluginHostServiceServer {
+	t.Helper()
+	h := NewHost(WithCommandQuerier(q))
+	t.Cleanup(func() { _ = h.Close(context.Background()) })
+	return &pluginHostServiceServer{host: h, pluginName: "test-plugin"}
+}
+
+// dispatchTokenCtx issues a host-vouched dispatch token for the given character
+// actor and returns an incoming-metadata context carrying it — the binary
+// equivalent of what DeliverCommand/DeliverEvent stamp before plugin code runs
+// (INV-PLUGIN-51). LookupActor recovers the actor from this token; the wire
+// character_id is irrelevant.
+func dispatchTokenCtx(t *testing.T, srv *pluginHostServiceServer, charID string) context.Context {
+	t.Helper()
+	actor := core.Actor{Kind: core.ActorCharacter, ID: charID}
+	token, err := srv.host.tokenStore.Issue(srv.pluginName, actor, "")
+	require.NoError(t, err, "failed to issue dispatch token")
+	t.Cleanup(func() { srv.host.tokenStore.Revoke(token) })
+	return metadata.NewIncomingContext(
+		context.Background(),
+		metadata.New(map[string]string{"x-holomush-emit-token": token}),
+	)
 }
 
 func TestPluginHostServiceListCommandsFiltersByCharacter(t *testing.T) {
@@ -39,12 +64,9 @@ func TestPluginHostServiceListCommandsFiltersByCharacter(t *testing.T) {
 	require.NoError(t, reg.Register(look))
 	q := commandquery.New(reg, policytest.AllowAllEngine(), command.NewAliasCache())
 
-	srv := &pluginHostServiceServer{
-		host:       &Host{commandQuerier: q},
-		pluginName: "test-plugin",
-	}
-	resp, err := srv.ListCommands(dispatchCtx(), &hostv1.ListCommandsRequest{
-		CharacterId: "01HCHAR0000000000000000ZZZ",
+	srv := commandTestServer(t, q)
+	resp, err := srv.ListCommands(dispatchTokenCtx(t, srv, theChar), &hostv1.ListCommandsRequest{
+		CharacterId: wireSpoof,
 	})
 	require.NoError(t, err)
 	require.Len(t, resp.GetCommands(), 1)
@@ -53,8 +75,8 @@ func TestPluginHostServiceListCommandsFiltersByCharacter(t *testing.T) {
 
 func TestPluginHostServiceListCommandsFailsClosedWithoutQuerier(t *testing.T) {
 	srv := &pluginHostServiceServer{host: &Host{}, pluginName: "test-plugin"}
-	_, err := srv.ListCommands(dispatchCtx(), &hostv1.ListCommandsRequest{
-		CharacterId: "01HCHAR0000000000000000ZZZ",
+	_, err := srv.ListCommands(context.Background(), &hostv1.ListCommandsRequest{
+		CharacterId: theChar,
 	})
 	require.Error(t, err)
 }
@@ -65,10 +87,10 @@ func TestPluginHostServiceGetCommandHelpReturnsDetailForGranted(t *testing.T) {
 	require.NoError(t, reg.Register(look))
 	q := commandquery.New(reg, policytest.AllowAllEngine(), command.NewAliasCache())
 
-	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
-	resp, err := srv.GetCommandHelp(dispatchCtx(), &hostv1.GetCommandHelpRequest{
+	srv := commandTestServer(t, q)
+	resp, err := srv.GetCommandHelp(dispatchTokenCtx(t, srv, theChar), &hostv1.GetCommandHelpRequest{
 		Name:        "look",
-		CharacterId: "01HCHAR0000000000000000ZZZ",
+		CharacterId: wireSpoof,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "look", resp.GetName())
@@ -84,19 +106,19 @@ func TestPluginHostServiceGetCommandHelpDeniesUngranted(t *testing.T) {
 	require.NoError(t, reg.Register(scene))
 	q := commandquery.New(reg, policytest.DenyAllEngine(), command.NewAliasCache())
 
-	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
-	_, err := srv.GetCommandHelp(dispatchCtx(), &hostv1.GetCommandHelpRequest{
+	srv := commandTestServer(t, q)
+	_, err := srv.GetCommandHelp(dispatchTokenCtx(t, srv, theChar), &hostv1.GetCommandHelpRequest{
 		Name:        "scene",
-		CharacterId: "01HCHAR0000000000000000ZZZ",
+		CharacterId: wireSpoof,
 	})
 	require.Error(t, err)
 }
 
 func TestPluginHostServiceGetCommandHelpFailsClosedWithoutQuerier(t *testing.T) {
 	srv := &pluginHostServiceServer{host: &Host{}, pluginName: "test-plugin"}
-	_, err := srv.GetCommandHelp(dispatchCtx(), &hostv1.GetCommandHelpRequest{
+	_, err := srv.GetCommandHelp(context.Background(), &hostv1.GetCommandHelpRequest{
 		Name:        "look",
-		CharacterId: "01HCHAR0000000000000000ZZZ",
+		CharacterId: theChar,
 	})
 	require.Error(t, err)
 }
@@ -110,20 +132,24 @@ func TestListCommandsIgnoresWireCharacterIDUsesDispatch(t *testing.T) {
 	eng := policytest.NewGrantEngine()
 	eng.GrantCommandExecution(access.CharacterSubject(dispatchChar), "look")
 	q := commandquery.New(reg, eng, command.NewAliasCache())
-	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
+	srv := commandTestServer(t, q)
 
-	ctx := pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{Subject: access.CharacterSubject(dispatchChar)})
-	resp, err := srv.ListCommands(ctx, &hostv1.ListCommandsRequest{CharacterId: "01HCHARWIRESPOOF000000ZZZ"}) // different wire id
+	ctx := dispatchTokenCtx(t, srv, dispatchChar)
+	resp, err := srv.ListCommands(ctx, &hostv1.ListCommandsRequest{CharacterId: wireSpoof}) // different wire id
 	require.NoError(t, err)
-	require.Len(t, resp.GetCommands(), 1, "command list must reflect the DISPATCH subject's grants, not the wire character_id")
+	require.Len(t, resp.GetCommands(), 1, "command list must reflect the host-vouched DISPATCH actor's grants, not the wire character_id")
 	assert.Equal(t, "look", resp.GetCommands()[0].GetName())
 }
 
+// TestListCommandsFailsClosedWithoutDispatch asserts the fail-closed path when no
+// host-vouched actor is recoverable: with no dispatch token in the incoming
+// metadata, LookupActor fails closed (EMIT_TOKEN_MISSING) and the handler never
+// reaches the querier — no command visibility leaks to an unauthenticated caller.
 func TestListCommandsFailsClosedWithoutDispatch(t *testing.T) {
 	q := commandquery.New(command.NewRegistry(), policytest.AllowAllEngine(), command.NewAliasCache())
-	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
-	_, err := srv.ListCommands(context.Background(), &hostv1.ListCommandsRequest{CharacterId: "01HCHAR0000000000000000ZZZ"})
-	errutil.AssertErrorCode(t, err, "NO_DISPATCH_SUBJECT")
+	srv := commandTestServer(t, q)
+	_, err := srv.ListCommands(context.Background(), &hostv1.ListCommandsRequest{CharacterId: theChar})
+	errutil.AssertErrorCode(t, err, "EMIT_TOKEN_MISSING")
 }
 
 // Verifies: INV-PLUGIN-51
@@ -139,23 +165,26 @@ func TestGetCommandHelpIgnoresWireCharacterIDUsesDispatch(t *testing.T) {
 	eng.GrantCommandExecution(access.CharacterSubject(dispatchChar), "scene")
 	eng.Grant(access.CharacterSubject(dispatchChar), "write", "scene")
 	q := commandquery.New(reg, eng, command.NewAliasCache())
-	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
+	srv := commandTestServer(t, q)
 
-	ctx := pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{Subject: access.CharacterSubject(dispatchChar)})
+	ctx := dispatchTokenCtx(t, srv, dispatchChar)
 	resp, err := srv.GetCommandHelp(ctx, &hostv1.GetCommandHelpRequest{
 		Name:        "scene",
-		CharacterId: "01HCHARWIRESPOOF000000ZZZ", // different wire id
+		CharacterId: wireSpoof, // different wire id
 	})
-	require.NoError(t, err, "help detail must reflect the DISPATCH subject's grants, not the wire character_id")
+	require.NoError(t, err, "help detail must reflect the host-vouched DISPATCH actor's grants, not the wire character_id")
 	assert.Equal(t, "scene", resp.GetName())
 }
 
+// TestGetCommandHelpFailsClosedWithoutDispatch asserts the fail-closed path: no
+// dispatch token ⇒ LookupActor returns EMIT_TOKEN_MISSING and the handler refuses
+// before any querier access.
 func TestGetCommandHelpFailsClosedWithoutDispatch(t *testing.T) {
 	q := commandquery.New(command.NewRegistry(), policytest.AllowAllEngine(), command.NewAliasCache())
-	srv := &pluginHostServiceServer{host: &Host{commandQuerier: q}, pluginName: "test-plugin"}
+	srv := commandTestServer(t, q)
 	_, err := srv.GetCommandHelp(context.Background(), &hostv1.GetCommandHelpRequest{
 		Name:        "look",
-		CharacterId: "01HCHAR0000000000000000ZZZ",
+		CharacterId: theChar,
 	})
-	errutil.AssertErrorCode(t, err, "NO_DISPATCH_SUBJECT")
+	errutil.AssertErrorCode(t, err, "EMIT_TOKEN_MISSING")
 }

--- a/internal/plugin/goplugin/host_test.go
+++ b/internal/plugin/goplugin/host_test.go
@@ -1417,7 +1417,7 @@ func TestSDKActorKindToCoreDefaultsToPluginKind(t *testing.T) {
 }
 
 func TestNewPluginHostServiceServerRegistersCapabilityServices(t *testing.T) {
-	factory := newPluginHostServiceServer(NewHost(), "core-scenes")
+	factory := newPluginHostServiceServer(NewHost(), &plugins.Manifest{Name: "core-scenes"})
 
 	server := factory(nil)
 	t.Cleanup(server.Stop)

--- a/internal/plugin/help_integration_test.go
+++ b/internal/plugin/help_integration_test.go
@@ -28,6 +28,17 @@ import (
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 )
 
+// helpActorCtx stamps the host-vouched ActorCharacter on ctx exactly as the
+// production command dispatcher does (internal/command/dispatcher.go), so the
+// command-registry shims (list_commands/get_command_help) see the host-vouched
+// dispatch subject (INV-PLUGIN-51, holomush-eykuh.3). These tests call
+// LuaHost.DeliverCommand directly, bypassing the dispatcher, so they must stamp
+// the acting character themselves — the shims no longer trust the
+// CommandRequest.CharacterID arg.
+func helpActorCtx(ctx context.Context, charID string) context.Context {
+	return core.WithActor(ctx, core.Actor{Kind: core.ActorCharacter, ID: charID})
+}
+
 // mockHelpCommandRegistry provides test commands for the help plugins.
 type mockHelpCommandRegistry struct{}
 
@@ -107,7 +118,7 @@ var _ = Describe("Help Plugin Integration", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -126,7 +137,7 @@ var _ = Describe("Help Plugin Integration", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "say",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -145,7 +156,7 @@ var _ = Describe("Help Plugin Integration", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "nonexistent",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -165,7 +176,7 @@ var _ = Describe("Help Plugin Integration", func() {
 			// and "dig" ("Create a new room or exit"), but not "look". The help
 			// plugin searches the name and help fields (not usage), so this exercises
 			// help-field matching with selectivity.
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "search room",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -258,7 +269,7 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -281,7 +292,7 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "search room",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -313,7 +324,7 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -339,7 +350,7 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -364,7 +375,7 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, "01HTEST000000000000000CHAR"), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "search look",
 				CharacterID: "01HTEST000000000000000CHAR",
@@ -414,7 +425,7 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+			resp, err := fixture.LuaHost.DeliverCommand(helpActorCtx(ctx, charID), "core-help", pluginsdk.CommandRequest{
 				Command:     "help",
 				Args:        "",
 				CharacterID: charID,

--- a/internal/plugin/hostcap/descriptor.go
+++ b/internal/plugin/hostcap/descriptor.go
@@ -39,9 +39,11 @@ type CapabilityDescriptor struct {
 
 // Descriptors is the single host-owned source for M1/M2/M3 per-method metadata,
 // keyed by capability token. It is the per-method companion to the sub-spec-2
-// token->service registry. Scope-eligible rows and the remaining capability
-// tokens (focus, emit, audit, stream-history, stream-subscription, session,
-// property, world, log) are added in Task 4.
+// token->service registry, covering every served host.v1 capability token (the
+// fail-closed interceptor denies UNCLASSIFIED_CAPABILITY_METHOD for any
+// classified method with no entry here). Scope-eligibility and the per-method
+// extractors for the read/write rows beyond world.mutation are layered on by
+// later tasks (.10/.11).
 var Descriptors = map[string]CapabilityDescriptor{
 	"eval": {Token: "eval", Methods: map[string]MethodDescriptor{
 		"Evaluate": {Action: "evaluate", Resource: "policy", Class: ClassRead},
@@ -88,6 +90,51 @@ var Descriptors = map[string]CapabilityDescriptor{
 				return r.GetLocationId(), r.GetLocationId() != ""
 			},
 		},
+	}},
+	"world.query": {Token: "world.query", Methods: map[string]MethodDescriptor{
+		"QueryLocation":           {Action: "read", Resource: "location", Class: ClassRead},
+		"QueryCharacter":          {Action: "read", Resource: "character", Class: ClassRead},
+		"QueryLocationCharacters": {Action: "read", Resource: "location", Class: ClassRead},
+		"QueryObject":             {Action: "read", Resource: "object", Class: ClassRead},
+		"FindLocation":            {Action: "read", Resource: "location", Class: ClassRead},
+	}},
+	"property": {Token: "property", Methods: map[string]MethodDescriptor{
+		"GetProperty": {Action: "read", Resource: "property", Class: ClassRead},
+		"SetProperty": {Action: "write", Resource: "property", Class: ClassWrite},
+	}},
+	"session": {Token: "session", Methods: map[string]MethodDescriptor{
+		"FindByName":       {Action: "read", Resource: "session", Class: ClassRead},
+		"ListActive":       {Action: "list", Resource: "session", Class: ClassRead},
+		"SetLastWhispered": {Action: "write", Resource: "session", Class: ClassWrite},
+	}},
+	"session.admin": {Token: "session.admin", Methods: map[string]MethodDescriptor{
+		"Broadcast":  {Action: "write", Resource: "session", Class: ClassWrite},
+		"Disconnect": {Action: "write", Resource: "session", Class: ClassWrite},
+	}},
+	"focus": {Token: "focus", Methods: map[string]MethodDescriptor{
+		"JoinFocus":          {Action: "write", Resource: "focus", Class: ClassWrite},
+		"LeaveFocus":         {Action: "write", Resource: "focus", Class: ClassWrite},
+		"LeaveFocusByTarget": {Action: "write", Resource: "focus", Class: ClassWrite},
+		"PresentFocus":       {Action: "write", Resource: "focus", Class: ClassWrite},
+		"SetConnectionFocus": {Action: "write", Resource: "focus", Class: ClassWrite},
+		"GetConnectionFocus": {Action: "read", Resource: "focus", Class: ClassRead},
+		"AutoFocusOnJoin":    {Action: "write", Resource: "focus", Class: ClassWrite},
+		"IsAnyConnFocused":   {Action: "read", Resource: "focus", Class: ClassRead},
+	}},
+	"emit": {Token: "emit", Methods: map[string]MethodDescriptor{
+		"EmitEvent":        {Action: "write", Resource: "event", Class: ClassWrite},
+		"RequestEmitToken": {Action: "write", Resource: "event", Class: ClassWrite},
+		"RegisterEmitType": {Action: "write", Resource: "event", Class: ClassWrite},
+	}},
+	"stream.history": {Token: "stream.history", Methods: map[string]MethodDescriptor{
+		"QueryStreamHistory": {Action: "read", Resource: "stream", Class: ClassRead},
+	}},
+	"stream.subscription": {Token: "stream.subscription", Methods: map[string]MethodDescriptor{
+		"AddSessionStream":    {Action: "write", Resource: "stream", Class: ClassWrite},
+		"RemoveSessionStream": {Action: "write", Resource: "stream", Class: ClassWrite},
+	}},
+	"audit": {Token: "audit", Methods: map[string]MethodDescriptor{
+		"DecryptOwnAuditRows": {Action: "read", Resource: "audit", Class: ClassRead},
 	}},
 }
 

--- a/internal/plugin/hostcap/descriptor.go
+++ b/internal/plugin/hostcap/descriptor.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap
+
+// OperationClass is the read/write class of a host.v1 method (M2).
+type OperationClass int
+
+const (
+	// ClassRead marks a host method that only reads state.
+	ClassRead OperationClass = iota
+	// ClassWrite marks a host method that mutates state.
+	ClassWrite
+)
+
+// ScopedResourceFn extracts the ABAC resource id a request touches, for the
+// scope condition (M3). Returns "" when no resource is in play.
+type ScopedResourceFn func(req any) (resourceID string, ok bool)
+
+// MethodDescriptor is the host-owned per-method classification.
+type MethodDescriptor struct {
+	Action   string           // ABAC action, e.g. "write"
+	Resource string           // ABAC resource type, e.g. "location"
+	Class    OperationClass   // read | write (M2)
+	Scopes   []string         // supported scope tokens (M3); empty => not scope-eligible
+	Extract  ScopedResourceFn // required iff len(Scopes) > 0 (M3, INV-PLUGIN-52)
+}
+
+// CapabilityDescriptor is the host-owned table for one capability token.
+type CapabilityDescriptor struct {
+	Token   string
+	Methods map[string]MethodDescriptor
+}
+
+// Descriptors is the single host-owned source for M1/M2/M3 per-method metadata,
+// keyed by capability token. It is the per-method companion to the sub-spec-2
+// token->service registry. Scope-eligible rows and the remaining capability
+// tokens (focus, emit, audit, stream-history, stream-subscription, session,
+// property, world, log) are added in Task 4.
+var Descriptors = map[string]CapabilityDescriptor{
+	"eval": {Token: "eval", Methods: map[string]MethodDescriptor{
+		"Evaluate": {Action: "evaluate", Resource: "policy", Class: ClassRead},
+	}},
+	"settings": {Token: "settings", Methods: map[string]MethodDescriptor{
+		"GetSetting": {Action: "read", Resource: "setting", Class: ClassRead},
+		"SetSetting": {Action: "write", Resource: "setting", Class: ClassWrite},
+	}},
+	"kv": {Token: "kv", Methods: map[string]MethodDescriptor{
+		"KVGet":    {Action: "read", Resource: "kv", Class: ClassRead},
+		"KVSet":    {Action: "write", Resource: "kv", Class: ClassWrite},
+		"KVDelete": {Action: "write", Resource: "kv", Class: ClassWrite},
+	}},
+	"command-registry": {Token: "command-registry", Methods: map[string]MethodDescriptor{
+		"ListCommands":   {Action: "list", Resource: "command", Class: ClassRead},
+		"GetCommandHelp": {Action: "read", Resource: "command", Class: ClassRead},
+	}},
+}

--- a/internal/plugin/hostcap/descriptor.go
+++ b/internal/plugin/hostcap/descriptor.go
@@ -51,9 +51,9 @@ var Descriptors = map[string]CapabilityDescriptor{
 		"SetSetting": {Action: "write", Resource: "setting", Class: ClassWrite},
 	}},
 	"kv": {Token: "kv", Methods: map[string]MethodDescriptor{
-		"KVGet":    {Action: "read", Resource: "kv", Class: ClassRead},
-		"KVSet":    {Action: "write", Resource: "kv", Class: ClassWrite},
-		"KVDelete": {Action: "write", Resource: "kv", Class: ClassWrite},
+		"Get":    {Action: "read", Resource: "kv", Class: ClassRead},
+		"Set":    {Action: "write", Resource: "kv", Class: ClassWrite},
+		"Delete": {Action: "write", Resource: "kv", Class: ClassWrite},
 	}},
 	"command-registry": {Token: "command-registry", Methods: map[string]MethodDescriptor{
 		"ListCommands":   {Action: "list", Resource: "command", Class: ClassRead},

--- a/internal/plugin/hostcap/descriptor.go
+++ b/internal/plugin/hostcap/descriptor.go
@@ -3,6 +3,11 @@
 
 package hostcap
 
+import (
+	plugins "github.com/holomush/holomush/internal/plugin"
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
 // OperationClass is the read/write class of a host.v1 method (M2).
 type OperationClass int
 
@@ -54,4 +59,55 @@ var Descriptors = map[string]CapabilityDescriptor{
 		"ListCommands":   {Action: "list", Resource: "command", Class: ClassRead},
 		"GetCommandHelp": {Action: "read", Resource: "command", Class: ClassRead},
 	}},
+	"world.mutation": {Token: "world.mutation", Methods: map[string]MethodDescriptor{
+		// CreateLocation has no pre-existing location operand → not scope-eligible.
+		"CreateLocation": {Action: "write", Resource: "location", Class: ClassWrite},
+		// CreateExit acts on its source location (from_id); own-location restricts
+		// a plugin to building exits out of the dispatch location.
+		"CreateExit": {
+			Action: "write", Resource: "location", Class: ClassWrite,
+			Scopes: []string{"own-location"},
+			Extract: func(req any) (string, bool) {
+				r, ok := req.(*hostv1.CreateExitRequest)
+				if !ok {
+					return "", false
+				}
+				return r.GetFromId(), r.GetFromId() != ""
+			},
+		},
+		// CreateObject acts on its location placement; GetLocationId() is "" for
+		// character-held / container-nested placements (ok=false), which is correct.
+		"CreateObject": {
+			Action: "write", Resource: "location", Class: ClassWrite,
+			Scopes: []string{"own-location"},
+			Extract: func(req any) (string, bool) {
+				r, ok := req.(*hostv1.CreateObjectRequest)
+				if !ok {
+					return "", false
+				}
+				return r.GetLocationId(), r.GetLocationId() != ""
+			},
+		},
+	}},
+}
+
+// init registers the scope vocabulary of each capability descriptor into the
+// plugins package scope-token registry. Called once at program startup; the
+// plugins package MUST NOT import hostcap (cycle), so hostcap registers inward.
+func init() {
+	for token, cap := range Descriptors {
+		seen := map[string]bool{}
+		var scopes []string
+		for _, m := range cap.Methods {
+			for _, s := range m.Scopes {
+				if !seen[s] {
+					seen[s] = true
+					scopes = append(scopes, s)
+				}
+			}
+		}
+		if len(scopes) > 0 {
+			plugins.RegisterCapabilityScopeTokens(token, scopes...)
+		}
+	}
 }

--- a/internal/plugin/hostcap/descriptor.go
+++ b/internal/plugin/hostcap/descriptor.go
@@ -37,6 +37,19 @@ type CapabilityDescriptor struct {
 	Methods map[string]MethodDescriptor
 }
 
+// declarationExemptCapabilities are SELF-GATED capabilities: their access is
+// authorized by a dedicated mechanism, not by manifest `requires:` declaration,
+// so the capability interceptor MUST NOT declaration-gate them (doing so
+// fail-closes legitimate calls — holomush-eykuh.3.17). They still carry
+// descriptor entries (classification/Class) so the interceptor recognizes them.
+//   - "emit": gated by the emit fence (event_emitter.go::Emit) + `emits:` field
+//   - actor_kinds_claimable; plugins declare via `emits:`, not requires:.
+//   - "command-registry": gated by the host-vouched dispatch subject (eykuh.3.12).
+var declarationExemptCapabilities = map[string]bool{
+	"emit":             true,
+	"command-registry": true,
+}
+
 // Descriptors is the single host-owned source for M1/M2/M3 per-method metadata,
 // keyed by capability token. It is the per-method companion to the sub-spec-2
 // token->service registry, covering every served host.v1 capability token (the

--- a/internal/plugin/hostcap/descriptor_completeness_test.go
+++ b/internal/plugin/hostcap/descriptor_completeness_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/pkg/errutil"
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
+// TestEveryScopeEligibleMethodHasExtractor is a build-time meta-test: a scope-
+// eligible descriptor method (one carrying scope tokens) MUST wire a resource
+// Extract, or the interceptor's scope half has no resource to authorize against
+// — a fail-open hazard. Adding scopes to a method without an extractor fails CI.
+//
+// Verifies: INV-PLUGIN-52
+func TestEveryScopeEligibleMethodHasExtractor(t *testing.T) {
+	for token, d := range Descriptors {
+		for name, m := range d.Methods {
+			if len(m.Scopes) > 0 {
+				require.NotNilf(t, m.Extract,
+					"capability %q method %q is scope-eligible but has no extractor (fail-open hazard)",
+					token, name)
+			}
+		}
+	}
+}
+
+// TestInterceptorScopedMethodWithoutExtractorFailsClosed proves the interceptor's
+// runtime guard fires when a scope-eligible method has a nil Extract. All real
+// scoped methods carry extractors (enforced by the meta-test above), so we
+// temporarily strip the extractor off a real scoped descriptor (CreateExit),
+// restoring it via t.Cleanup so the global table is unaffected afterward. The
+// guard MUST deny with SCOPE_NO_EXTRACTOR before any policy evaluation.
+//
+// Verifies: INV-PLUGIN-52
+func TestInterceptorScopedMethodWithoutExtractorFailsClosed(t *testing.T) {
+	// Save + restore the real CreateExit descriptor so other tests are unaffected.
+	orig := Descriptors["world.mutation"].Methods["CreateExit"]
+	t.Cleanup(func() { Descriptors["world.mutation"].Methods["CreateExit"] = orig })
+	noExtract := orig
+	noExtract.Extract = nil
+	Descriptors["world.mutation"].Methods["CreateExit"] = noExtract
+
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         ownLocationEngine{}, // guard fires before eval; engine choice is irrelevant
+		PluginName:     "builder-bot",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "write", true },
+	})
+	_, err := ic(scopedDispatchCtx(testLocID), &hostv1.CreateExitRequest{FromId: testLocID},
+		createExitInfo(), okHandler)
+	errutil.AssertErrorCode(t, err, "SCOPE_NO_EXTRACTOR")
+}

--- a/internal/plugin/hostcap/descriptor_test.go
+++ b/internal/plugin/hostcap/descriptor_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap_test
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/plugin/hostcap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescriptorClassifiesEvalMethods(t *testing.T) {
+	d, ok := hostcap.Descriptors["eval"]
+	require.True(t, ok, "eval capability has a descriptor")
+	m, ok := d.Methods["Evaluate"]
+	require.True(t, ok)
+	assert.Equal(t, hostcap.ClassRead, m.Class)
+	assert.Empty(t, m.Scopes, "eval is not scope-eligible")
+}

--- a/internal/plugin/hostcap/descriptor_test.go
+++ b/internal/plugin/hostcap/descriptor_test.go
@@ -6,10 +6,23 @@ package hostcap_test
 import (
 	"testing"
 
+	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/hostcap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestEveryServedCapabilityHasADescriptor pre-stages the INV-PLUGIN-52
+// completeness gate: every served host.v1 capability token MUST have a
+// non-empty Descriptors entry so the fail-closed interceptor never denies a
+// legitimately-classified method as UNCLASSIFIED_CAPABILITY_METHOD.
+func TestEveryServedCapabilityHasADescriptor(t *testing.T) {
+	for token := range plugins.CapabilityServiceNames {
+		cd, ok := hostcap.Descriptors[token]
+		require.True(t, ok, "capability %q must have a descriptor entry", token)
+		require.NotEmpty(t, cd.Methods, "capability %q descriptor must list methods", token)
+	}
+}
 
 func TestDescriptorClassifiesEvalMethods(t *testing.T) {
 	d, ok := hostcap.Descriptors["eval"]

--- a/internal/plugin/hostcap/descriptor_test.go
+++ b/internal/plugin/hostcap/descriptor_test.go
@@ -19,3 +19,16 @@ func TestDescriptorClassifiesEvalMethods(t *testing.T) {
 	assert.Equal(t, hostcap.ClassRead, m.Class)
 	assert.Empty(t, m.Scopes, "eval is not scope-eligible")
 }
+
+func TestWorldMutationIsScopeEligibleWithExtractor(t *testing.T) {
+	m := hostcap.Descriptors["world.mutation"].Methods["CreateExit"]
+	assert.Equal(t, hostcap.ClassWrite, m.Class)
+	assert.Contains(t, m.Scopes, "own-location")
+	require.NotNil(t, m.Extract, "scope-eligible method must carry an extractor")
+}
+
+func TestCreateLocationIsNotScopeEligible(t *testing.T) {
+	m := hostcap.Descriptors["world.mutation"].Methods["CreateLocation"]
+	assert.Empty(t, m.Scopes, "CreateLocation has no pre-existing location operand")
+	assert.Nil(t, m.Extract)
+}

--- a/internal/plugin/hostcap/interceptor.go
+++ b/internal/plugin/hostcap/interceptor.go
@@ -118,10 +118,34 @@ func classifyHostMethod(fullMethod string) (capToken, method string, ok bool) {
 // undifferentiated capability call. The broader M1 operator-policy surface for
 // non-scoped capabilities is layered on by a later task.
 func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
+	if d.DeclaredAccess == nil {
+		// Misconfigured interceptor: without a declaration lookup every gated
+		// call would dereference a nil func and panic. Fail closed — deny all
+		// host.v1 capability calls (non-host.v1 methods still pass through, as
+		// in the normal path). Both production install sites build this via
+		// DeclaredAccessFromManifest, so this guards a misconfiguration only.
+		return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, h grpc.UnaryHandler) (any, error) {
+			if strings.HasPrefix(info.FullMethod, "/holomush.plugin.host.v1.") {
+				return nil, oops.Code("CAPABILITY_DECLARATION_LOOKUP_MISSING").
+					With("method", info.FullMethod).
+					Errorf("capability interceptor misconfigured: DeclaredAccess is nil")
+			}
+			return h(ctx, req)
+		}
+	}
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, h grpc.UnaryHandler) (any, error) {
 		capToken, method, ok := classifyHostMethod(info.FullMethod)
 		if !ok {
-			return h(ctx, req) // not a gated host.v1 method
+			if strings.HasPrefix(info.FullMethod, "/holomush.plugin.host.v1.") {
+				// A host.v1 method whose service is not in the capability map is
+				// unclassifiable. Fail closed rather than forward ungated — an
+				// unmapped host.v1 service must not bypass capability enforcement
+				// (default-deny, INV-PLUGIN-50).
+				return nil, oops.Code("UNCLASSIFIED_CAPABILITY_METHOD").
+					With("method", info.FullMethod).
+					Errorf("host.v1 method not mapped to a capability token")
+			}
+			return h(ctx, req) // not a host.v1 method — pass through untouched
 		}
 		md, ok := Descriptors[capToken].Methods[method]
 		if !ok {

--- a/internal/plugin/hostcap/interceptor.go
+++ b/internal/plugin/hostcap/interceptor.go
@@ -11,18 +11,20 @@ import (
 	"github.com/samber/oops"
 	"google.golang.org/grpc"
 
+	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 )
 
-// InterceptorDeps wires the host-capability interceptor. Engine and Auditor are
-// reserved for the policy + scope half (Task 10); the static half (M2) consumes
-// only PluginName and DeclaredAccess.
+// InterceptorDeps wires the host-capability interceptor. The static half (M2)
+// consumes PluginName and DeclaredAccess; the dynamic half (M1 policy + M3
+// scope) additionally consumes Engine and Auditor.
 type InterceptorDeps struct {
-	// Engine evaluates ABAC policy in the dynamic half (Task 10); unused here.
+	// Engine evaluates the ABAC policy decision in the dynamic half (M1/M3)
+	// via pluginauthz.EvaluateCapabilityAccess.
 	Engine types.AccessPolicyEngine
-	// Auditor records capability decisions in the dynamic half (Task 10); unused here.
+	// Auditor records the single capability-access decision per scoped call.
 	Auditor pluginauthz.Auditor
 	// PluginName identifies the calling plugin for DeclaredAccess lookups.
 	PluginName string
@@ -95,11 +97,26 @@ func classifyHostMethod(fullMethod string) (capToken, method string, ok bool) {
 	return capToken, method, true
 }
 
-// NewCapabilityInterceptor builds the host-capability unary interceptor. This is
-// the static half (M2): it classifies the method, fails closed on an
-// unclassified or undeclared capability, and denies when the plugin's declared
-// access class does not cover the method's operation class. Policy and scope
-// enforcement (Task 10) plug in at the marked passthrough.
+// NewCapabilityInterceptor builds the host-capability unary interceptor.
+//
+// Static half (M2): it classifies the method, fails closed on an unclassified or
+// undeclared capability, and denies when the plugin's declared access class does
+// not cover the method's operation class.
+//
+// Dynamic half (M1 policy + M3 scope): for a scope-eligible method (a descriptor
+// entry with non-empty Scopes), it requires a host-vouched dispatch context,
+// fails closed when the scope-eligible method has no wired extractor
+// (INV-PLUGIN-52), extracts the concrete scoped resource, builds the scope
+// context from the host-vouched dispatch attributes (the acting character's
+// resolved "location" is surfaced to the policy DSL as the action attribute
+// "dispatch_location"), and runs the default-deny ABAC decision via
+// pluginauthz.EvaluateCapabilityAccess keyed on the plugin:<name> subject
+// (INV-PLUGIN-50). Non-scoped capability methods pass through after the static
+// half: this task's policy evaluation is intentionally limited to scoped methods,
+// because no default-permit operator seed exists for the read-only host
+// capabilities and running default-deny ABAC on them would deny every
+// undifferentiated capability call. The broader M1 operator-policy surface for
+// non-scoped capabilities is layered on by a later task.
 func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, h grpc.UnaryHandler) (any, error) {
 		capToken, method, ok := classifyHostMethod(info.FullMethod)
@@ -130,7 +147,65 @@ func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
 				With("method", method).
 				Errorf("declared access: read does not cover write method")
 		}
-		// Policy + scope enforcement (Task 10) plugs in here; static half passes through.
+
+		// Dynamic half (M1 policy + M3 scope). Only scope-eligible methods are
+		// policy-evaluated in this task (see the doc comment for why).
+		if len(md.Scopes) == 0 {
+			return h(ctx, req)
+		}
+
+		dc, haveDispatch := pluginauthz.DispatchForHost(ctx)
+		if !haveDispatch || dc.Subject == "" {
+			// A scoped capability call with no host-vouched dispatch context has
+			// no acting-character location to scope against: fail closed.
+			return nil, oops.Code("SCOPE_NO_DISPATCH").
+				With("capability", capToken).
+				With("method", method).
+				Errorf("scoped capability call without dispatch context")
+		}
+		if md.Extract == nil {
+			// A scope-eligible method MUST resolve its resource through a wired
+			// extractor; a missing extractor fails closed (INV-PLUGIN-52).
+			return nil, oops.Code("SCOPE_NO_EXTRACTOR").
+				With("capability", capToken).
+				With("method", method).
+				Errorf("scope-eligible method missing extractor")
+		}
+		resourceID, ok := md.Extract(req)
+		if !ok || resourceID == "" {
+			// No concrete scoped resource present on a scope-eligible call:
+			// fail closed rather than forward unscoped (INV-PLUGIN-52).
+			return nil, oops.Code("SCOPE_NO_RESOURCE").
+				With("capability", capToken).
+				With("method", method).
+				Errorf("scope-eligible method has no scoped resource to evaluate")
+		}
+		resource := md.Resource + ":" + resourceID
+		scopeAttrs := map[string]any{"dispatch_location": dc.Attributes["location"]}
+
+		dec, err := pluginauthz.EvaluateCapabilityAccess(ctx, pluginauthz.CapabilityInput{
+			Engine:     d.Engine,
+			Auditor:    d.Auditor,
+			PluginName: d.PluginName,
+			Subject:    access.PluginSubject(d.PluginName),
+			Action:     md.Action,
+			Resource:   resource,
+			Declared:   true, // the declaration gate above already passed
+			Context:    scopeAttrs,
+		})
+		if err != nil {
+			// Fail closed. EvaluateCapabilityAccess already returns a
+			// context-wrapped oops error (engine/subject/resource); re-wrapping
+			// would double-wrap and obscure its fail-closed code.
+			return nil, err //nolint:wrapcheck // pluginauthz already wraps with oops context
+		}
+		if !dec.Allowed {
+			return nil, oops.Code("SCOPE_DENIED").
+				With("capability", capToken).
+				With("method", method).
+				With("resource", resource).
+				Errorf("denied by policy/scope")
+		}
 		return h(ctx, req)
 	}
 }

--- a/internal/plugin/hostcap/interceptor.go
+++ b/internal/plugin/hostcap/interceptor.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/samber/oops"
+	"google.golang.org/grpc"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// InterceptorDeps wires the host-capability interceptor. Engine and Auditor are
+// reserved for the policy + scope half (Task 10); the static half (M2) consumes
+// only PluginName and DeclaredAccess.
+type InterceptorDeps struct {
+	// Engine evaluates ABAC policy in the dynamic half (Task 10); unused here.
+	Engine types.AccessPolicyEngine
+	// Auditor records capability decisions in the dynamic half (Task 10); unused here.
+	Auditor pluginauthz.Auditor
+	// PluginName identifies the calling plugin for DeclaredAccess lookups.
+	PluginName string
+	// DeclaredAccess reports the access class the plugin declared for a
+	// capability token ("" => undifferentiated), and whether it declared the
+	// capability at all. A false second return is fail-closed denial.
+	DeclaredAccess func(plugin, capToken string) (string, bool)
+}
+
+// bareServiceToToken reverses plugins.CapabilityServiceNames (token->bare
+// service) into bare-service->token. Built once; the source map is fixed at
+// program start.
+var (
+	bareServiceToTokenOnce sync.Once
+	bareServiceToToken     map[string]string
+)
+
+func reverseServiceMap() map[string]string {
+	bareServiceToTokenOnce.Do(func() {
+		bareServiceToToken = make(map[string]string, len(plugins.CapabilityServiceNames))
+		for token, bareService := range plugins.CapabilityServiceNames {
+			bareServiceToToken[bareService] = token
+		}
+	})
+	return bareServiceToToken
+}
+
+// classifyHostMethod maps a gRPC FullMethod (e.g.
+// "/holomush.plugin.host.v1.KVService/Set") to its capability token and bare
+// method name. ok is false when the method is not a gated host.v1 capability
+// service method, in which case the interceptor passes it through untouched.
+func classifyHostMethod(fullMethod string) (capToken, method string, ok bool) {
+	if !strings.HasPrefix(fullMethod, "/") {
+		return "", "", false
+	}
+	servicePath, method, found := strings.Cut(fullMethod[1:], "/")
+	if !found || servicePath == "" || method == "" {
+		return "", "", false
+	}
+	bareService := servicePath
+	if i := strings.LastIndex(servicePath, "."); i >= 0 {
+		bareService = servicePath[i+1:]
+	}
+	capToken, ok = reverseServiceMap()[bareService]
+	if !ok {
+		return "", "", false
+	}
+	return capToken, method, true
+}
+
+// NewCapabilityInterceptor builds the host-capability unary interceptor. This is
+// the static half (M2): it classifies the method, fails closed on an
+// unclassified or undeclared capability, and denies when the plugin's declared
+// access class does not cover the method's operation class. Policy and scope
+// enforcement (Task 10) plug in at the marked passthrough.
+func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, h grpc.UnaryHandler) (any, error) {
+		capToken, method, ok := classifyHostMethod(info.FullMethod)
+		if !ok {
+			return h(ctx, req) // not a gated host.v1 method
+		}
+		md, ok := Descriptors[capToken].Methods[method]
+		if !ok {
+			// Fail closed: a host.v1 method with no descriptor entry is unclassifiable.
+			return nil, oops.Code("UNCLASSIFIED_CAPABILITY_METHOD").
+				With("method", info.FullMethod).
+				Errorf("no descriptor entry for host method")
+		}
+		declAccess, declared := d.DeclaredAccess(d.PluginName, capToken)
+		if !declared {
+			return nil, oops.Code("CAPABILITY_NOT_DECLARED").
+				With("capability", capToken).
+				Errorf("plugin did not declare capability")
+		}
+		if declAccess == "read" && md.Class == ClassWrite {
+			return nil, oops.Code("ACCESS_CLASS_DENIED").
+				With("capability", capToken).
+				With("method", method).
+				Errorf("declared access: read does not cover write method")
+		}
+		// Policy + scope enforcement (Task 10) plugs in here; static half passes through.
+		return h(ctx, req)
+	}
+}

--- a/internal/plugin/hostcap/interceptor.go
+++ b/internal/plugin/hostcap/interceptor.go
@@ -113,6 +113,11 @@ func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
 				With("method", info.FullMethod).
 				Errorf("no descriptor entry for host method")
 		}
+		if declarationExemptCapabilities[capToken] {
+			// Self-gated capability: skip the declaration + access-class checks;
+			// its own mechanism (emit fence / dispatch subject) is the authority.
+			return h(ctx, req)
+		}
 		declAccess, declared := d.DeclaredAccess(d.PluginName, capToken)
 		if !declared {
 			return nil, oops.Code("CAPABILITY_NOT_DECLARED").

--- a/internal/plugin/hostcap/interceptor.go
+++ b/internal/plugin/hostcap/interceptor.go
@@ -32,6 +32,28 @@ type InterceptorDeps struct {
 	DeclaredAccess func(plugin, capToken string) (string, bool)
 }
 
+// DeclaredAccessFromManifest builds the InterceptorDeps.DeclaredAccess lookup
+// from a plugin manifest's capability requires. Presence of a capability-kind
+// entry => declared; the value is the declared access narrowing ("" when
+// undifferentiated). Service-kind entries are ignored. A nil manifest declares
+// nothing (fail-closed). This single constructor is used by BOTH the binary and
+// Lua install sites so the trust gate is built identically across runtimes
+// (plugin-runtime-symmetry, INV-PLUGIN-45/49).
+func DeclaredAccessFromManifest(m *plugins.Manifest) func(plugin, capToken string) (string, bool) {
+	declared := make(map[string]string)
+	if m != nil {
+		for _, d := range m.Requires {
+			if d.Kind == plugins.DependencyCapability {
+				declared[d.Name] = d.Access
+			}
+		}
+	}
+	return func(_, capToken string) (string, bool) {
+		a, ok := declared[capToken]
+		return a, ok
+	}
+}
+
 // bareServiceToToken reverses plugins.CapabilityServiceNames (token->bare
 // service) into bare-service->token. Built once; the source map is fixed at
 // program start.

--- a/internal/plugin/hostcap/interceptor_test.go
+++ b/internal/plugin/hostcap/interceptor_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/pkg/errutil"
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
+func okHandler(_ context.Context, _ any) (any, error) { return struct{}{}, nil }
+
+// ctxWithDispatch returns a ctx carrying a host-vouched dispatch context. The
+// static half does not read it; it is here so Task 10's scope tests can reuse it.
+func ctxWithDispatch(t *testing.T) context.Context {
+	t.Helper()
+	return pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{Subject: "character:01TEST"})
+}
+
+func TestInterceptorAccessReadDeniesWriteMethod(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		DeclaredAccess: func(_, _ string) (string, bool) { return "read", true },
+	})
+	_, err := ic(ctxWithDispatch(t), &hostv1.SetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/Set",
+	}, okHandler)
+	errutil.AssertErrorCode(t, err, "ACCESS_CLASS_DENIED")
+}
+
+func TestInterceptorAbsentDeclaredAccessPermitsWrite(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		DeclaredAccess: func(_, _ string) (string, bool) { return "", true }, // declared, no access narrowing
+	})
+	_, err := ic(ctxWithDispatch(t), &hostv1.SetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/Set",
+	}, okHandler)
+	require.NoError(t, err)
+}
+
+func TestInterceptorUndeclaredCapabilityDenied(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		DeclaredAccess: func(_, _ string) (string, bool) { return "", false }, // not declared
+	})
+	_, err := ic(ctxWithDispatch(t), &hostv1.GetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/Get",
+	}, okHandler)
+	errutil.AssertErrorCode(t, err, "CAPABILITY_NOT_DECLARED")
+}
+
+func TestInterceptorNonHostMethodPassesThrough(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		DeclaredAccess: func(_, _ string) (string, bool) { return "", false },
+	})
+	resp, err := ic(context.Background(), struct{}{}, &grpc.UnaryServerInfo{
+		FullMethod: "/some.other.Service/Method",
+	}, okHandler)
+	require.NoError(t, err)
+	require.NotNil(t, resp) // handler ran
+}
+
+func TestClassifyHostMethodResolvesKnownService(t *testing.T) {
+	capToken, method, ok := classifyHostMethod("/holomush.plugin.host.v1.KVService/Set")
+	require.True(t, ok)
+	require.Equal(t, "kv", capToken)
+	require.Equal(t, "Set", method)
+}
+
+func TestClassifyHostMethodRejectsNonHostMethod(t *testing.T) {
+	_, _, ok := classifyHostMethod("/some.other.Service/Method")
+	require.False(t, ok)
+}

--- a/internal/plugin/hostcap/interceptor_test.go
+++ b/internal/plugin/hostcap/interceptor_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/holomush/holomush/internal/access/policy/policytest"
+	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 	"github.com/holomush/holomush/pkg/errutil"
 	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
@@ -80,4 +81,49 @@ func TestClassifyHostMethodResolvesKnownService(t *testing.T) {
 func TestClassifyHostMethodRejectsNonHostMethod(t *testing.T) {
 	_, _, ok := classifyHostMethod("/some.other.Service/Method")
 	require.False(t, ok)
+}
+
+func TestDeclaredAccessFromManifestReportsDeclaredCapabilityAccess(t *testing.T) {
+	m := &plugins.Manifest{
+		Name: "p",
+		Requires: []plugins.Dependency{
+			{Kind: plugins.DependencyCapability, Name: "kv", Access: "read"},
+			{Kind: plugins.DependencyCapability, Name: "world.query"}, // undifferentiated
+			{Kind: plugins.DependencyService, Name: "holomush.scene.v1.SceneService"},
+		},
+	}
+	lookup := DeclaredAccessFromManifest(m)
+
+	access, declared := lookup("p", "kv")
+	require.True(t, declared)
+	require.Equal(t, "read", access)
+
+	access, declared = lookup("p", "world.query")
+	require.True(t, declared)
+	require.Equal(t, "", access)
+}
+
+func TestDeclaredAccessFromManifestDeniesUndeclaredCapability(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:     "p",
+		Requires: []plugins.Dependency{{Kind: plugins.DependencyCapability, Name: "kv", Access: "write"}},
+	}
+	access, declared := DeclaredAccessFromManifest(m)("p", "session")
+	require.False(t, declared)
+	require.Equal(t, "", access)
+}
+
+func TestDeclaredAccessFromManifestIgnoresServiceKindEntries(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:     "p",
+		Requires: []plugins.Dependency{{Kind: plugins.DependencyService, Name: "kv"}},
+	}
+	// A service-kind entry named "kv" must NOT be treated as a declared capability.
+	_, declared := DeclaredAccessFromManifest(m)("p", "kv")
+	require.False(t, declared)
+}
+
+func TestDeclaredAccessFromManifestNilManifestDeniesAll(t *testing.T) {
+	_, declared := DeclaredAccessFromManifest(nil)("p", "kv")
+	require.False(t, declared)
 }

--- a/internal/plugin/hostcap/interceptor_test.go
+++ b/internal/plugin/hostcap/interceptor_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/access/policy/types"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 	"github.com/holomush/holomush/pkg/errutil"
@@ -20,10 +21,106 @@ import (
 func okHandler(_ context.Context, _ any) (any, error) { return struct{}{}, nil }
 
 // ctxWithDispatch returns a ctx carrying a host-vouched dispatch context. The
-// static half does not read it; it is here so Task 10's scope tests can reuse it.
+// static half does not read it; the dynamic (M3) scope half reads dc.Subject
+// and dc.Attributes["location"] to build the scope attributes.
 func ctxWithDispatch(t *testing.T) context.Context {
 	t.Helper()
 	return pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{Subject: "character:01TEST"})
+}
+
+// ownLocationEngine is a test AccessPolicyEngine that models the own-location
+// scope condition the way the seed policy does: it permits a plugin write to
+// "location:<id>" only when the caller-overlaid action attribute
+// "dispatch_location" equals <id>. It lets the interceptor unit tests assert the
+// dynamic half end-to-end (extract resource → build scope attrs from dispatch →
+// EvaluateCapabilityAccess → deny on mismatch) without standing up a full
+// DSL-backed engine; the seed DSL itself is verified by the seed smoke tests in
+// the policy package (TestSeedSmokePluginWorldMutationOwnLocation*).
+type ownLocationEngine struct{}
+
+func (ownLocationEngine) Evaluate(_ context.Context, req types.AccessRequest) (types.Decision, error) {
+	resType, resID, ok := splitTypeID(req.Resource)
+	if !ok || resType != "location" || req.Action != "write" {
+		return types.NewDecision(types.EffectDefaultDeny, "no policy", ""), nil
+	}
+	dispatchLoc, _ := req.Attributes["dispatch_location"].(string)
+	if dispatchLoc != "" && dispatchLoc == resID {
+		return types.NewDecision(types.EffectAllow, "own-location", "test:own-location"), nil
+	}
+	return types.NewDecision(types.EffectDefaultDeny, "not own-location", ""), nil
+}
+
+func (ownLocationEngine) CanPerformAction(_ context.Context, _, _, _, _ string) (bool, error) {
+	return true, nil
+}
+
+func splitTypeID(ref string) (typ, id string, ok bool) {
+	for i := 0; i < len(ref); i++ {
+		if ref[i] == ':' {
+			if i == 0 || i == len(ref)-1 {
+				return "", "", false
+			}
+			return ref[:i], ref[i+1:], true
+		}
+	}
+	return "", "", false
+}
+
+const testLocID = "01LOCAAAAAAAAAAAAAAAAAAAAAA"
+
+// scopedDispatchCtx carries a dispatch context whose acting-character location
+// is loc, mirroring what eykuh.3.15 populates at delivery time.
+func scopedDispatchCtx(loc string) context.Context {
+	return pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{
+		Subject:    "character:01TEST",
+		Attributes: map[string]string{"location": loc},
+	})
+}
+
+// createExitInLocation builds a CreateExit gRPC call whose source location is
+// fromID; the descriptor's Extract pulls from_id as the scoped resource.
+func createExitInfo() *grpc.UnaryServerInfo {
+	return &grpc.UnaryServerInfo{FullMethod: "/holomush.plugin.host.v1.WorldMutationService/CreateExit"}
+}
+
+// Verifies: INV-PLUGIN-50
+func TestInterceptorScopeOwnLocationPermitsMatch(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         ownLocationEngine{},
+		PluginName:     "builder-bot",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "write", true },
+	})
+	resp, err := ic(scopedDispatchCtx(testLocID), &hostv1.CreateExitRequest{FromId: testLocID},
+		createExitInfo(), okHandler)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// Verifies: INV-PLUGIN-50
+func TestInterceptorScopeOwnLocationDeniesMismatch(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         ownLocationEngine{},
+		PluginName:     "builder-bot",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "write", true },
+	})
+	// Dispatch location differs from the exit's source location => own-location fails.
+	otherLoc := "01LOCBBBBBBBBBBBBBBBBBBBBBB"
+	_, err := ic(scopedDispatchCtx(otherLoc), &hostv1.CreateExitRequest{FromId: testLocID},
+		createExitInfo(), okHandler)
+	errutil.AssertErrorCode(t, err, "SCOPE_DENIED")
+}
+
+// Verifies: INV-PLUGIN-52
+func TestInterceptorScopedCallFailsClosedWithoutDispatch(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         ownLocationEngine{},
+		PluginName:     "builder-bot",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "write", true },
+	})
+	// No dispatch context on the ctx => a scoped capability call must fail closed.
+	_, err := ic(context.Background(), &hostv1.CreateExitRequest{FromId: testLocID},
+		createExitInfo(), okHandler)
+	errutil.AssertErrorCode(t, err, "SCOPE_NO_DISPATCH")
 }
 
 func TestInterceptorAccessReadDeniesWriteMethod(t *testing.T) {

--- a/internal/plugin/hostcap/interceptor_test.go
+++ b/internal/plugin/hostcap/interceptor_test.go
@@ -111,6 +111,22 @@ func TestInterceptorScopeOwnLocationDeniesMismatch(t *testing.T) {
 }
 
 // Verifies: INV-PLUGIN-52
+func TestInterceptorScopedCallFailsClosedWithEmptyResource(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         ownLocationEngine{},
+		PluginName:     "builder-bot",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "write", true },
+	})
+	// CreateObject with a character placement: GetLocationId() returns "" => ok=false.
+	// The interceptor must fail closed rather than forwarding without a scoped resource.
+	_, err := ic(scopedDispatchCtx(testLocID),
+		&hostv1.CreateObjectRequest{Placement: &hostv1.CreateObjectRequest_CharacterId{CharacterId: "01CHAR0000000000000000000A"}},
+		&grpc.UnaryServerInfo{FullMethod: "/holomush.plugin.host.v1.WorldMutationService/CreateObject"},
+		okHandler)
+	errutil.AssertErrorCode(t, err, "SCOPE_NO_RESOURCE")
+}
+
+// Verifies: INV-PLUGIN-52
 func TestInterceptorScopedCallFailsClosedWithoutDispatch(t *testing.T) {
 	ic := NewCapabilityInterceptor(InterceptorDeps{
 		Engine:         ownLocationEngine{},

--- a/internal/plugin/hostcap/interceptor_test.go
+++ b/internal/plugin/hostcap/interceptor_test.go
@@ -59,6 +59,24 @@ func TestInterceptorUndeclaredCapabilityDenied(t *testing.T) {
 	errutil.AssertErrorCode(t, err, "CAPABILITY_NOT_DECLARED")
 }
 
+func TestInterceptorPassesThroughSelfGatedCapabilityWhenUndeclared(t *testing.T) {
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		DeclaredAccess: func(_, _ string) (string, bool) { return "", false }, // NOT declared
+	})
+	// emit is self-gated: an undeclared emit call must pass through (not CAPABILITY_NOT_DECLARED).
+	resp, err := ic(context.Background(), &hostv1.EmitEventRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.EmitService/EmitEvent",
+	}, okHandler)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// command-registry likewise (ListCommands is ClassRead, undeclared).
+	_, err = ic(context.Background(), &hostv1.ListCommandsRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.CommandRegistryService/ListCommands",
+	}, okHandler)
+	require.NoError(t, err)
+}
+
 func TestInterceptorNonHostMethodPassesThrough(t *testing.T) {
 	ic := NewCapabilityInterceptor(InterceptorDeps{
 		Engine:         policytest.AllowAllEngine(),

--- a/internal/plugin/hostcap/servers.go
+++ b/internal/plugin/hostcap/servers.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus/cursor"
@@ -951,12 +950,14 @@ type commandRegistryServer struct {
 	hostCapabilityBase
 }
 
-// ListCommands enumerates the commands the named character may execute,
-// ABAC-filtered by the host. Unlike Evaluate/EmitEvent, this is read-only
-// metadata keyed by the request's character_id (parity with the Lua
-// list_commands host function), so it does NOT require a dispatch token.
-// Fail-closed on nil host / nil querier.
-func (s *commandRegistryServer) ListCommands(ctx context.Context, req *hostv1.ListCommandsRequest) (*hostv1.ListCommandsResponse, error) {
+// ListCommands enumerates the commands the acting character may execute,
+// ABAC-filtered by the host. The ABAC subject is the HOST-VOUCHED dispatch
+// subject stamped onto ctx by DeliverCommand/DeliverEvent (INV-PLUGIN-51) — the
+// wire-supplied character_id is NOT trusted for authorization (it would let any
+// plugin enumerate command visibility for an arbitrary character). Fails closed
+// (NO_DISPATCH_SUBJECT) when no dispatch subject is present; also on nil host /
+// nil querier.
+func (s *commandRegistryServer) ListCommands(ctx context.Context, _ *hostv1.ListCommandsRequest) (*hostv1.ListCommandsResponse, error) {
 	if s.host == nil {
 		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
 	}
@@ -964,11 +965,12 @@ func (s *commandRegistryServer) ListCommands(ctx context.Context, req *hostv1.Li
 	if q == nil {
 		return nil, oops.Code("COMMAND_QUERIER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("command querier is not configured")
 	}
-	charID, err := ulid.Parse(req.GetCharacterId())
-	if err != nil {
-		return nil, oops.Code("INVALID_ARGUMENT").With("plugin", s.pluginName).Errorf("invalid character_id")
+	dc, ok := pluginauthz.DispatchForHost(ctx)
+	if !ok || dc.Subject == "" {
+		return nil, oops.Code("NO_DISPATCH_SUBJECT").With("plugin", s.pluginName).
+			Errorf("command-registry call without a host-vouched dispatch subject")
 	}
-	res, err := q.Available(ctx, access.CharacterSubject(charID.String()))
+	res, err := q.Available(ctx, dc.Subject)
 	if err != nil {
 		return nil, oops.With("plugin", s.pluginName).Wrap(err)
 	}
@@ -985,8 +987,11 @@ func (s *commandRegistryServer) ListCommands(ctx context.Context, req *hostv1.Li
 }
 
 // GetCommandHelp returns full help detail for one command after an access check
-// for character_id. Read-only; no dispatch token required (parity with Lua
-// get_command_help host function).
+// for the acting character. The ABAC subject is the HOST-VOUCHED dispatch
+// subject stamped onto ctx by DeliverCommand/DeliverEvent (INV-PLUGIN-51) — the
+// wire-supplied character_id is NOT trusted for authorization. Fails closed
+// (NO_DISPATCH_SUBJECT) when no dispatch subject is present; also on nil host /
+// nil querier.
 func (s *commandRegistryServer) GetCommandHelp(ctx context.Context, req *hostv1.GetCommandHelpRequest) (*hostv1.GetCommandHelpResponse, error) {
 	if s.host == nil {
 		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
@@ -995,11 +1000,12 @@ func (s *commandRegistryServer) GetCommandHelp(ctx context.Context, req *hostv1.
 	if q == nil {
 		return nil, oops.Code("COMMAND_QUERIER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("command querier is not configured")
 	}
-	charID, err := ulid.Parse(req.GetCharacterId())
-	if err != nil {
-		return nil, oops.Code("INVALID_ARGUMENT").With("plugin", s.pluginName).Errorf("invalid character_id")
+	dc, ok := pluginauthz.DispatchForHost(ctx)
+	if !ok || dc.Subject == "" {
+		return nil, oops.Code("NO_DISPATCH_SUBJECT").With("plugin", s.pluginName).
+			Errorf("command-registry call without a host-vouched dispatch subject")
 	}
-	d, err := q.Help(ctx, access.CharacterSubject(charID.String()), req.GetName())
+	d, err := q.Help(ctx, dc.Subject, req.GetName())
 	if err != nil {
 		return nil, oops.With("plugin", s.pluginName).Wrap(err)
 	}

--- a/internal/plugin/hostcap/servers.go
+++ b/internal/plugin/hostcap/servers.go
@@ -951,11 +951,14 @@ type commandRegistryServer struct {
 }
 
 // ListCommands enumerates the commands the acting character may execute,
-// ABAC-filtered by the host. The ABAC subject is the HOST-VOUCHED dispatch
-// subject stamped onto ctx by DeliverCommand/DeliverEvent (INV-PLUGIN-51) — the
-// wire-supplied character_id is NOT trusted for authorization (it would let any
-// plugin enumerate command visibility for an arbitrary character). Fails closed
-// (NO_DISPATCH_SUBJECT) when no dispatch subject is present; also on nil host /
+// ABAC-filtered by the host. The ABAC subject is the HOST-VOUCHED actor recovered
+// via the port's LookupActor (INV-PLUGIN-51) — runtime-neutral and uniform with
+// evalServer.Evaluate: the binary adapter reads the host-issued dispatch token
+// from the incoming gRPC metadata; the Lua adapter reads the connection-scoped
+// actor from core.ActorFromContext. The wire-supplied character_id is NOT trusted
+// for authorization (it would let any plugin enumerate command visibility for an
+// arbitrary character) — the proto field is structurally ignored. Fails closed
+// (NO_DISPATCH_SUBJECT) when no host-vouched actor is present; also on nil host /
 // nil querier.
 func (s *commandRegistryServer) ListCommands(ctx context.Context, _ *hostv1.ListCommandsRequest) (*hostv1.ListCommandsResponse, error) {
 	if s.host == nil {
@@ -965,12 +968,16 @@ func (s *commandRegistryServer) ListCommands(ctx context.Context, _ *hostv1.List
 	if q == nil {
 		return nil, oops.Code("COMMAND_QUERIER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("command querier is not configured")
 	}
-	dc, ok := pluginauthz.DispatchForHost(ctx)
-	if !ok || dc.Subject == "" {
-		return nil, oops.Code("NO_DISPATCH_SUBJECT").With("plugin", s.pluginName).
-			Errorf("command-registry call without a host-vouched dispatch subject")
+	storedActor, _, err := s.host.LookupActor(ctx, s.pluginName)
+	if err != nil {
+		return nil, oops.With("plugin", s.pluginName).Wrap(err)
 	}
-	res, err := q.Available(ctx, dc.Subject)
+	subject := pluginauthz.ActorSubject(storedActor)
+	if subject == "" {
+		return nil, oops.Code("NO_DISPATCH_SUBJECT").With("plugin", s.pluginName).
+			Errorf("command-registry call without a host-vouched actor")
+	}
+	res, err := q.Available(ctx, subject)
 	if err != nil {
 		return nil, oops.With("plugin", s.pluginName).Wrap(err)
 	}
@@ -987,10 +994,13 @@ func (s *commandRegistryServer) ListCommands(ctx context.Context, _ *hostv1.List
 }
 
 // GetCommandHelp returns full help detail for one command after an access check
-// for the acting character. The ABAC subject is the HOST-VOUCHED dispatch
-// subject stamped onto ctx by DeliverCommand/DeliverEvent (INV-PLUGIN-51) — the
-// wire-supplied character_id is NOT trusted for authorization. Fails closed
-// (NO_DISPATCH_SUBJECT) when no dispatch subject is present; also on nil host /
+// for the acting character. The ABAC subject is the HOST-VOUCHED actor recovered
+// via the port's LookupActor (INV-PLUGIN-51) — runtime-neutral and uniform with
+// evalServer.Evaluate: the binary adapter reads the host-issued dispatch token
+// from the incoming gRPC metadata; the Lua adapter reads the connection-scoped
+// actor from core.ActorFromContext. The wire-supplied character_id is NOT trusted
+// for authorization — the proto field is structurally ignored. Fails closed
+// (NO_DISPATCH_SUBJECT) when no host-vouched actor is present; also on nil host /
 // nil querier.
 func (s *commandRegistryServer) GetCommandHelp(ctx context.Context, req *hostv1.GetCommandHelpRequest) (*hostv1.GetCommandHelpResponse, error) {
 	if s.host == nil {
@@ -1000,12 +1010,16 @@ func (s *commandRegistryServer) GetCommandHelp(ctx context.Context, req *hostv1.
 	if q == nil {
 		return nil, oops.Code("COMMAND_QUERIER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("command querier is not configured")
 	}
-	dc, ok := pluginauthz.DispatchForHost(ctx)
-	if !ok || dc.Subject == "" {
-		return nil, oops.Code("NO_DISPATCH_SUBJECT").With("plugin", s.pluginName).
-			Errorf("command-registry call without a host-vouched dispatch subject")
+	storedActor, _, err := s.host.LookupActor(ctx, s.pluginName)
+	if err != nil {
+		return nil, oops.With("plugin", s.pluginName).Wrap(err)
 	}
-	d, err := q.Help(ctx, dc.Subject, req.GetName())
+	subject := pluginauthz.ActorSubject(storedActor)
+	if subject == "" {
+		return nil, oops.Code("NO_DISPATCH_SUBJECT").With("plugin", s.pluginName).
+			Errorf("command-registry call without a host-vouched actor")
+	}
+	d, err := q.Help(ctx, subject, req.GetName())
 	if err != nil {
 		return nil, oops.With("plugin", s.pluginName).Wrap(err)
 	}

--- a/internal/plugin/hostfunc/commands.go
+++ b/internal/plugin/hostfunc/commands.go
@@ -7,12 +7,11 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 	lua "github.com/yuin/gopher-lua"
 
-	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/command/commandquery"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 )
 
 // WithCommandQuerier injects the shared command-query service. The
@@ -27,7 +26,8 @@ func WithCommandQuerier(q *commandquery.Querier) Option {
 }
 
 // listCommandsFn returns the list_commands host function.
-// Args: character_id (string) - the character whose capabilities determine visible commands
+// Args: character_id (string) — IGNORED for authorization (see below); kept for
+// Lua-call-signature compatibility only.
 // Returns: (result table, error string or nil)
 //
 // Result table structure:
@@ -41,22 +41,22 @@ func WithCommandQuerier(q *commandquery.Querier) Option {
 //     may be incomplete (e.g., show the error string from the second return value).
 //   - The error string (second return) is non-nil only when incomplete is true.
 //
-// This function is a thin shim: it parses/validates the character_id, then
+// Subject derivation (INV-PLUGIN-51): the ABAC subject is the HOST-VOUCHED
+// dispatch subject stamped on ls.Context() by the Lua host's stampDispatch
+// (eykuh.3.6), NOT the Lua-supplied character_id. A plugin therefore cannot
+// enumerate another character's command visibility by passing a foreign id.
+// The character_id arg is read for call-signature compatibility and discarded;
+// removing it from the Lua surface is a follow-up. When no host-vouched
+// dispatch subject is present we fail closed (no command visibility).
+//
+// This function is a thin shim: it resolves the host-vouched subject, then
 // delegates to commandquery.Querier (INV-COMMAND-1). All ABAC filtering, capability
 // AND-logic, and the engine-error circuit breaker live in commandquery.
 func (f *Functions) listCommandsFn(_ string) lua.LGFunction {
 	return func(ls *lua.LState) int {
-		charIDStr := ls.CheckString(1)
-		if charIDStr == "" {
-			ls.RaiseError("character ID cannot be empty")
-			return 0
-		}
-
-		charID, err := ulid.Parse(charIDStr)
-		if err != nil {
-			ls.RaiseError("invalid character ID: %s", charIDStr)
-			return 0
-		}
+		// Read (and discard for authz) the character_id arg for call-signature
+		// compatibility. It MUST NOT influence the ABAC subject.
+		_ = ls.CheckString(1)
 
 		ctx := ls.Context()
 		if ctx == nil {
@@ -73,8 +73,15 @@ func (f *Functions) listCommandsFn(_ string) lua.LGFunction {
 			return 2
 		}
 
-		subject := access.CharacterSubject(charID.String())
-		return listCommandsViaQuerier(ctx, ls, f.commandQuerier, subject)
+		dc, ok := pluginauthz.DispatchForHost(ctx)
+		if !ok || dc.Subject == "" {
+			// Fail closed: no host-vouched acting character ⇒ no command visibility.
+			ls.Push(lua.LNil)
+			ls.Push(lua.LString("no host-vouched dispatch subject"))
+			return 2
+		}
+
+		return listCommandsViaQuerier(ctx, ls, f.commandQuerier, dc.Subject)
 	}
 }
 
@@ -112,7 +119,8 @@ func listCommandsViaQuerier(ctx context.Context, ls *lua.LState, q *commandquery
 }
 
 // getCommandHelpFn returns the get_command_help host function.
-// Args: command_name (string), character_id (string)
+// Args: command_name (string), character_id (string) — character_id is IGNORED
+// for authorization (see below); kept for Lua-call-signature compatibility only.
 // Returns: (command info table, error string)
 //
 // This function is a thin shim over commandquery.Querier.Help (INV-COMMAND-1). It maps
@@ -122,15 +130,24 @@ func listCommandsViaQuerier(ctx context.Context, ls *lua.LState, q *commandquery
 //   - PERMISSION_DENIED  → "access denied"
 //   - UNAVAILABLE / other → "access check failed"
 //
-// Precedence note: command lookup (NOT_FOUND) happens inside Querier.Help BEFORE
-// any capability/character evaluation, so a non-existent command yields
-// "command not found" regardless of the character_id value — matching the
-// pre-refactor contract. We therefore only parse/validate character_id AFTER a
-// successful Help (i.e. for the subject string), not before the lookup.
+// Subject derivation (INV-PLUGIN-51): the capability check uses the HOST-VOUCHED
+// dispatch subject stamped on ls.Context() (eykuh.3.6), NOT the Lua-supplied
+// character_id. A plugin cannot probe another character's gated-command help by
+// passing a foreign id. When no host-vouched dispatch subject is present we
+// fail closed before consulting the querier — a missing dispatch is abnormal
+// for an in-VM hostfunc call.
+//
+// Precedence note: for the with-dispatch case, command lookup (NOT_FOUND) still
+// happens inside Querier.Help BEFORE any capability/character evaluation, so a
+// non-existent command yields "command not found" regardless of caller. We
+// preserve that by calling Help with the host-vouched subject (no pre-empting
+// of the lookup).
 func (f *Functions) getCommandHelpFn(_ string) lua.LGFunction {
 	return func(ls *lua.LState) int {
 		name := ls.CheckString(1)
-		characterID := ls.CheckString(2)
+		// Read (and discard for authz) the character_id arg for call-signature
+		// compatibility. It MUST NOT influence the ABAC subject.
+		_ = ls.CheckString(2)
 		if name == "" {
 			ls.RaiseError("command name cannot be empty")
 			return 0
@@ -148,17 +165,15 @@ func (f *Functions) getCommandHelpFn(_ string) lua.LGFunction {
 			return 2
 		}
 
-		// Validate character_id but do NOT let a bad id pre-empt the command
-		// lookup: a non-existent command must report "command not found" even
-		// when the character_id is malformed. We pass a best-effort subject to
-		// the querier; for an empty/invalid id the subject is harmless because
-		// Querier.Help resolves NOT_FOUND before consulting the engine. Only
-		// when the command exists AND requires capabilities does the subject
-		// matter — and in that case an invalid id surfaces as a denied/failed
-		// access check, which is the correct fail-closed behavior.
-		subject := characterSubjectOrRaw(characterID)
+		dc, ok := pluginauthz.DispatchForHost(ctx)
+		if !ok || dc.Subject == "" {
+			// Fail closed: no host-vouched acting character ⇒ no command help.
+			ls.Push(lua.LNil)
+			ls.Push(lua.LString("no host-vouched dispatch subject"))
+			return 2
+		}
 
-		detail, helpErr := f.commandQuerier.Help(ctx, subject, name)
+		detail, helpErr := f.commandQuerier.Help(ctx, dc.Subject, name)
 		if helpErr != nil {
 			if oopsErr, ok := oops.AsOops(helpErr); ok {
 				switch oopsErr.Code() {
@@ -178,19 +193,6 @@ func (f *Functions) getCommandHelpFn(_ string) lua.LGFunction {
 		}
 		return buildHelpTable(ls, detail)
 	}
-}
-
-// characterSubjectOrRaw formats characterID as a character subject when it is a
-// valid ULID, otherwise returns the raw string. A raw (non-ULID) subject can
-// never match a granting policy, so capability-gated commands fail closed —
-// while a non-existent command still resolves to NOT_FOUND before the subject is
-// ever consulted (Querier.Help order). This preserves the pre-refactor
-// "command not found wins over invalid character_id" precedence.
-func characterSubjectOrRaw(characterID string) string {
-	if charID, err := ulid.Parse(characterID); err == nil {
-		return access.CharacterSubject(charID.String())
-	}
-	return characterID
 }
 
 // buildHelpTable pushes a command help result table onto the Lua stack.

--- a/internal/plugin/hostfunc/commands_test.go
+++ b/internal/plugin/hostfunc/commands_test.go
@@ -4,6 +4,7 @@
 package hostfunc
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -16,7 +17,21 @@ import (
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/commandquery"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 )
+
+// withDispatchState builds a Lua state whose context carries a host-vouched
+// dispatch subject for the given character — mirroring what the lua host's
+// stampDispatch sets on ls.Context() before plugin code runs (eykuh.3.6).
+func withDispatchState(t *testing.T, subjectChar ulid.ULID) *lua.LState {
+	t.Helper()
+	L := lua.NewState()
+	ctx := pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{
+		Subject: access.CharacterSubject(subjectChar.String()),
+	})
+	L.SetContext(ctx)
+	return L
+}
 
 // These tests cover ONLY the list_commands / get_command_help host-function
 // SHIMS — the thin Go↔Lua bridge over commandquery.Querier (design spec INV-COMMAND-1).
@@ -67,7 +82,7 @@ func TestListCommandsShimBuildsLuaTableFromQuerierResult(t *testing.T) {
 	charID := ulid.Make()
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 
@@ -117,7 +132,7 @@ func TestListCommandsShimMapsIncompleteToWarningString(t *testing.T) {
 	charID := ulid.Make()
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 
@@ -150,26 +165,22 @@ func TestListCommandsShimNilQuerierReturnsRegistryUnavailable(t *testing.T) {
 	assert.Contains(t, errVal.String(), "command registry not available")
 }
 
-func TestListCommandsShimEmptyCharacterIDRaises(t *testing.T) {
-	hf := New(nil, WithCommandQuerier(newAllowQuerier(nil)))
-	L := lua.NewState()
-	defer L.Close()
-	hf.Register(L, "test-plugin")
+func TestListCommandsShimEmptyOrInvalidArgIsIgnored(t *testing.T) {
+	// The character_id arg no longer drives authorization (INV-PLUGIN-51), so an
+	// empty or non-ULID arg no longer raises — it is simply discarded and the
+	// host-vouched dispatch subject is used instead.
+	charID := ulid.Make()
+	for _, arg := range []string{`""`, `"not-a-ulid"`} {
+		hf := New(nil, WithCommandQuerier(newAllowQuerier(nil)))
+		L := withDispatchState(t, charID)
+		hf.Register(L, "test-plugin")
 
-	err := L.DoString(`commands, err = holomush.list_commands("")`)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "character ID cannot be empty")
-}
-
-func TestListCommandsShimInvalidCharacterIDRaises(t *testing.T) {
-	hf := New(nil, WithCommandQuerier(newAllowQuerier(nil)))
-	L := lua.NewState()
-	defer L.Close()
-	hf.Register(L, "test-plugin")
-
-	err := L.DoString(`commands, err = holomush.list_commands("not-a-ulid")`)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid character ID")
+		err := L.DoString(`result, err = holomush.list_commands(` + arg + `)`)
+		L.Close()
+		require.NoError(t, err, "arg %s must be ignored, not raise", arg)
+		_, ok := L.GetGlobal("result").(*lua.LTable)
+		assert.True(t, ok, "result table returned for arg %s (dispatch subject used)", arg)
+	}
 }
 
 func TestGetCommandHelpShimMapsDetailToLuaTable(t *testing.T) {
@@ -191,7 +202,7 @@ func TestGetCommandHelpShimMapsDetailToLuaTable(t *testing.T) {
 	q := commandquery.New(registry, ac, nil)
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 
@@ -224,7 +235,7 @@ func TestGetCommandHelpShimTranslatesNotFound(t *testing.T) {
 	charID := ulid.Make()
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 
@@ -249,7 +260,7 @@ func TestGetCommandHelpShimTranslatesPermissionDenied(t *testing.T) {
 	charID := ulid.Make()
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 
@@ -274,7 +285,7 @@ func TestGetCommandHelpShimTranslatesUnavailableToCheckFailed(t *testing.T) {
 	charID := ulid.Make()
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 
@@ -312,18 +323,20 @@ func TestGetCommandHelpShimEmptyCommandNameRaises(t *testing.T) {
 	assert.Contains(t, err.Error(), "command name cannot be empty")
 }
 
-func TestGetCommandHelpShimNotFoundWinsOverInvalidCharacterID(t *testing.T) {
+func TestGetCommandHelpShimNotFoundWinsOverDenial(t *testing.T) {
 	// (e) Precedence: a non-existent command must resolve to "command not found"
-	// even when the character_id is malformed — the lookup (NOT_FOUND) happens
-	// inside Querier.Help before the subject is consulted, so the shim must NOT
-	// pre-parse/validate character_id ahead of the lookup.
+	// before the engine is consulted — even under a deny-all engine. The lookup
+	// (NOT_FOUND) happens inside Querier.Help before the dispatch subject is
+	// evaluated, so the shim preserves "command not found wins". The Lua arg is
+	// ignored entirely now (INV-PLUGIN-51); a malformed arg must NOT change this.
 	registry := &mockCommandRegistry{commands: []command.CommandEntry{
 		{Name: "look", Help: "Look around", Source: "core"},
 	}}
-	q := commandquery.New(registry, policytest.AllowAllEngine(), nil)
+	q := commandquery.New(registry, policytest.DenyAllEngine(), nil)
+	charID := ulid.Make()
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 
@@ -332,7 +345,133 @@ func TestGetCommandHelpShimNotFoundWinsOverInvalidCharacterID(t *testing.T) {
 
 	assert.Equal(t, lua.LNil, L.GetGlobal("info"))
 	assert.Contains(t, L.GetGlobal("err").String(), "command not found",
-		"non-existent command must win over invalid character_id")
+		"non-existent command must resolve to NOT_FOUND before the engine is consulted")
+}
+
+// Verifies: INV-PLUGIN-51
+func TestLuaListCommandsIgnoresArgUsesDispatch(t *testing.T) {
+	// The Lua-supplied character_id arg MUST NOT determine ABAC visibility:
+	// the host-vouched dispatch subject does. Grant a command ONLY for the
+	// dispatch char X, then call list_commands with a DIFFERENT char Y's id —
+	// the returned set must reflect X's grants, proving Y is ignored.
+	dispatchChar := ulid.Make()
+	otherChar := ulid.Make()
+
+	registry := &mockCommandRegistry{commands: []command.CommandEntry{
+		command.NewTestEntry(command.CommandEntryConfig{
+			Name:         "boot",
+			Help:         "Boot a player",
+			Capabilities: []command.Capability{{Action: "admin", Resource: "server", Scope: command.ScopeGlobal}},
+			Source:       "admin",
+		}),
+		{Name: "look", Help: "Look around", Source: "core"},
+	}}
+	ac := policytest.NewGrantEngine()
+	ac.GrantCommandExecution(access.CharacterSubject(dispatchChar.String()), "boot", "look")
+	ac.Grant(access.CharacterSubject(dispatchChar.String()), "admin", "server")
+	q := commandquery.New(registry, ac, nil)
+
+	hf := New(nil, WithCommandQuerier(q))
+	L := withDispatchState(t, dispatchChar)
+	defer L.Close()
+	hf.Register(L, "test-plugin")
+
+	// Pass otherChar (NOT granted) as the arg; dispatch subject is dispatchChar.
+	err := L.DoString(`result, err = holomush.list_commands("` + otherChar.String() + `")`)
+	require.NoError(t, err)
+
+	resultTbl, ok := L.GetGlobal("result").(*lua.LTable)
+	require.True(t, ok, "expected result table, got %T", L.GetGlobal("result"))
+	assert.Equal(t, lua.LNil, L.GetGlobal("err"))
+
+	commands, ok := L.GetField(resultTbl, "commands").(*lua.LTable)
+	require.True(t, ok)
+
+	var bootFound bool
+	commands.ForEach(func(_, v lua.LValue) {
+		if cmdTbl, ok := v.(*lua.LTable); ok && L.GetField(cmdTbl, "name").String() == "boot" {
+			bootFound = true
+		}
+	})
+	assert.True(t, bootFound,
+		"capability-gated 'boot' visible ⇒ dispatch subject X used, not arg Y (else it would be filtered out)")
+}
+
+func TestLuaListCommandsFailsClosedWithoutDispatch(t *testing.T) {
+	// No host-vouched dispatch subject on the ls context ⇒ fail closed:
+	// list_commands returns (nil, errmsg) and never enumerates anything.
+	q := newAllowQuerier([]command.CommandEntry{
+		{Name: "look", Help: "Look around", Source: "core"},
+	})
+	charID := ulid.Make()
+
+	hf := New(nil, WithCommandQuerier(q))
+	L := lua.NewState() // no dispatch context set
+	defer L.Close()
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`result, err = holomush.list_commands("` + charID.String() + `")`)
+	require.NoError(t, err)
+
+	assert.Equal(t, lua.LNil, L.GetGlobal("result"))
+	assert.Contains(t, L.GetGlobal("err").String(), "host-vouched dispatch")
+}
+
+// Verifies: INV-PLUGIN-51
+func TestLuaGetCommandHelpIgnoresArgUsesDispatch(t *testing.T) {
+	// The character_id arg MUST NOT determine authorization for capability-gated
+	// help: the dispatch subject does. Grant the gated command ONLY for dispatch
+	// char X, then request help passing a DIFFERENT char Y — help must succeed
+	// (proving X's grants applied, not Y's).
+	dispatchChar := ulid.Make()
+	otherChar := ulid.Make()
+
+	registry := &mockCommandRegistry{commands: []command.CommandEntry{
+		command.NewTestEntry(command.CommandEntryConfig{
+			Name:         "secret-cmd",
+			Help:         "Secret command",
+			Capabilities: []command.Capability{{Action: "admin", Resource: "server", Scope: command.ScopeGlobal}},
+			Source:       "admin",
+		}),
+	}}
+	ac := policytest.NewGrantEngine()
+	ac.GrantCommandExecution(access.CharacterSubject(dispatchChar.String()), "secret-cmd")
+	ac.Grant(access.CharacterSubject(dispatchChar.String()), "admin", "server")
+	q := commandquery.New(registry, ac, nil)
+
+	hf := New(nil, WithCommandQuerier(q))
+	L := withDispatchState(t, dispatchChar)
+	defer L.Close()
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`info, err = holomush.get_command_help("secret-cmd", "` + otherChar.String() + `")`)
+	require.NoError(t, err)
+
+	tbl, ok := L.GetGlobal("info").(*lua.LTable)
+	require.True(t, ok, "help must succeed for dispatch char X despite arg Y; got err=%v", L.GetGlobal("err"))
+	assert.Equal(t, "secret-cmd", L.GetField(tbl, "name").String())
+	assert.Equal(t, lua.LNil, L.GetGlobal("err"))
+}
+
+func TestLuaGetCommandHelpFailsClosedWithoutDispatch(t *testing.T) {
+	// No host-vouched dispatch subject ⇒ fail closed before consulting the
+	// querier (a missing dispatch is abnormal for an in-VM hostfunc call).
+	registry := &mockCommandRegistry{commands: []command.CommandEntry{
+		{Name: "look", Help: "Look around", Source: "core"},
+	}}
+	q := commandquery.New(registry, policytest.AllowAllEngine(), nil)
+	charID := ulid.Make()
+
+	hf := New(nil, WithCommandQuerier(q))
+	L := lua.NewState() // no dispatch context set
+	defer L.Close()
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`info, err = holomush.get_command_help("look", "` + charID.String() + `")`)
+	require.NoError(t, err)
+
+	assert.Equal(t, lua.LNil, L.GetGlobal("info"))
+	assert.Contains(t, L.GetGlobal("err").String(), "host-vouched dispatch")
 }
 
 func TestGetCommandHelpShimNoCapabilitiesSkipsAccessCheck(t *testing.T) {
@@ -345,7 +484,7 @@ func TestGetCommandHelpShimNoCapabilitiesSkipsAccessCheck(t *testing.T) {
 	charID := ulid.Make()
 
 	hf := New(nil, WithCommandQuerier(q))
-	L := lua.NewState()
+	L := withDispatchState(t, charID)
 	defer L.Close()
 	hf.Register(L, "test-plugin")
 

--- a/internal/plugin/hostfunc/commands_test.go
+++ b/internal/plugin/hostfunc/commands_test.go
@@ -176,10 +176,10 @@ func TestListCommandsShimEmptyOrInvalidArgIsIgnored(t *testing.T) {
 		hf.Register(L, "test-plugin")
 
 		err := L.DoString(`result, err = holomush.list_commands(` + arg + `)`)
-		L.Close()
 		require.NoError(t, err, "arg %s must be ignored, not raise", arg)
 		_, ok := L.GetGlobal("result").(*lua.LTable)
 		assert.True(t, ok, "result table returned for arg %s (dispatch subject used)", arg)
+		L.Close()
 	}
 }
 

--- a/internal/plugin/lua/bufconn_endpoint.go
+++ b/internal/plugin/lua/bufconn_endpoint.go
@@ -22,16 +22,33 @@ type pluginEndpoint struct {
 }
 
 // newPluginEndpoint creates a per-plugin bufconn endpoint serving the Lua
-// capability set. It builds a *grpc.Server, registers the LuaDefaultSet
-// capability servers (INV-PLUGIN-49), and wraps the server with an in-process
-// bufconn listener. The caller must call Close when the plugin is unloaded.
-func newPluginEndpoint(adapter hostcap.HostCapabilities, pluginName string) (*pluginEndpoint, error) {
+// capability set. It builds a *grpc.Server, chains the host-capability
+// interceptor, registers the LuaDefaultSet capability servers (INV-PLUGIN-49),
+// and wraps the server with an in-process bufconn listener. The caller must call
+// Close when the plugin is unloaded.
+//
+// The interceptor (holomush-eykuh.3) is built from the SAME
+// hostcap.DeclaredAccessFromManifest helper the binary broker server uses
+// (internal/plugin/goplugin/host_service.go), so the declaration + access-class
+// trust gate is identical across runtimes (plugin-runtime-symmetry,
+// INV-PLUGIN-45/49). Engine/Auditor are sourced identically on both runtimes
+// through the hostcap.HostCapabilities port (adapter.AccessEngine()/Auditor());
+// the static half (this task) does not read them — Task 10 wires the
+// policy/scope half.
+func newPluginEndpoint(adapter hostcap.HostCapabilities, manifest *plugins.Manifest) (*pluginEndpoint, error) {
+	pluginName := manifest.Name
+	ic := hostcap.NewCapabilityInterceptor(hostcap.InterceptorDeps{
+		Engine:         adapter.AccessEngine(),
+		Auditor:        adapter.Auditor(),
+		PluginName:     pluginName,
+		DeclaredAccess: hostcap.DeclaredAccessFromManifest(manifest),
+	})
 	// The server is served exclusively over an in-memory bufconn listener
 	// (plugins.NewInProcessConn below), never a network socket — there is no
 	// wire to encrypt or tamper with. TLS credentials are therefore N/A; this
 	// mirrors the client half of the same transport, which carries the matching
 	// nosemgrep on insecure.NewCredentials (internal/plugin/inprocess_conn.go).
-	srv := grpc.NewServer() // nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
+	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(ic)) // nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
 	hostcap.RegisterCapabilities(srv, hostcap.NewBase(adapter, pluginName), hostcap.LuaDefaultSet)
 	conn, err := plugins.NewInProcessConn(srv)
 	if err != nil {

--- a/internal/plugin/lua/bufconn_endpoint_test.go
+++ b/internal/plugin/lua/bufconn_endpoint_test.go
@@ -84,7 +84,12 @@ func TestPluginEndpoint(t *testing.T) {
 			name: "serves host caps over the in-process bufconn",
 			run: func(t *testing.T) {
 				adapter := newLuaHostCapAdapter(newTestFunctions(t))
-				ep, err := newPluginEndpoint(adapter, "echo-bot")
+				// Declare the session capability so the interceptor permits the
+				// ListActive round-trip below.
+				ep, err := newPluginEndpoint(adapter, &plugins.Manifest{
+					Name:     "echo-bot",
+					Requires: []plugins.Dependency{{Kind: plugins.DependencyCapability, Name: "session"}},
+				})
 				require.NoError(t, err)
 				defer ep.Close()
 
@@ -101,7 +106,7 @@ func TestPluginEndpoint(t *testing.T) {
 			name: "exposes a non-nil conn and closes cleanly",
 			run: func(t *testing.T) {
 				adapter := newLuaHostCapAdapter(newTestFunctions(t))
-				ep, err := newPluginEndpoint(adapter, "test-plugin")
+				ep, err := newPluginEndpoint(adapter, &plugins.Manifest{Name: "test-plugin"})
 				require.NoError(t, err)
 				assert.NotNil(t, ep.Conn())
 				require.NoError(t, ep.Close())
@@ -156,6 +161,30 @@ func TestPluginEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, tc.run)
 	}
+}
+
+// TestLuaHostServerDeniesUndeclaredCapability proves the capability interceptor
+// is installed on the Lua per-plugin bufconn server identically to the binary
+// broker server: a plugin whose manifest declares NO capabilities is denied
+// (fail-closed) when it calls a gated host.v1 method (KVService.Get) over the
+// in-process conn. The binary mirror is
+// goplugin.TestBinaryHostServerDeniesUndeclaredCapability; both stand up the
+// REAL per-plugin server and dial the ACTUALLY-INSTALLED interceptor built from
+// the SAME hostcap.DeclaredAccessFromManifest helper, so together they prove the
+// trust gate is identical across runtimes (plugin-runtime-symmetry).
+//
+// Verifies: INV-PLUGIN-45
+func TestLuaHostServerDeniesUndeclaredCapability(t *testing.T) {
+	adapter := newLuaHostCapAdapter(newTestFunctions(t))
+	// Manifest declares no capability requires — kv is therefore undeclared.
+	ep, err := newPluginEndpoint(adapter, &plugins.Manifest{Name: "no-caps-plugin"})
+	require.NoError(t, err)
+	defer ep.Close()
+
+	client := hostv1.NewKVServiceClient(ep.Conn())
+	_, err = client.Get(context.Background(), &hostv1.GetRequest{Key: "k"})
+	require.Error(t, err, "undeclared capability call must be denied by the interceptor")
+	assert.Contains(t, err.Error(), "plugin did not declare capability")
 }
 
 // TestHostCapBridgeInjection verifies the bridge opt-in/opt-out coexistence

--- a/internal/plugin/lua/dispatch.go
+++ b/internal/plugin/lua/dispatch.go
@@ -9,11 +9,12 @@ import (
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/pkg/errutil"
 )
 
 // stampDispatch stamps the host-vouched pluginauthz.DispatchContext onto ctx
 // before the Lua state's context is set, so in-VM hostfuncs inherit the
-// host-vouched ABAC subject (INV-PLUGIN-51).
+// host-vouched ABAC subject and attributes (INV-PLUGIN-51).
 //
 // Only character actors are vouched: when the ctx carries an actor with
 // Kind == core.ActorCharacter and a non-empty ID, the subject is
@@ -21,17 +22,51 @@ import (
 // none) the ctx is returned unchanged — absence is fail-closed at
 // scope-enforcement time.
 //
-// Attributes (the dispatch location backing scope:own-location) are resolved by
-// a follow-up wiring task (holomush-eykuh.3); nil is fail-closed at
-// scope-enforcement time, since the DSL evaluator treats missing attributes as
+// When a dispatch attribute resolver is wired (WithDispatchAttributeResolver),
+// the acting character's attributes (notably "location", backing
+// scope:own-location) are resolved and projected onto the dispatch context. A
+// resolver error or a nil resolver leaves Attributes nil, which is fail-closed
+// at scope-enforcement time: the DSL evaluator treats missing attributes as
 // false for every operator.
-func stampDispatch(ctx context.Context) context.Context {
+func (h *Host) stampDispatch(ctx context.Context) context.Context {
 	actor, ok := core.ActorFromContext(ctx)
 	if !ok || actor.Kind != core.ActorCharacter || actor.ID == "" {
 		return ctx
 	}
+	subject := access.CharacterSubject(actor.ID)
+
+	var attrs map[string]string
+	if h.dispatchAttrResolver != nil {
+		raw, err := h.dispatchAttrResolver.ResolveSubject(ctx, subject)
+		if err != nil {
+			// Fail-closed: leave attrs nil so scope-enforcement denies rather
+			// than evaluating against a partial bag.
+			errutil.LogErrorContext(ctx, "resolve dispatch attributes failed", err, "subject", subject)
+		} else {
+			attrs = stringAttrs(raw)
+		}
+	}
+
 	return pluginauthz.WithDispatch(ctx, pluginauthz.DispatchContext{
-		Subject:    access.CharacterSubject(actor.ID),
-		Attributes: nil,
+		Subject:    subject,
+		Attributes: attrs,
 	})
+}
+
+// stringAttrs projects the string-valued keys of a resolved attribute bag into
+// a string map suitable for pluginauthz.DispatchContext.Attributes, dropping
+// non-string values (bools, slices, ...). It returns nil — never an empty
+// map — when the input has no string values, so "no attributes" stays == nil
+// and matches the default (no-resolver) behavior.
+func stringAttrs(raw map[string]any) map[string]string {
+	var out map[string]string
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			if out == nil {
+				out = make(map[string]string, len(raw))
+			}
+			out[k] = s
+		}
+	}
+	return out
 }

--- a/internal/plugin/lua/dispatch.go
+++ b/internal/plugin/lua/dispatch.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package lua
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// stampDispatch stamps the host-vouched pluginauthz.DispatchContext onto ctx
+// before the Lua state's context is set, so in-VM hostfuncs inherit the
+// host-vouched ABAC subject (INV-PLUGIN-51).
+//
+// Only character actors are vouched: when the ctx carries an actor with
+// Kind == core.ActorCharacter and a non-empty ID, the subject is
+// access.CharacterSubject(actor.ID). For any other actor kind (plugin, system,
+// none) the ctx is returned unchanged — absence is fail-closed at
+// scope-enforcement time.
+//
+// Attributes (the dispatch location backing scope:own-location) are resolved by
+// a follow-up wiring task (holomush-eykuh.3); nil is fail-closed at
+// scope-enforcement time, since the DSL evaluator treats missing attributes as
+// false for every operator.
+func stampDispatch(ctx context.Context) context.Context {
+	actor, ok := core.ActorFromContext(ctx)
+	if !ok || actor.Kind != core.ActorCharacter || actor.ID == "" {
+		return ctx
+	}
+	return pluginauthz.WithDispatch(ctx, pluginauthz.DispatchContext{
+		Subject:    access.CharacterSubject(actor.ID),
+		Attributes: nil,
+	})
+}

--- a/internal/plugin/lua/dispatch_test.go
+++ b/internal/plugin/lua/dispatch_test.go
@@ -20,28 +20,87 @@ func TestStampDispatchStampsHostVouchedSubjectForCharacterActor(t *testing.T) {
 	charID := core.NewULID().String()
 	ctx := core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: charID})
 
-	got := stampDispatch(ctx)
+	got := NewHost().stampDispatch(ctx)
 
 	dc, ok := pluginauthz.DispatchForHost(got)
 	require.True(t, ok, "dispatch context must be stamped for a character actor")
 	assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
-	assert.Nil(t, dc.Attributes, "attributes resolved by a follow-up wiring task")
+	assert.Nil(t, dc.Attributes, "no resolver wired ⇒ Attributes nil")
 }
 
 func TestStampDispatchLeavesNonCharacterActorUnchanged(t *testing.T) {
 	base := context.Background()
+	h := NewHost()
 
 	// No actor on ctx.
-	_, ok := pluginauthz.DispatchForHost(stampDispatch(base))
+	_, ok := pluginauthz.DispatchForHost(h.stampDispatch(base))
 	assert.False(t, ok, "missing actor must not stamp a dispatch subject")
 
 	// Plugin actor.
 	plug := core.WithActor(base, core.Actor{Kind: core.ActorPlugin, ID: core.NewULID().String()})
-	_, ok = pluginauthz.DispatchForHost(stampDispatch(plug))
+	_, ok = pluginauthz.DispatchForHost(h.stampDispatch(plug))
 	assert.False(t, ok, "plugin actor must not stamp a dispatch subject")
 
 	// Character actor with empty ID: fail-closed.
 	empty := core.WithActor(base, core.Actor{Kind: core.ActorCharacter, ID: ""})
-	_, ok = pluginauthz.DispatchForHost(stampDispatch(empty))
+	_, ok = pluginauthz.DispatchForHost(h.stampDispatch(empty))
 	assert.False(t, ok, "empty-ID character actor must not stamp a dispatch subject")
+}
+
+// fakeAttrResolver is a test double for pluginauthz.AttributeResolver.
+type fakeAttrResolver struct {
+	attrs map[string]any
+	err   error
+}
+
+func (f fakeAttrResolver) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return f.attrs, f.err
+}
+
+// Verifies: INV-PLUGIN-51
+func TestStampDispatchResolvesCharacterAttributesWhenResolverWired(t *testing.T) {
+	charID := core.NewULID().String()
+	ctx := core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: charID})
+
+	t.Run("projects string-valued attributes and drops non-strings", func(t *testing.T) {
+		h := NewHost(WithDispatchAttributeResolver(fakeAttrResolver{
+			attrs: map[string]any{
+				"location":     "01LOC",
+				"has_location": true,
+				"roles":        []string{"player"},
+			},
+		}))
+		dc, ok := pluginauthz.DispatchForHost(h.stampDispatch(ctx))
+		require.True(t, ok, "character actor must stamp a dispatch subject")
+		assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
+		require.NotNil(t, dc.Attributes, "string attributes must be projected")
+		assert.Equal(t, "01LOC", dc.Attributes["location"], "location attribute projected")
+		_, hasBool := dc.Attributes["has_location"]
+		assert.False(t, hasBool, "non-string attribute (bool) must be dropped")
+		_, hasSlice := dc.Attributes["roles"]
+		assert.False(t, hasSlice, "non-string attribute (slice) must be dropped")
+	})
+
+	t.Run("resolver error is fail-closed with nil attributes", func(t *testing.T) {
+		h := NewHost(WithDispatchAttributeResolver(fakeAttrResolver{err: assert.AnError}))
+		dc, ok := pluginauthz.DispatchForHost(h.stampDispatch(ctx))
+		require.True(t, ok, "subject is still stamped on resolver error")
+		assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
+		assert.Nil(t, dc.Attributes, "resolver error leaves Attributes nil (fail-closed)")
+	})
+
+	t.Run("nil resolver leaves attributes nil", func(t *testing.T) {
+		dc, ok := pluginauthz.DispatchForHost(NewHost().stampDispatch(ctx))
+		require.True(t, ok, "character actor must stamp a dispatch subject")
+		assert.Nil(t, dc.Attributes, "no resolver wired ⇒ Attributes nil (current behavior)")
+	})
+
+	t.Run("resolver returning only non-string attributes yields nil", func(t *testing.T) {
+		h := NewHost(WithDispatchAttributeResolver(fakeAttrResolver{
+			attrs: map[string]any{"has_location": false},
+		}))
+		dc, ok := pluginauthz.DispatchForHost(h.stampDispatch(ctx))
+		require.True(t, ok, "character actor must stamp a dispatch subject")
+		assert.Nil(t, dc.Attributes, "no string-valued attributes ⇒ nil, not empty map")
+	})
 }

--- a/internal/plugin/lua/dispatch_test.go
+++ b/internal/plugin/lua/dispatch_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package lua
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// Verifies: INV-PLUGIN-51
+func TestStampDispatchStampsHostVouchedSubjectForCharacterActor(t *testing.T) {
+	charID := core.NewULID().String()
+	ctx := core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: charID})
+
+	got := stampDispatch(ctx)
+
+	dc, ok := pluginauthz.DispatchForHost(got)
+	require.True(t, ok, "dispatch context must be stamped for a character actor")
+	assert.Equal(t, access.CharacterSubject(charID), dc.Subject, "host-vouched subject")
+	assert.Nil(t, dc.Attributes, "attributes resolved by a follow-up wiring task")
+}
+
+func TestStampDispatchLeavesNonCharacterActorUnchanged(t *testing.T) {
+	base := context.Background()
+
+	// No actor on ctx.
+	_, ok := pluginauthz.DispatchForHost(stampDispatch(base))
+	assert.False(t, ok, "missing actor must not stamp a dispatch subject")
+
+	// Plugin actor.
+	plug := core.WithActor(base, core.Actor{Kind: core.ActorPlugin, ID: core.NewULID().String()})
+	_, ok = pluginauthz.DispatchForHost(stampDispatch(plug))
+	assert.False(t, ok, "plugin actor must not stamp a dispatch subject")
+
+	// Character actor with empty ID: fail-closed.
+	empty := core.WithActor(base, core.Actor{Kind: core.ActorCharacter, ID: ""})
+	_, ok = pluginauthz.DispatchForHost(stampDispatch(empty))
+	assert.False(t, ok, "empty-ID character actor must not stamp a dispatch subject")
+}

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -418,6 +418,11 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginsdk.Ev
 	}
 	defer L.Close()
 
+	// Stamp the host-vouched dispatch subject before the Lua state's context is
+	// set, so in-VM hostfuncs inherit it (INV-PLUGIN-51). Only character actors
+	// are vouched; see stampDispatch.
+	ctx = stampDispatch(ctx)
+
 	// Set context on the Lua state so host functions can inherit it
 	L.SetContext(ctx)
 
@@ -513,6 +518,11 @@ func (h *Host) DeliverCommand(ctx context.Context, name string, cmd pluginsdk.Co
 		return nil, oops.In("lua").With("plugin", name).With("operation", "deliver_command").Hint("failed to create state").Wrap(err)
 	}
 	defer L.Close()
+
+	// Stamp the host-vouched dispatch subject before the Lua state's context is
+	// set, so in-VM hostfuncs inherit it (INV-PLUGIN-51). Only character actors
+	// are vouched; see stampDispatch.
+	ctx = stampDispatch(ctx)
 
 	L.SetContext(ctx)
 

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -333,7 +333,7 @@ func (h *Host) Load(ctx context.Context, manifest *plugins.Manifest, dir string)
 	// the host-brokered capability path (safe: no bridge will wire the nil conn).
 	var ep *pluginEndpoint
 	if h.hostCapAdapter != nil {
-		ep, err = newPluginEndpoint(h.hostCapAdapter, manifest.Name)
+		ep, err = newPluginEndpoint(h.hostCapAdapter, manifest)
 		if err != nil {
 			return oops.In("lua").With("plugin", manifest.Name).With("operation", "load").
 				Hint("failed to create bufconn endpoint").Wrap(err)

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -22,6 +22,7 @@ import (
 	"github.com/holomush/holomush/internal/plugin/hostcap"
 	"github.com/holomush/holomush/internal/plugin/hostfunc"
 	"github.com/holomush/holomush/internal/plugin/luabridge"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 	"github.com/holomush/holomush/internal/settings"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 )
@@ -54,6 +55,13 @@ type Host struct {
 	configOverrides      map[string]map[string]string
 	mergedConfigs        map[string]map[string]string
 	bridgeEnabledPlugins map[string]bool // opt-in allowlist for host-cap bridge injection; empty = production (no bridge)
+	// dispatchAttrResolver resolves the acting character's host-vouched dispatch
+	// attributes (notably "location") at delivery time, populating
+	// DispatchContext.Attributes (holomush-eykuh.3). Nil leaves Attributes nil,
+	// fail-closed at scope-enforcement time. Mirrors goplugin.Host's field
+	// (plugin-runtime-symmetry). Wired at construction via
+	// WithDispatchAttributeResolver.
+	dispatchAttrResolver pluginauthz.AttributeResolver
 }
 
 // HostOption customizes Host construction.
@@ -105,6 +113,15 @@ func WithPluginConfigOverrides(o map[string]map[string]string) HostOption {
 		cloned[name] = maps.Clone(cfg)
 	}
 	return func(h *Host) { h.configOverrides = cloned }
+}
+
+// WithDispatchAttributeResolver configures the host with the resolver used to
+// populate DispatchContext.Attributes (notably "location") at command/event
+// delivery (holomush-eykuh.3). Without it, dispatch Attributes stay nil —
+// fail-closed at scope-enforcement time. The binary host has the same option
+// (plugin-runtime-symmetry). Satisfied by access/policy/attribute.Resolver.
+func WithDispatchAttributeResolver(r pluginauthz.AttributeResolver) HostOption {
+	return func(h *Host) { h.dispatchAttrResolver = r }
 }
 
 // NewHost creates a new Lua plugin host without host functions.
@@ -421,7 +438,7 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginsdk.Ev
 	// Stamp the host-vouched dispatch subject before the Lua state's context is
 	// set, so in-VM hostfuncs inherit it (INV-PLUGIN-51). Only character actors
 	// are vouched; see stampDispatch.
-	ctx = stampDispatch(ctx)
+	ctx = h.stampDispatch(ctx)
 
 	// Set context on the Lua state so host functions can inherit it
 	L.SetContext(ctx)
@@ -522,7 +539,7 @@ func (h *Host) DeliverCommand(ctx context.Context, name string, cmd pluginsdk.Co
 	// Stamp the host-vouched dispatch subject before the Lua state's context is
 	// set, so in-VM hostfuncs inherit it (INV-PLUGIN-51). Only character actors
 	// are vouched; see stampDispatch.
-	ctx = stampDispatch(ctx)
+	ctx = h.stampDispatch(ctx)
 
 	L.SetContext(ctx)
 

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -368,6 +368,10 @@ var validHistoryScopes = map[string]bool{
 	"custom": true,
 }
 
+// validAccess is the closed enum of accepted access: values on capability
+// dependency entries (INV-PLUGIN-53). The empty string means "unspecified".
+var validAccess = map[string]bool{"": true, "read": true, "write": true}
+
 // ParseManifest parses and validates a plugin.yaml file.
 func ParseManifest(data []byte) (*Manifest, error) {
 	if len(data) == 0 {
@@ -492,6 +496,20 @@ func (m *Manifest) Validate() error {
 		}
 	default:
 		return oops.In("manifest").With("name", m.Name).With("type", m.Type).New("type must be 'lua', 'binary', or 'setting'")
+	}
+
+	// Validate requires entries: access:/scope: are capability-only (INV-PLUGIN-53).
+	for _, d := range m.Requires {
+		if d.Kind == DependencyService && (d.Scope != "" || d.Access != "") {
+			return oops.Code("LEAST_PRIVILEGE_PARAM_ON_SERVICE").
+				With("plugin", m.Name).With("service", d.Name).
+				Errorf("access:/scope: are valid only on capability entries (INV-PLUGIN-53)")
+		}
+		if !validAccess[d.Access] {
+			return oops.Code("INVALID_ACCESS_VALUE").
+				With("plugin", m.Name).With("access", d.Access).
+				Errorf("access must be one of: read, write")
+		}
 	}
 
 	// Validate session_streams: only lua and binary plugins can contribute session streams.

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -510,6 +510,13 @@ func (m *Manifest) Validate() error {
 				With("plugin", m.Name).With("access", d.Access).
 				Errorf("access must be one of: read, write")
 		}
+		if d.Kind == DependencyCapability && d.Scope != "" {
+			if !capabilityScopeTokens(d.Name)[d.Scope] {
+				return oops.Code("UNKNOWN_SCOPE_TOKEN").
+					With("plugin", m.Name).With("capability", d.Name).With("scope", d.Scope).
+					Errorf("capability %q does not support scope %q", d.Name, d.Scope)
+			}
+		}
 	}
 
 	// Validate session_streams: only lua and binary plugins can contribute session streams.

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -2680,6 +2680,7 @@ func validBaseManifest(t *testing.T, frag string) *plugins.Manifest {
 	return &m
 }
 
+// Verifies: INV-PLUGIN-53
 func TestManifestRejectsLeastPrivilegeParamsOnServiceEntry(t *testing.T) {
 	for _, tc := range []struct{ name, yamlFrag, code string }{
 		{"scope on service", "requires:\n  - service: holomush.scene.v1.SceneService\n    scope: own-location\n", "LEAST_PRIVILEGE_PARAM_ON_SERVICE"},

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
 	plugins "github.com/holomush/holomush/internal/plugin"
+	_ "github.com/holomush/holomush/internal/plugin/hostcap" // registers scope tokens via init()
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
@@ -2698,5 +2699,15 @@ func TestManifestRejectsUnknownAccessValue(t *testing.T) {
 
 func TestManifestAcceptsAccessReadOnCapability(t *testing.T) {
 	m := validBaseManifest(t, "requires:\n  - capability: kv\n    access: read\n")
+	require.NoError(t, m.Validate())
+}
+
+func TestManifestRejectsUnknownScopeToken(t *testing.T) {
+	m := validBaseManifest(t, "requires:\n  - capability: world.mutation\n    scope: own-galaxy\n")
+	errutil.AssertErrorCode(t, m.Validate(), "UNKNOWN_SCOPE_TOKEN")
+}
+
+func TestManifestAcceptsKnownScopeTokenOnCapability(t *testing.T) {
+	m := validBaseManifest(t, "requires:\n  - capability: world.mutation\n    scope: own-location\n")
 	require.NoError(t, m.Validate())
 }

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
@@ -2665,4 +2666,37 @@ history_scope: unknown
 			}
 		})
 	}
+}
+
+// validBaseManifest builds a minimal Lua manifest (bypassing ParseManifest so
+// negative-case tests can call Validate() and assert specific error codes rather
+// than having ParseManifest swallow the error and return nil).
+func validBaseManifest(t *testing.T, frag string) *plugins.Manifest {
+	t.Helper()
+	base := "name: test-plugin\nversion: 1.0.0\ntype: lua\nlua-plugin:\n  entry: main.lua\n"
+	var m plugins.Manifest
+	require.NoError(t, yaml.Unmarshal([]byte(base+frag), &m))
+	return &m
+}
+
+func TestManifestRejectsLeastPrivilegeParamsOnServiceEntry(t *testing.T) {
+	for _, tc := range []struct{ name, yamlFrag, code string }{
+		{"scope on service", "requires:\n  - service: holomush.scene.v1.SceneService\n    scope: own-location\n", "LEAST_PRIVILEGE_PARAM_ON_SERVICE"},
+		{"access on service", "requires:\n  - service: holomush.scene.v1.SceneService\n    access: read\n", "LEAST_PRIVILEGE_PARAM_ON_SERVICE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := validBaseManifest(t, tc.yamlFrag)
+			errutil.AssertErrorCode(t, m.Validate(), tc.code)
+		})
+	}
+}
+
+func TestManifestRejectsUnknownAccessValue(t *testing.T) {
+	m := validBaseManifest(t, "requires:\n  - capability: kv\n    access: delete\n")
+	errutil.AssertErrorCode(t, m.Validate(), "INVALID_ACCESS_VALUE")
+}
+
+func TestManifestAcceptsAccessReadOnCapability(t *testing.T) {
+	m := validBaseManifest(t, "requires:\n  - capability: kv\n    access: read\n")
+	require.NoError(t, m.Validate())
 }

--- a/internal/plugin/pluginauthz/capability.go
+++ b/internal/plugin/pluginauthz/capability.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginauthz
+
+import (
+	"context"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/audit"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// CapabilityInput is the capability-access decision input. Subject is
+// host-derived (plugin:<name>); Declared is the resolver-proven manifest reach.
+type CapabilityInput struct {
+	Engine     types.AccessPolicyEngine
+	Auditor    Auditor
+	PluginName string
+	Subject    string
+	Action     string
+	Resource   string
+	Declared   bool
+	Context    map[string]any // dispatch attributes for scope conditions (M3)
+}
+
+// EvaluateCapabilityAccess authorizes a plugin's consumption of a host
+// capability. Entitlement is manifest-declaration (Declared), NOT OwnedTypes —
+// host-capability resources are not plugin-owned (INV-PLUGIN-50). Shares the
+// engine call + single audit event with Evaluate (INV-PLUGIN-26). Fails closed:
+// a non-nil error always accompanies a non-allowing Decision.
+func EvaluateCapabilityAccess(ctx context.Context, in CapabilityInput) (Decision, error) {
+	if in.Engine == nil {
+		return Decision{}, oops.Code("EVALUATE_NO_ENGINE").With("plugin", in.PluginName).Errorf("evaluate called with nil engine")
+	}
+	if in.Subject == "" {
+		return Decision{}, oops.Code("EVALUATE_NO_SUBJECT").With("plugin", in.PluginName).Errorf("evaluate called without an authenticated subject")
+	}
+	if in.Action == "" {
+		return Decision{}, oops.Code("EVALUATE_EMPTY_ACTION").With("plugin", in.PluginName).Errorf("action must not be empty")
+	}
+	if !in.Declared {
+		return Decision{}, oops.Code("CAPABILITY_NOT_DECLARED").
+			With("plugin", in.PluginName).With("resource", in.Resource).
+			Errorf("plugin did not declare this capability")
+	}
+	req, reqErr := types.NewAccessRequest(in.Subject, in.Action, in.Resource, in.Context)
+	if reqErr != nil {
+		return Decision{}, oops.With("plugin", in.PluginName).Wrap(reqErr)
+	}
+	dec, evalErr := in.Engine.Evaluate(ctx, req)
+	if evalErr != nil {
+		errutil.LogErrorContext(ctx, "plugin capability-access engine error", evalErr,
+			"plugin", in.PluginName, "action", in.Action, "resource", in.Resource)
+		return Decision{}, oops.With("plugin", in.PluginName).Wrap(evalErr) // fail closed
+	}
+	result := Decision{Allowed: dec.IsAllowed(), Reason: dec.Reason(), MatchedPolicy: dec.PolicyID()}
+	// Single audit event (mirror Evaluate; Name "plugin.capability_access").
+	if in.Auditor != nil {
+		auditEffect := types.EffectDeny
+		if dec.IsAllowed() {
+			auditEffect = types.EffectAllow
+		}
+		if logErr := in.Auditor.Log(ctx, audit.Event{
+			Name: "plugin.capability_access", Source: audit.SourcePlugin, Component: in.PluginName,
+			Subject: in.Subject, Action: in.Action, Resource: in.Resource,
+			Effect: auditEffect, Timestamp: time.Now(),
+		}); logErr != nil {
+			errutil.LogErrorContext(ctx, "plugin capability-access audit log failed", logErr, "plugin", in.PluginName, "action", in.Action)
+		}
+	}
+	return result, nil
+}

--- a/internal/plugin/pluginauthz/capability_test.go
+++ b/internal/plugin/pluginauthz/capability_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginauthz_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// Verifies: INV-PLUGIN-50
+func TestEvaluateCapabilityAccessAllowsDeclaredPermitted(t *testing.T) {
+	dec, err := pluginauthz.EvaluateCapabilityAccess(context.Background(), pluginauthz.CapabilityInput{
+		Engine: policytest.AllowAllEngine(), PluginName: "core-objects",
+		Subject: access.PluginSubject("core-objects"),
+		Action:  "read", Resource: "kv:foo", Declared: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, dec.Allowed)
+}
+
+// Verifies: INV-PLUGIN-50
+func TestEvaluateCapabilityAccessDeniedByPolicyDespiteDeclaration(t *testing.T) {
+	dec, _ := pluginauthz.EvaluateCapabilityAccess(context.Background(), pluginauthz.CapabilityInput{
+		Engine: policytest.DenyAllEngine(), PluginName: "core-objects",
+		Subject: access.PluginSubject("core-objects"),
+		Action:  "read", Resource: "kv:foo", Declared: true,
+	})
+	assert.False(t, dec.Allowed) // INV-PLUGIN-50: declaration necessary, not sufficient
+}
+
+func TestEvaluateCapabilityAccessUndeclaredFailsClosed(t *testing.T) {
+	_, err := pluginauthz.EvaluateCapabilityAccess(context.Background(), pluginauthz.CapabilityInput{
+		Engine: policytest.AllowAllEngine(), PluginName: "core-objects",
+		Subject: access.PluginSubject("core-objects"),
+		Action:  "read", Resource: "kv:foo", Declared: false,
+	})
+	errutil.AssertErrorCode(t, err, "CAPABILITY_NOT_DECLARED")
+}

--- a/internal/plugin/pluginauthz/capability_test.go
+++ b/internal/plugin/pluginauthz/capability_test.go
@@ -29,11 +29,12 @@ func TestEvaluateCapabilityAccessAllowsDeclaredPermitted(t *testing.T) {
 
 // Verifies: INV-PLUGIN-50
 func TestEvaluateCapabilityAccessDeniedByPolicyDespiteDeclaration(t *testing.T) {
-	dec, _ := pluginauthz.EvaluateCapabilityAccess(context.Background(), pluginauthz.CapabilityInput{
+	dec, err := pluginauthz.EvaluateCapabilityAccess(context.Background(), pluginauthz.CapabilityInput{
 		Engine: policytest.DenyAllEngine(), PluginName: "core-objects",
 		Subject: access.PluginSubject("core-objects"),
 		Action:  "read", Resource: "kv:foo", Declared: true,
 	})
+	require.NoError(t, err)
 	assert.False(t, dec.Allowed) // INV-PLUGIN-50: declaration necessary, not sufficient
 }
 

--- a/internal/plugin/pluginauthz/dispatch.go
+++ b/internal/plugin/pluginauthz/dispatch.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginauthz
+
+import "context"
+
+// DispatchContext carries the host-vouched ABAC subject and host-resolved
+// acting-character attributes for one command/event delivery (INV-PLUGIN-51).
+type DispatchContext struct {
+	Subject    string            // host-vouched ABAC subject (access.CharacterSubject)
+	Attributes map[string]string // host-resolved acting-character attributes (location, ...)
+}
+
+type dispatchKey struct{}
+
+// WithDispatch stamps the host-vouched dispatch context. Host-only; called from
+// DeliverCommand/DeliverEvent before any plugin code runs (INV-PLUGIN-51).
+func WithDispatch(ctx context.Context, dc DispatchContext) context.Context {
+	return context.WithValue(ctx, dispatchKey{}, dc)
+}
+
+// DispatchForHost reads the dispatch context. Exported for the host-side
+// readers in other packages (hostcap interceptor, command-registry servers,
+// Lua hostfuncs). Plugins are not Go callers of this package and cannot set
+// the key (only WithDispatch does), so exporting the reader is safe.
+func DispatchForHost(ctx context.Context) (DispatchContext, bool) {
+	dc, ok := ctx.Value(dispatchKey{}).(DispatchContext)
+	return dc, ok
+}

--- a/internal/plugin/pluginauthz/dispatch.go
+++ b/internal/plugin/pluginauthz/dispatch.go
@@ -12,6 +12,21 @@ type DispatchContext struct {
 	Attributes map[string]string // host-resolved acting-character attributes (location, ...)
 }
 
+// AttributeResolver resolves host-vouched dispatch attributes for an ABAC
+// subject (e.g. the acting character's "location") at delivery time. It is
+// satisfied structurally by the production attribute resolver
+// (access/policy/attribute.Resolver, via ResolveSubject) and by
+// access/policy/attribute.CharacterProvider. The plugin hosts use it to
+// populate DispatchContext.Attributes (holomush-eykuh.3); a nil resolver leaves
+// Attributes nil, which is fail-closed at scope-enforcement time (the DSL
+// evaluator treats missing attributes as false for every operator).
+//
+// pluginauthz MUST NOT import the attribute package — the dependency is one-way
+// (the resolver satisfies this interface, not the other way around).
+type AttributeResolver interface {
+	ResolveSubject(ctx context.Context, subject string) (map[string]any, error)
+}
+
 type dispatchKey struct{}
 
 // WithDispatch stamps the host-vouched dispatch context. Host-only; called from

--- a/internal/plugin/pluginauthz/dispatch_test.go
+++ b/internal/plugin/pluginauthz/dispatch_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginauthz_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+func TestDispatchContextRoundTrips(t *testing.T) {
+	dc := pluginauthz.DispatchContext{Subject: "character:01ABC", Attributes: map[string]string{"location": "01LOC"}}
+	ctx := pluginauthz.WithDispatch(context.Background(), dc)
+	got, ok := pluginauthz.DispatchForHost(ctx)
+	require.True(t, ok)
+	assert.Equal(t, dc.Subject, got.Subject)
+	assert.Equal(t, "01LOC", got.Attributes["location"])
+}
+
+func TestDispatchAbsentByDefault(t *testing.T) {
+	_, ok := pluginauthz.DispatchForHost(context.Background())
+	assert.False(t, ok, "absent dispatch context must be detectable for fail-closed")
+}

--- a/internal/plugin/schema.go
+++ b/internal/plugin/schema.go
@@ -98,6 +98,7 @@ func tightenRequiresSchema(schema *jsonschema.Schema) {
 	objProps.Set("version", &jsonschema.Schema{Type: "string"})
 	objProps.Set("optional", &jsonschema.Schema{Type: "boolean"})
 	objProps.Set("scope", &jsonschema.Schema{Type: "string"})
+	objProps.Set("access", &jsonschema.Schema{Type: "string"})
 
 	objectForm := &jsonschema.Schema{
 		Type: "object",

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -205,6 +205,11 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		// merged map at Load time (INV-PLUGIN-3: identical merged map for both
 		// binary and Lua runtimes via plugins.MergePluginConfig).
 		pluginlua.WithPluginConfigOverrides(s.cfg.PluginConfigOverrides),
+		// Wire the attribute resolver so stampDispatch populates
+		// DispatchContext.Attributes (notably "location") at delivery time
+		// (holomush-eykuh.3). Same instance as the binary host below
+		// (plugin-runtime-symmetry); it is the resolver the ABAC engine reads.
+		pluginlua.WithDispatchAttributeResolver(s.cfg.ABAC.AttributeResolver()),
 	)
 
 	// 4. Create service registry for proto service resolution.
@@ -285,6 +290,11 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		// Thread per-plugin config overrides from PluginSubsystemConfig into the
 		// binary host so overrideFor() can look them up at plugin init time.
 		goplugin.WithConfigOverrides(s.cfg.PluginConfigOverrides),
+		// Wire the attribute resolver so stampDispatch populates
+		// DispatchContext.Attributes (notably "location") at delivery time for
+		// binary plugins (holomush-eykuh.3). Same resolver instance as the Lua
+		// host above (plugin-runtime-symmetry).
+		goplugin.WithDispatchAttributeResolver(s.cfg.ABAC.AttributeResolver()),
 	)
 
 	if s.cfg.CertsDir != "" {

--- a/internal/plugin/setup/subsystem_wiring_test.go
+++ b/internal/plugin/setup/subsystem_wiring_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 	lua "github.com/yuin/gopher-lua"
 
+	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/commandquery"
 	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 )
 
 // TestPluginSubsystemWiresCommandQuerierIntoLuaHost documents the late-binding
@@ -72,7 +74,13 @@ func TestPluginSubsystemWiresCommandQuerierIntoLuaHost(t *testing.T) {
 
 	L2 := lua.NewState()
 	defer L2.Close()
-	L2.SetContext(context.Background())
+	// list_commands reads the host-vouched dispatch subject (INV-PLUGIN-51,
+	// holomush-eykuh.3); in production stampDispatch sets it from the dispatcher's
+	// ActorCharacter. This test invokes list_commands directly (no DeliverCommand),
+	// so stamp the dispatch context on the Lua VM ctx itself.
+	L2.SetContext(pluginauthz.WithDispatch(context.Background(), pluginauthz.DispatchContext{
+		Subject: access.CharacterSubject(charID.String()),
+	}))
 	hfWired.Register(L2, "test-plugin")
 
 	err = L2.DoString(`result, errMsg = holomush.list_commands("` + charID.String() + `")`)

--- a/pkg/plugin/command_lister.go
+++ b/pkg/plugin/command_lister.go
@@ -47,11 +47,18 @@ func newHostCommandClient(conn grpc.ClientConnInterface) CommandLister {
 }
 
 // ListCommands implements CommandLister. A nil client fails closed.
+//
+// The host command-registry handler derives the ABAC subject from the
+// host-vouched dispatch-token actor via LookupActor (holomush-eykuh.3), so the
+// per-dispatch token MUST be ferried from the incoming command/event context to
+// this outgoing RPC — identical to the Evaluate / Settings clients. Without it
+// the handler fails closed with EMIT_TOKEN_MISSING. The wire character_id is
+// retained for diagnostics only; the handler ignores it for authorization.
 func (c *hostCommandClient) ListCommands(ctx context.Context, characterID string) (CommandList, error) {
 	if c.client == nil {
 		return CommandList{}, oops.New("host command lister client is not configured")
 	}
-	resp, err := c.client.ListCommands(ctx, &hostv1.ListCommandsRequest{CharacterId: characterID})
+	resp, err := c.client.ListCommands(withDispatchToken(ctx), &hostv1.ListCommandsRequest{CharacterId: characterID})
 	if err != nil {
 		return CommandList{}, oops.With("character_id", characterID).Wrap(err)
 	}

--- a/plugins/core-scenes/plugin.yaml
+++ b/plugins/core-scenes/plugin.yaml
@@ -8,6 +8,21 @@ resource_types: [scene]
 
 requires:
   - holomush.world.v1.WorldService
+  # Host capabilities core-scenes invokes through its SDK clients (eykuh.3
+  # least-privilege). The host capability interceptor default-denies any
+  # host.v1 capability a manifest does not declare, so each client call below
+  # must have a matching declaration. `emit` is self-gated by the emit fence
+  # (declarationExemptCapabilities) and is intentionally NOT declared here.
+  - capability: focus # FocusService: JoinFocus/AutoFocusOnJoin/... (commands.go)
+    access: write
+  - capability: eval # EvalService.Evaluate — admin-gated scene commands
+    access: read
+  - capability: settings # SettingsService.GetSetting — content-warning taxonomy
+    access: read
+  - capability: stream.history # StreamHistoryService.QueryStreamHistory
+    access: read
+  - capability: audit # AuditService.DecryptOwnAuditRows — publish/export snapshot read-back
+    access: read
 
 provides:
   - holomush.scene.v1.SceneService

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -280,6 +280,9 @@
               },
               "scope": {
                 "type": "string"
+              },
+              "access": {
+                "type": "string"
               }
             },
             "additionalProperties": false,

--- a/test/integration/plugin/command_introspection_parity_test.go
+++ b/test/integration/plugin/command_introspection_parity_test.go
@@ -57,6 +57,7 @@ import (
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/goplugin"
 	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 	"github.com/holomush/holomush/internal/plugin/plugintest"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 )
@@ -143,7 +144,15 @@ func luaNamesForQuerier(ctx context.Context, q *commandquery.Querier, charID str
 	hf := hostfunc.New(nil, hostfunc.WithCommandQuerier(q))
 	L := lua.NewState()
 	defer L.Close()
-	L.SetContext(ctx)
+	// Stamp the host-vouched dispatch subject for charID, mirroring what the
+	// Lua host's stampDispatch sets on ls.Context() before plugin code runs
+	// (INV-PLUGIN-51 / eykuh.3.6). The hostfunc derives the ABAC subject from
+	// this dispatch context, NOT from the Lua-supplied arg — the binary side
+	// derives it the same way (host-side) inside host.DeliverEvent, so this
+	// keeps the parity comparison honest.
+	L.SetContext(pluginauthz.WithDispatch(ctx, pluginauthz.DispatchContext{
+		Subject: access.CharacterSubject(charID),
+	}))
 	hf.Register(L, "test-parity-plugin")
 
 	err := L.DoString(`result, listErr = holomush.list_commands("` + charID + `")`)


### PR DESCRIPTION
## Summary

Implements sub-spec 4 of the plugin-capability epic (`holomush-eykuh.3`): declaration-gated, least-privilege host-capability access with ABAC, plus the command-registry subject-spoofing fix. A plugin now gets **only** what it declares, enforced uniformly across the binary and Lua runtimes (plugin-runtime-symmetry).

**What changed (14 commits):**
- **Manifest:** `access:`/`scope:` fields on capability `requires` entries + validation (capability-only, well-formed; `INV-PLUGIN-53`).
- **CapabilityDescriptor table** (`internal/plugin/hostcap`): host-owned per-method Action/Resource/Class/Scopes/Extract for **all 14 served capabilities**; scope-eligible `world.mutation` rows with typed extractors.
- **DispatchContext** (`pluginauthz`): host-vouched subject + resolved attributes (`location`) stamped on the delivery ctx at both runtimes; attribute resolver wired through `setup/subsystem.go`.
- **Capability interceptor** (one, runtime-neutral): static declaration + `access:`-class checks (M2); dynamic operator-policy + `scope:own-location` enforcement (M1/M3) keyed on the `plugin:<name>` subject; fail-closed throughout. Installed symmetrically on the binary broker + Lua bufconn servers.
- **`EvaluateCapabilityAccess`**: capability-access entitlement (manifest-declaration, not OwnedTypes; `INV-PLUGIN-50`).
- **Command-registry trust fix (PR #4430 finding):** `ListCommands`/`GetCommandHelp` derive the ABAC subject from the host-vouched actor (binary: dispatch token via `LookupActor`; Lua: `DispatchForHost`) — the wire/arg `character_id` is no longer trusted, on **both** runtimes.
- **Self-gated exemption:** `emit` and `command-registry` are exempt from the declaration gate (their own mechanisms gate them) to avoid double-gating.
- **Seed policy** `seed:plugin-world-mutation-own-location` + bound invariants `INV-PLUGIN-50..53`.

## Test Plan
- [x] `task pr-prep` (fast lane) green — lint/fmt/unit/build/bats
- [x] Plugin + whole-system integration suites green
- [x] Invariant meta-gates green; `INV-PLUGIN-50..53` bound
- [ ] CI: `Integration Test` + `E2E Test` required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)