### PR TITLE
docs(plugin): capability-declaration enforcement — spec, plan, ADRs (holomush-si3zs)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,11 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Gate binary plugin capability injection on manifest declaration](holomush-m4ac3-gate-binary-plugin-capability-injection-manifest-declaration.md) | 2026-06-13 | Accepted | `holomush-m4ac3` |
+| [Make binary plugin Init unconditional to close the degenerate-manifest escape](holomush-toh7a-make-binary-plugin-init-unconditional-close-degenerate-manif.md) | 2026-06-13 | Accepted | `holomush-toh7a` |
+| [Two single-clause capability-enforcement invariants (INV-PLUGIN-54 / 55)](holomush-1psri-two-single-clause-capability-enforcement-invariants-inv-plug.md) | 2026-06-13 | Accepted | `holomush-1psri` |
+| [Wholesystem census as the capability-declaration integration guard](holomush-wlyzs-wholesystem-census-as-capability-declaration-integration-gua.md) | 2026-06-13 | Accepted | `holomush-wlyzs` |
+| [Defer Lua capability-declaration enforcement to eykuh.4 (binary-only now)](holomush-nk46j-defer-lua-capability-declaration-enforcement-eykuh-4-binary.md) | 2026-06-13 | Accepted | `holomush-nk46j` |
 | [Stamp dispatch context host-side; never accept a wire subject](holomush-wvrtc-stamp-dispatch-context-host-side-never-accept-wire-subject.md) | 2026-06-12 | Accepted | `holomush-wvrtc` |
 | [Capability access is a default-deny ABAC decision, not a set check](holomush-syhc2-capability-access-is-default-deny-abac-decision-not-set-chec.md) | 2026-06-12 | Accepted | `holomush-syhc2` |
 | [access: and scope: are valid only on capability entries, not service entries](holomush-u1sdq-access-and-scope-are-valid-only-capability-entries-not-servi.md) | 2026-06-12 | Accepted | `holomush-u1sdq` |

--- a/docs/adr/holomush-1psri-two-single-clause-capability-enforcement-invariants-inv-plug.md
+++ b/docs/adr/holomush-1psri-two-single-clause-capability-enforcement-invariants-inv-plug.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-1psri; do not edit manually; use `/adr update holomush-1psri` -->
+
+# Two single-clause capability-enforcement invariants (INV-PLUGIN-54 / 55)
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-1psri
+**Deciders:** Sean Brandt, Claude Opus 4.8
+
+## Context
+
+Binary capability enforcement is provable now; Lua enforcement is unverified until holomush-eykuh.4 migrates production Lua off the legacy hostfunc shim. The invariant registry prohibits a pending entry carrying asserted_by, and warns against a bound multi-clause entry whose test proves only one clause (partial-binding hazard).
+
+## Decision
+
+Register INV-PLUGIN-54 (binary, binding: bound, with asserted_by) and INV-PLUGIN-55 (Lua, binding: pending, no asserted_by) as two separate entries in docs/architecture/invariants.yaml.
+
+## Rationale
+
+- No registry-honest way to represent 'binary proven, Lua not yet' with one entry (partial-binding hazard + pending-with-asserted_by is rejected by TestProvenanceGuard).\n- Two entries let the binary guarantee bind immediately and give eykuh.4 a named target (55 pending → bound).
+
+## Alternatives Considered
+
+**Single multi-clause invariant** (binary+Lua together): rejected — cannot bind until both proven; would delay a provable guarantee or fabricate provenance.\n**Two single-clause entries** (chosen).
+
+## Consequences
+
+Positive: 54 bound now with genuine provenance; 55 is a durable cross-reference eykuh.4 cannot forget; meta-tests pass. Negative: parity story split across two IDs. Neutral: 55 stays pending until eykuh.4 (not a CI failure).

--- a/docs/adr/holomush-m4ac3-gate-binary-plugin-capability-injection-manifest-declaration.md
+++ b/docs/adr/holomush-m4ac3-gate-binary-plugin-capability-injection-manifest-declaration.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-m4ac3; do not edit manually; use `/adr update holomush-m4ac3` -->
+
+# Gate binary plugin capability injection on manifest declaration
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-m4ac3
+**Deciders:** Sean Brandt, Claude Opus 4.8
+
+## Context
+
+Binary plugin SDK Init (pkg/plugin/sdk.go) unconditionally type-asserts the provider against *Aware interfaces and injects host-capability clients regardless of manifest declarations (the root of the eykuh.3 scenes CI regression). Enforcement model needed for INV-PLUGIN-54.
+
+## Decision
+
+pluginServerAdapter.Init validates declared capabilities BEFORE injecting any host-capability client; injection is reached only for a validated (declared) capability — gate and validate realized as a single pre-injection pass that fails load (CAPABILITY_NOT_DECLARED) on an undeclared non-exempt capability.
+
+## Rationale
+
+- Gating on declaration enforces least-privilege structurally, not just at error-path time — a plugin cannot receive a client it did not declare.\n- Converges binary wiring with eykuh.4's declaration-gated Lua end state (plugin-runtime-symmetry).\n- Closes an escape hatch: validate-only would still inject if the error were ever suppressed.
+
+## Alternatives Considered
+
+**Validate-only** (fail load but still inject by *Aware): rejected — leaves binary structurally divergent from the Lua end state and not least-privilege.\n**Gate + validate** (chosen): injection structurally gated on declaration.
+
+## Consequences
+
+Positive: binary capability wiring is structurally least-privilege; convergent with eykuh.4. Negative: existing injection tests that omit declarations must add DeclaredCapabilities. Neutral: zero overhead on the healthy path.

--- a/docs/adr/holomush-nk46j-defer-lua-capability-declaration-enforcement-eykuh-4-binary.md
+++ b/docs/adr/holomush-nk46j-defer-lua-capability-declaration-enforcement-eykuh-4-binary.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-nk46j; do not edit manually; use `/adr update holomush-nk46j` -->
+
+# Defer Lua capability-declaration enforcement to eykuh.4 (binary-only now)
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-nk46j
+**Deciders:** Sean Brandt, Claude Opus 4.8
+
+## Context
+
+Both runtimes have ungated capability injection in production today. Binary consumption is statically knowable via *Aware interfaces; Lua requires migrating production off the legacy hostfunc shim onto the declaration-gated luabridge — work scoped to holomush-eykuh.4.
+
+## Decision
+
+This spec delivers the binary half only; production Lua wiring is explicitly not altered. INV-PLUGIN-55 is registered pending until eykuh.4 migrates production Lua onto the declaration-gated bridge.
+
+## Rationale
+
+- Binary *Aware interfaces give a complete static picture of consumption; Lua script usage is not knowable from Go.\n- The declaration-gated Lua bridge already exists (luabridge/WithHostCapBridge); the missing work is the production migration = eykuh.4's scope.\n- Doing both here would make this spec contingent on eykuh.4 and unbounded.
+
+## Alternatives Considered
+
+**Attempt partial Lua migration in this spec**: rejected — eykuh.4-sized; would delay a completeable binary improvement.\n**Binary-only, defer Lua** (chosen).
+
+## Consequences
+
+Positive: binary enforcement ships on a clean bounded timeline; INV-PLUGIN-55 pending entry is a durable cross-reference. Negative: runtime asymmetry (and a temporary plugin-runtime-symmetry gap in production) persists until eykuh.4. Neutral: the eykuh.3 call-time interceptor already enforces both runtimes at CALL time; this adds binary LOAD-time.

--- a/docs/adr/holomush-toh7a-make-binary-plugin-init-unconditional-close-degenerate-manif.md
+++ b/docs/adr/holomush-toh7a-make-binary-plugin-init-unconditional-close-degenerate-manif.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-toh7a; do not edit manually; use `/adr update holomush-toh7a` -->
+
+# Make binary plugin Init unconditional to close the degenerate-manifest escape
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-toh7a
+**Deciders:** Sean Brandt, Claude Opus 4.8
+
+## Context
+
+The host loader gates Init on manifestNeedsInit (requires/storage/config/emits). With capability validation in the SDK Init, a binary plugin implementing a *Aware interface but declaring nothing would skip Init and escape INV-PLUGIN-54 load-time enforcement. Discovered during plan grounding.
+
+## Decision
+
+Replace the manifestNeedsInit gate with needsInit := true for binary plugins; all binary plugins are Init'd so the SDK capability validation always runs.
+
+## Rationale
+
+- A *Aware-implementing plugin with no other manifest fields would otherwise satisfy the skip conditions — a silent fail-open.\n- Unconditional Init is the simplest predicate (no edge cases).\n- The extra gRPC round-trip for a trivial plugin is negligible.
+
+## Alternatives Considered
+
+**Keep the gate + add a capability-check exemption**: rejected — a two-predicate gate is harder to reason about and still risks escape.\n**Unconditional Init** (chosen): definitively closes the gap; manifestNeedsInit + its tests can be deleted.
+
+## Consequences
+
+Positive: INV-PLUGIN-54 genuinely airtight; less code. Negative: empty-manifest binary plugins incur one extra round-trip; skip-Init tests inverted. Neutral: recorded as a refinement of spec §3.2.

--- a/docs/adr/holomush-wlyzs-wholesystem-census-as-capability-declaration-integration-gua.md
+++ b/docs/adr/holomush-wlyzs-wholesystem-census-as-capability-declaration-integration-gua.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-wlyzs; do not edit manually; use `/adr update holomush-wlyzs` -->
+
+# Wholesystem census as the capability-declaration integration guard
+
+**Date:** 2026-06-13
+**Status:** Accepted
+**Decision:** holomush-wlyzs
+**Deciders:** Sean Brandt, Claude Opus 4.8
+
+## Context
+
+With load-time SDK validation, a misdeclared binary plugin fails Manager.LoadAll. The in-tree enforcement approach needed deciding: reuse the existing wholesystem census (loads all in-tree plugins via the real path) or add a separate static meta-test.
+
+## Decision
+
+The existing test/integration/wholesystem census is the integration enforcement point; no separate capability meta-test is introduced. A misdeclared plugin fails load → fails the census automatically.
+
+## Rationale
+
+- With Init validation in place, the census becomes an enforcer for free — enforcement is the runtime itself, not a test approximation.\n- A separately-maintained token map in test code would drift from the runtime registry (two sources of truth).\n- Reflection/AST alternatives are blocked or advisory.
+
+## Alternatives Considered
+
+**AST/source-scan meta-test**: rejected — CI-only, advisory, hand-maintained map, redundant once census is the guard.\n**Reflection meta-test**: rejected/blocked — binary plugins are package main, providers not importable.\n**Wholesystem census** (chosen).
+
+## Consequences
+
+Positive: no new infra; future in-tree plugins auto-covered; no test false-negative possible (runtime is the enforcer). Negative: runs in task test:int (Docker), not the fast pr-prep lane; covers only in-tree plugins (acceptable — no external ecosystem). Neutral: pkg/plugin unit tests still cover the validation logic itself.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -326,6 +326,8 @@ invariants.
 | `INV-PLUGIN-51` | Any character subject or dispatch attribute used in a plugin-mediated authorization decision MUST be host-vouched (derived from the host delivery context) and MUST NOT originate from plugin- or wire-supplied data. Covers the command-registry RPCs and scope: anchoring. | — | bound |
 | `INV-PLUGIN-52` | Every scope-eligible capability method MUST resolve its scoped resource through a wired extractor; a method missing its extractor MUST fail closed (deny), never forward unscoped. No silent fail-open. | — | bound |
 | `INV-PLUGIN-53` | The per-entry least-privilege parameters (access:, scope:) are valid only on a capability: requires entry; either on a service: entry MUST be a hard manifest error at load. | — | bound |
+| `INV-PLUGIN-54` | A binary plugin's Init MUST fail closed when its provider implements a host-capability *Aware interface for a non-exempt capability absent from the manifest; capability clients are injected only for declared capabilities. emit and command-registry are self-gated and exempt. | — | pending |
+| `INV-PLUGIN-55` | A Lua plugin MUST be wired only the capabilities its manifest declares (declaration-gated host-cap bridge); bound by holomush-eykuh.4's production Lua migration off the legacy hostfunc shim. | — | pending |
 
 ### `INV-EVENTBUS`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3847,6 +3847,19 @@ invariants:
     binding: bound
     asserted_by:
       - "internal/plugin/manifest_test.go"
+  - id: INV-PLUGIN-54
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md"
+    summary: "A binary plugin's Init MUST fail closed when its provider implements a host-capability *Aware interface for
+      a non-exempt capability absent from the manifest; capability clients are injected only for declared capabilities. emit
+      and command-registry are self-gated and exempt."
+    binding: pending
+  - id: INV-PLUGIN-55
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md"
+    summary: "A Lua plugin MUST be wired only the capabilities its manifest declares (declaration-gated host-cap bridge);
+      bound by holomush-eykuh.4's production Lua migration off the legacy hostfunc shim."
+    binding: pending
   - id: INV-COMMAND-1
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/docs/superpowers/plans/2026-06-13-plugin-capability-declaration-enforcement.md
+++ b/docs/superpowers/plans/2026-06-13-plugin-capability-declaration-enforcement.md
@@ -1,0 +1,563 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Capability-Declaration Enforcement (binary half) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a binary plugin fail to load (fail-closed) when its code can consume a non-exempt `host.v1` capability its manifest does not declare, bringing binary plugins to parity with Lua's declaration-driven wiring.
+
+**Architecture:** The host passes the manifest's declared capabilities to the binary plugin via a new `ServiceConfig.declared_capabilities` proto field; the plugin SDK's `Init` validates — before injecting any host-capability client — that every non-exempt capability token granted by an implemented `*Aware` interface is declared, returning `CAPABILITY_NOT_DECLARED` (which fails `Init` → fails load) otherwise. Validation runs before injection, so injection is reached only for validated declarations (the spec's gate+validate, realized as one validation pass). The host calls `Init` unconditionally for binary plugins so the validation always runs. The existing wholesystem census becomes the integration guard.
+
+**Tech Stack:** Go, Protocol Buffers (`buf`), `oops` errors, `manifest.RequiredCapabilities()`, testify.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md`
+**Design bead:** holomush-si3zs · **Invariants:** INV-PLUGIN-54 (binary, bound by this plan) / INV-PLUGIN-55 (Lua, pending → eykuh.4)
+
+---
+
+## File Structure
+
+- `api/proto/holomush/plugin/v1/plugin.proto` — add `declared_capabilities` to `ServiceConfig` (Task 1).
+- `pkg/plugin/*.pb.go` — regenerated (Task 1).
+- `pkg/plugin/capability_declaration.go` (Create) — the `*Aware`→token requirement registry + `validateDeclaredCapabilities` (Task 2).
+- `pkg/plugin/capability_declaration_test.go` (Create) — unit tests for validation; **binds INV-PLUGIN-54** (Task 2).
+- `pkg/plugin/sdk.go` — wire validation into `pluginServerAdapter.Init` before injection (Task 3).
+- `pkg/plugin/capability_declaration_registry_test.go` (Create) — registry-completeness meta-test (Task 4).
+- `internal/plugin/goplugin/host.go` — populate `declared_capabilities`; make `Init` unconditional for binary plugins (Task 5).
+- `internal/plugin/goplugin/host_test.go` — update/remove `manifestNeedsInit` tests (Task 5).
+- `docs/architecture/invariants.yaml` + `docs/architecture/invariants.md` — register INV-PLUGIN-54/55 + regen (Task 6).
+- `test/integration/wholesystem/census_test.go` — positive guard assertion (Task 7).
+
+---
+
+## Task 1: Add `declared_capabilities` to the `ServiceConfig` proto
+
+**Files:**
+
+- Modify: `api/proto/holomush/plugin/v1/plugin.proto:54-66`
+- Regenerate: `pkg/plugin/v1/*.pb.go` (via `buf`)
+
+- [ ] **Step 1: Add the field** to the `ServiceConfig` message, after `plugin_config = 3`:
+
+```proto
+  // Capability tokens the plugin declared in its manifest `requires:`
+  // (manifest.RequiredCapabilities()). The plugin SDK validates, at Init, that
+  // every non-exempt host capability its code can consume (via an implemented
+  // *Aware interface) appears here, failing load otherwise (INV-PLUGIN-54).
+  repeated string declared_capabilities = 4;
+```
+
+- [ ] **Step 2: Regenerate proto bindings**
+
+Run: `task proto:generate` (or `buf generate` per the repo's proto task)
+Expected: `pkg/plugin/.../service.pb.go` (or equivalent) gains `ServiceConfig.DeclaredCapabilities []string` + `GetDeclaredCapabilities()`.
+
+- [ ] **Step 3: Verify the generated accessor exists**
+
+Run: `rg -n 'func \(x \*ServiceConfig\) GetDeclaredCapabilities' pkg/plugin`
+Expected: one match.
+
+- [ ] **Step 4: Verify proto lint passes**
+
+Run: `task lint:proto`
+Expected: PASS (the new field has a Go-grounded doc comment; no name-echo).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(plugin): add ServiceConfig.declared_capabilities proto field (holomush-si3zs)"`
+
+---
+
+## Task 2: SDK validation registry + `validateDeclaredCapabilities`
+
+**Files:**
+
+- Create: `pkg/plugin/capability_declaration.go`
+- Test: `pkg/plugin/capability_declaration_test.go`
+
+- [ ] **Step 1: Write the failing test** (`pkg/plugin/capability_declaration_test.go`)
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// focusOnlyProvider implements FocusClientAware (grants focus + stream.history).
+type focusOnlyProvider struct{ ServiceProvider }
+
+func (focusOnlyProvider) SetFocusClient(FocusClient) {}
+
+// Verifies: INV-PLUGIN-54
+func TestValidateDeclaredCapabilitiesFailsClosedOnUndeclared(t *testing.T) {
+	// FocusClientAware grants focus + stream.history; declaring only focus must fail.
+	err := validateDeclaredCapabilities(focusOnlyProvider{}, []string{"focus"})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "CAPABILITY_NOT_DECLARED")
+	assert.Contains(t, err.Error(), "stream.history")
+}
+
+// Verifies: INV-PLUGIN-54
+func TestValidateDeclaredCapabilitiesPassesWhenAllDeclared(t *testing.T) {
+	err := validateDeclaredCapabilities(focusOnlyProvider{}, []string{"focus", "stream.history"})
+	require.NoError(t, err)
+}
+
+// emitOnlyProvider implements EventSinkAware (emit is exempt — no declaration needed).
+type emitOnlyProvider struct{ ServiceProvider }
+
+func (emitOnlyProvider) SetEventSink(EventSink) {}
+
+// Verifies: INV-PLUGIN-54
+func TestValidateDeclaredCapabilitiesExemptNeedsNoDeclaration(t *testing.T) {
+	err := validateDeclaredCapabilities(emitOnlyProvider{}, nil)
+	require.NoError(t, err, "emit is self-gated (exempt); needs no declaration")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestValidateDeclaredCapabilities ./pkg/plugin/`
+Expected: FAIL — `validateDeclaredCapabilities` undefined.
+
+- [ ] **Step 3: Write the implementation** (`pkg/plugin/capability_declaration.go`)
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import "github.com/samber/oops"
+
+// capabilityRequirement pairs a predicate reporting whether a provider opts into
+// a host capability (by implementing its *Aware interface) with the non-exempt
+// capability tokens that opt-in requires the manifest to declare. Exempt
+// capabilities (emit, command-registry) carry an empty tokens slice: opting in
+// is allowed with no declaration because they are self-gated (emit fence /
+// host-vouched dispatch subject), matching hostcap.declarationExemptCapabilities.
+type capabilityRequirement struct {
+	awareName  string          // *Aware interface name, for error messages
+	implements func(any) bool  // does the provider implement the interface?
+	tokens     []string        // non-exempt capability tokens it grants
+}
+
+// hostCapabilityRequirements is the single source of truth mapping each
+// host-capability *Aware interface to the capability tokens a provider
+// implementing it MUST declare in its manifest requires: (INV-PLUGIN-54).
+// FocusClientAware grants BOTH focus and stream.history (one interface backed by
+// FocusServiceClient + StreamHistoryServiceClient; pkg/plugin/focus_client.go).
+var hostCapabilityRequirements = []capabilityRequirement{
+	{"EventSinkAware", func(p any) bool { _, ok := p.(EventSinkAware); return ok }, nil}, // emit: exempt
+	{"FocusClientAware", func(p any) bool { _, ok := p.(FocusClientAware); return ok }, []string{"focus", "stream.history"}},
+	{"HostEvaluatorAware", func(p any) bool { _, ok := p.(HostEvaluatorAware); return ok }, []string{"eval"}},
+	{"SettingsClientAware", func(p any) bool { _, ok := p.(SettingsClientAware); return ok }, []string{"settings"}},
+	{"SnapshotDecryptorAware", func(p any) bool { _, ok := p.(SnapshotDecryptorAware); return ok }, []string{"audit"}},
+	{"CommandListerAware", func(p any) bool { _, ok := p.(CommandListerAware); return ok }, nil}, // command-registry: exempt
+}
+
+// validateDeclaredCapabilities returns a CAPABILITY_NOT_DECLARED error when the
+// provider implements a host-capability *Aware interface for a non-exempt
+// capability token absent from declared. Fail-closed: any undeclared token fails
+// plugin Init (and thus load), the host-side load-time half of INV-PLUGIN-54.
+func validateDeclaredCapabilities(provider any, declared []string) error {
+	declaredSet := make(map[string]bool, len(declared))
+	for _, c := range declared {
+		declaredSet[c] = true
+	}
+	for _, req := range hostCapabilityRequirements {
+		if !req.implements(provider) {
+			continue
+		}
+		for _, tok := range req.tokens {
+			if !declaredSet[tok] {
+				return oops.Code("CAPABILITY_NOT_DECLARED").
+					With("capability", tok).
+					With("aware_interface", req.awareName).
+					Errorf("plugin implements %s but did not declare capability %q in its manifest requires:", req.awareName, tok)
+			}
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestValidateDeclaredCapabilities ./pkg/plugin/`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(plugin): SDK capability-declaration validation registry (INV-PLUGIN-54, holomush-si3zs)"`
+
+---
+
+## Task 3: Wire validation into `pluginServerAdapter.Init`
+
+**Files:**
+
+- Modify: `pkg/plugin/sdk.go:157-205` (the `Init` method, before the injection block)
+- Test: `pkg/plugin/service_test.go` (extend with a validation-failure case)
+
+- [ ] **Step 1: Write the failing test** (append to `pkg/plugin/service_test.go`)
+
+```go
+// focusUndeclaredProvider implements FocusClientAware but the InitRequest will
+// declare no capabilities — Init must fail closed (INV-PLUGIN-54).
+type focusUndeclaredProvider struct{ focusClient FocusClient }
+
+func (p *focusUndeclaredProvider) SetFocusClient(c FocusClient) { p.focusClient = c }
+func (p *focusUndeclaredProvider) Init(context.Context, *pluginv1.ServiceConfig) error { return nil }
+
+// RegisterServices satisfies ServiceProvider (service.go:46) — the registrar is
+// grpc.ServiceRegistrar, NOT *grpc.Server. Mirrors the existing dualAwareProvider.
+func (p *focusUndeclaredProvider) RegisterServices(grpc.ServiceRegistrar) {}
+
+// Verifies: INV-PLUGIN-54
+func TestPluginServerAdapterInitFailsClosedOnUndeclaredCapability(t *testing.T) {
+	adapter := &pluginServerAdapter{serviceProvider: &focusUndeclaredProvider{}}
+	_, err := adapter.Init(context.Background(), &pluginv1.InitRequest{
+		Config: &pluginv1.ServiceConfig{DeclaredCapabilities: nil}, // declares nothing
+	})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "CAPABILITY_NOT_DECLARED")
+}
+```
+
+(Ensure `pkg/errutil` and `pluginv1` are imported in the test file; both are already used in `pkg/plugin`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestPluginServerAdapterInitFailsClosedOnUndeclaredCapability ./pkg/plugin/`
+Expected: FAIL — Init returns nil error (validation not yet wired); injection of focus client also panics on a nil broker, so the test may fail on the wrong path — that is acceptable for the red step (it is not yet returning CAPABILITY_NOT_DECLARED).
+
+- [ ] **Step 3: Add the validation call** in `pkg/plugin/sdk.go::Init`, immediately after `config` is resolved (after the block ending `config = req.GetConfig()` / the `var config` assignment around line 158-162) and **before** the `wantsSink/...` type-assertions:
+
+```go
+	// Fail closed at load: a provider that implements a host-capability *Aware
+	// interface for a non-exempt capability it did not declare must not load
+	// (INV-PLUGIN-54). Validation precedes injection, so a client is only ever
+	// wired for a validated declaration — the spec's gate+validate in one pass.
+	if a.serviceProvider != nil {
+		if err := validateDeclaredCapabilities(a.serviceProvider, req.GetConfig().GetDeclaredCapabilities()); err != nil {
+			return nil, oops.With("phase", "init").Wrap(err)
+		}
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestPluginServerAdapterInit ./pkg/plugin/`
+Expected: PASS — the new failure test plus the existing injection tests (which declare the capabilities their providers use, or use exempt-only providers).
+
+- [ ] **Step 5: Verify no existing pkg/plugin test regressed**
+
+Run: `task test -- ./pkg/plugin/`
+Expected: PASS. If an existing injection test (e.g. `TestPluginServerAdapterInitInjectsBothEventSinkAndFocusClient`) now fails because its provider implements `FocusClientAware` without declaring `focus`/`stream.history`, add `DeclaredCapabilities: []string{"focus", "stream.history"}` to that test's `InitRequest.Config` (EventSink is exempt). Fix each such test minimally.
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "feat(plugin): validate declared capabilities at SDK Init, fail closed (INV-PLUGIN-54, holomush-si3zs)"`
+
+---
+
+## Task 4: Registry-completeness meta-test
+
+**Files:**
+
+- Create: `pkg/plugin/capability_declaration_registry_test.go`
+
+Prevents drift: every host-capability `*Aware` interface in `pkg/plugin` must appear in `hostCapabilityRequirements`, and every non-exempt token it lists must be a real capability token.
+
+- [ ] **Step 1: Write the test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// canonicalNonExemptTokens mirrors the non-exempt host-capability tokens in
+// internal/plugin/capability_vocab.go (CapabilityServiceNames) minus the exempt
+// set (emit, command-registry). It is a literal here ON PURPOSE: pkg/plugin must
+// NOT import internal/plugin (internal/plugin imports pkg/plugin — importing back
+// would cycle). If a capability token is added to the canonical vocab, add it
+// here too; this list is the in-package drift guard for the requirements map.
+var canonicalNonExemptTokens = map[string]bool{
+	"world.query": true, "world.mutation": true, "property": true,
+	"session": true, "session.admin": true, "focus": true, "eval": true,
+	"settings": true, "kv": true, "stream.history": true,
+	"stream.subscription": true, "audit": true,
+}
+
+// TestHostCapabilityRequirementsTokensAreCanonical asserts every token listed in
+// the requirements map is a known non-exempt capability token.
+func TestHostCapabilityRequirementsTokensAreCanonical(t *testing.T) {
+	for _, req := range hostCapabilityRequirements {
+		for _, tok := range req.tokens {
+			assert.Truef(t, canonicalNonExemptTokens[tok],
+				"%s lists token %q which is not a known non-exempt capability token", req.awareName, tok)
+		}
+	}
+}
+
+// TestHostCapabilityRequirementsCoverKnownAwareNames is a guard list: the set of
+// *Aware interface names in hostCapabilityRequirements must equal the known set.
+// Adding a new SetXxx host-client injection in sdk.go without a registry row
+// fails this test.
+func TestHostCapabilityRequirementsCoverKnownAwareNames(t *testing.T) {
+	got := map[string]bool{}
+	for _, req := range hostCapabilityRequirements {
+		got[req.awareName] = true
+	}
+	want := []string{
+		"EventSinkAware", "FocusClientAware", "HostEvaluatorAware",
+		"SettingsClientAware", "SnapshotDecryptorAware", "CommandListerAware",
+	}
+	for _, name := range want {
+		assert.Truef(t, got[name], "hostCapabilityRequirements missing %s", name)
+	}
+	assert.Lenf(t, got, len(want), "hostCapabilityRequirements has an unexpected *Aware row; update want[] and the sdk.go injection block together")
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `task test -- -run TestHostCapabilityRequirements ./pkg/plugin/`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "test(plugin): registry-completeness meta-test for capability requirements (holomush-si3zs)"`
+
+---
+
+## Task 5: Host populates `declared_capabilities` + unconditional binary Init
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host.go:854-857` (InitRequest construction) and `:363` / `:850` (the `needsInit` gate)
+- Modify: `internal/plugin/goplugin/host_test.go` (manifestNeedsInit tests)
+
+- [ ] **Step 1: Write the failing test** (append to `internal/plugin/goplugin/host_test.go`)
+
+Use the existing inline mock-factory harness from this file (the exact pattern at
+`host_test.go:1175-1206`, `TestLoadCallsInitForPostgresStoragePlugin`):
+`mockGRPCPluginClient` → `mockPluginClient{protocol: &mockClientProtocol{pluginClient: …}}`
+→ `NewHostWithFactory(&mockClientFactory{client: …})` → `createTempExecutable` →
+`host.Load(...)`, then assert on `grpcClient.initReq` / `grpcClient.initCalled`.
+
+```go
+// Verifies: INV-PLUGIN-54
+func TestLoadPassesDeclaredCapabilitiesToInit(t *testing.T) {
+	grpcClient := &mockGRPCPluginClient{}
+	mockClient := &mockPluginClient{protocol: &mockClientProtocol{pluginClient: grpcClient}}
+	host := NewHostWithFactory(&mockClientFactory{client: mockClient})
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	require.NoError(t, createTempExecutable(tmpDir+"/test-plugin"))
+
+	manifest := &plugins.Manifest{
+		Name: "test-plugin", Version: "1.0.0", Type: plugins.TypeBinary,
+		BinaryPlugin: &plugins.BinaryConfig{Executable: "test-plugin"},
+		Requires: []plugins.Dependency{
+			{Kind: plugins.DependencyCapability, Name: "focus"},
+			{Kind: plugins.DependencyCapability, Name: "stream.history"},
+		},
+	}
+
+	require.NoError(t, host.Load(ctx, manifest, tmpDir))
+	require.NotNil(t, grpcClient.initReq, "Init must be called")
+	require.NotNil(t, grpcClient.initReq.Config, "ServiceConfig must be set")
+	assert.ElementsMatch(t, []string{"focus", "stream.history"},
+		grpcClient.initReq.Config.GetDeclaredCapabilities())
+}
+
+// Verifies: INV-PLUGIN-54 — unconditional Init: a binary plugin with no
+// requires/storage/config still gets Init, so the SDK capability validation
+// always runs (closes the degenerate "declares nothing" escape).
+func TestLoadCallsInitForBinaryPluginWithNoRequires(t *testing.T) {
+	grpcClient := &mockGRPCPluginClient{}
+	mockClient := &mockPluginClient{protocol: &mockClientProtocol{pluginClient: grpcClient}}
+	host := NewHostWithFactory(&mockClientFactory{client: mockClient})
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	require.NoError(t, createTempExecutable(tmpDir+"/bare-plugin"))
+
+	manifest := &plugins.Manifest{
+		Name: "bare-plugin", Version: "1.0.0", Type: plugins.TypeBinary,
+		BinaryPlugin: &plugins.BinaryConfig{Executable: "bare-plugin"},
+	}
+
+	require.NoError(t, host.Load(ctx, manifest, tmpDir))
+	assert.True(t, grpcClient.initCalled, "Init must be called even with no requires (INV-PLUGIN-54)")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run 'TestLoadPassesDeclaredCapabilitiesToInit|TestLoadCallsInitForBinaryPluginWithNoRequires' ./internal/plugin/goplugin/`
+Expected: FAIL — `TestLoadPasses…` fails (`GetDeclaredCapabilities()` empty, host not populating yet); `TestLoadCallsInitForBinaryPluginWithNoRequires` fails (`manifestNeedsInit` gates Init out for a no-requires plugin → `initCalled` false). Both red drive Steps 3-4.
+
+- [ ] **Step 3: Populate the field** — in `internal/plugin/goplugin/host.go`, the InitRequest construction (currently lines 855-857):
+
+```go
+		initReq := &pluginv1.InitRequest{
+			Config: &pluginv1.ServiceConfig{
+				RequiredServices:     requiredServices,
+				DeclaredCapabilities: manifest.RequiredCapabilities(),
+			},
+		}
+```
+
+- [ ] **Step 4: Make Init unconditional for binary plugins** — replace `needsInit := manifestNeedsInit(manifest)` (around line 850) with:
+
+```go
+	// All binary plugins are Init'd so the SDK validates declared capabilities
+	// even when the manifest has no requires/storage/config/emits — without this
+	// a plugin implementing a capability *Aware interface but declaring nothing
+	// would skip Init and escape the INV-PLUGIN-54 load-time check.
+	needsInit := true
+```
+
+Then check for other callers of `manifestNeedsInit`:
+
+Run: `rg -n 'manifestNeedsInit' internal/`
+
+- If the only references are its definition + this call site + its tests: delete the `manifestNeedsInit` function (host.go:359-369) and its dedicated tests, leaving `needsInit := true`.
+- If referenced elsewhere: keep the function but set `needsInit := true` at this call site and note why.
+
+- [ ] **Step 5: Update `manifestNeedsInit` tests** — remove/replace any test asserting Init is skipped for trivial binary plugins (those now always Init). Run:
+
+Run: `rg -n 'manifestNeedsInit|needsInit|Init.*not.*called|expected.*no.*init' internal/plugin/goplugin/host_test.go`
+Fix each: delete the skip-Init assertion or invert it to expect Init is now always called.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `task test -- ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+`jj commit -m "feat(plugin): host passes declared_capabilities + always Init binary plugins (INV-PLUGIN-54, holomush-si3zs)"`
+
+---
+
+## Task 6: Register INV-PLUGIN-54 (bound) + INV-PLUGIN-55 (pending)
+
+**Files:**
+
+- Modify: `docs/architecture/invariants.yaml`
+- Regenerate: `docs/architecture/invariants.md` (via `go run ./cmd/inv-render`)
+
+- [ ] **Step 1: Add both entries** to `docs/architecture/invariants.yaml` (match the existing INV-PLUGIN entry schema exactly — copy a neighbor like INV-PLUGIN-50 for field shape):
+
+```yaml
+  - id: INV-PLUGIN-54
+    scope: PLUGIN
+    origin_spec: docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md
+    summary: >-
+      A binary plugin's Init fails closed when its provider implements a
+      host-capability *Aware interface for a non-exempt capability absent from
+      the manifest; capability clients are injected only for declared
+      capabilities. emit and command-registry are self-gated and exempt.
+    binding: bound
+    asserted_by:
+      - pkg/plugin/capability_declaration_test.go
+      - pkg/plugin/service_test.go
+  - id: INV-PLUGIN-55
+    scope: PLUGIN
+    origin_spec: docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md
+    summary: >-
+      A Lua plugin is wired only the capabilities its manifest declares
+      (declaration-gated host-cap bridge). Pending until holomush-eykuh.4
+      migrates production Lua off the legacy hostfunc shim.
+    binding: pending
+```
+
+(Do **not** add `asserted_by` to INV-PLUGIN-55 — the meta-test rejects a `pending` entry with provenance.)
+
+- [ ] **Step 2: Regenerate the rendered table**
+
+Run: `go run ./cmd/inv-render`
+Expected: `docs/architecture/invariants.md` updates inside the generated regions with INV-PLUGIN-54/55 rows.
+
+- [ ] **Step 3: Run the registry meta-tests**
+
+Run: `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestProvenanceGuard|TestBoundInvariantsAreGenuinelyAsserted' ./test/meta/`
+Expected: PASS — INV-PLUGIN-54 bound with genuine asserting tests; INV-PLUGIN-55 pending with no provenance.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "docs(arch): register INV-PLUGIN-54 (bound) + INV-PLUGIN-55 (pending) (holomush-si3zs)"`
+
+---
+
+## Task 7: Wholesystem census — positive guard confirmation
+
+**Files:**
+
+- Modify: `test/integration/wholesystem/census_test.go`
+
+The census already loads every in-tree plugin via the real `Manager.LoadAll`. With Task 3+5, a misdeclared in-tree binary plugin now fails load → the census fails. Confirm the current (correctly-declared) tree still loads, and document that the census is the integration guard for INV-PLUGIN-54.
+
+- [ ] **Step 1: Add an assertion/comment** affirming the guard (the census already asserts all plugins load; add a focused comment + assertion that `core-scenes` is among the loaded set, since it is the plugin exercising the most capabilities):
+
+```go
+	// INV-PLUGIN-54: loading every in-tree plugin through the real path now also
+	// validates that each binary plugin declared the host capabilities its code
+	// consumes — a misdeclared plugin fails Init → fails load → fails this census.
+	loaded := srv.PluginManager().ListPlugins()
+	Expect(loaded).To(ContainElement("core-scenes"),
+		"core-scenes (heaviest capability consumer) must load with its declared capabilities")
+```
+
+This is a Ginkgo/gomega suite (`srv.PluginManager().ListPlugins()` + `ContainElement`, matching the existing "loads every in-tree plugin" `It` block at `census_test.go:43-46`) — not testify.
+
+- [ ] **Step 2: Run the census**
+
+Run: `task test:int -- ./test/integration/wholesystem/`
+Expected: PASS (the current tree declares all capabilities correctly, from PR #4434).
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "test(plugin): wholesystem census guards INV-PLUGIN-54 capability declaration (holomush-si3zs)"`
+
+---
+
+## Final verification
+
+- [ ] **Full unit suite:** `task test` → PASS
+- [ ] **Affected integration:** `task test:int -- ./test/integration/wholesystem/ ./test/integration/scenes/` → PASS
+- [ ] **Lint:** `task lint` → PASS
+- [ ] **pr-prep fast lane:** `task pr-prep` → status=pass
+- [ ] **Confirm INV-PLUGIN-54 binding:** `task test -- -run 'TestBoundInvariantsAreGenuinelyAsserted' ./test/meta/` → PASS
+
+## Notes on spec alignment
+
+- **Gate+validate** (spec §3.1): realized as validation-before-injection (Task 3) — injection is reached only after validation succeeds, so a client is never wired for an undeclared capability. No per-injection conditional is needed; this is the gate, structurally.
+- **Unconditional binary Init** (Task 5) is a grounding-discovered refinement of spec §3.2 (recorded on holomush-si3zs): without it a binary plugin declaring nothing would skip Init and escape the check.
+- **Negative arm** (spec §3.6): covered by the SDK unit test (Task 2/3) rather than a new under-declaring fixture binary plugin (heavier; the unit test exercises the same validation path directly). The census (Task 7) is the positive integration guard.
+- **Lua half** (INV-PLUGIN-55): out of scope; delivered by holomush-eykuh.4.
+<!-- adr-capture: sha256=97f0ac7cadb0315b; session=cli; ts=2026-06-13T18:52:12Z; adrs=holomush-m4ac3,holomush-toh7a,holomush-1psri,holomush-wlyzs,holomush-nk46j -->

--- a/docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md
@@ -1,0 +1,243 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Capability-Declaration Enforcement at Load (binary half; Lua via eykuh.4)
+
+- **Design bead:** holomush-si3zs
+- **Date:** 2026-06-13
+- **Status:** Draft (design-review round 2)
+- **Epic:** holomush-eykuh (Plugin capability & dependency architecture)
+- **Relates to:** holomush-eykuh.3 (least-privilege enforcement, merged PR #4434) — this spec closes a gap that epic left open. holomush-eykuh.4 (sub-spec 5, Lua production migration) — binds INV-PLUGIN-55 (the Lua invariant).
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are
+to be interpreted as described in RFC 2119 / RFC 8174.
+
+## 1. Problem
+
+The eykuh.3 sub-spec introduced a default-deny host-capability interceptor:
+a binary plugin that calls a `host.v1` capability service it did not declare in
+its manifest `requires:` is denied at **call** time with `CAPABILITY_NOT_DECLARED`
+(`internal/plugin/hostcap/interceptor.go`). But nothing fails **earlier**: such a
+plugin still **loads cleanly**, and the missing declaration only surfaces when a
+call path is exercised. `core-scenes` shipped declaring only
+`requires: WorldService` while its code consumed `focus`, `eval`, `settings`,
+`stream.history`, and `audit` — the gap was invisible to unit tests (synthetic
+manifests) and to the `wholesystem` census (which asserts only that plugins load
+and `help` is registered), and surfaced only in the scenes integration + E2E
+suites in CI, after an autonomous drain had already opened the PR (PR #4434, since
+fixed).
+
+### 1.1 Root cause — capability injection ignores the manifest (both runtimes, in production)
+
+The deeper defect is that **client/capability injection is driven by code shape,
+not by the manifest** — in production, for *both* runtimes:
+
+| Runtime | Production capability wiring | Manifest-respecting? |
+| --- | --- | --- |
+| **Binary** | `pkg/plugin/sdk.go::pluginServerAdapter.Init` type-asserts the provider against the `*Aware` interfaces and injects host clients **unconditionally** (`sdk.go:186-203`). | **No** — code-driven. |
+| **Lua** | Production Lua plugins are wired through the legacy `hostfunc.Register(L, name, requires…)` shim, which injects host functions **largely unconditionally** (eykuh.1 foundation spec, `2026-06-11-plugin-capability-dependency-foundation-design.md:83`). | **No** — code-driven. |
+
+There is a *declaration-gated* Lua bridge (`internal/plugin/luabridge`,
+`Host.WithHostCapBridge`), but it is **test-fixture-only for now** — its own doc
+comment at `internal/plugin/lua/host.go:88` states it is gated behind
+`WithHostCapBridge` pending "full production migration … tracked in sub-spec 5 /
+holomush-eykuh.4." So production Lua is **not** yet declaration-gated either.
+
+The capability a *binary* plugin's code can consume is fully expressed,
+statically, by which `*Aware` interfaces its provider implements — so the binary
+half is closeable now. The Lua half (migrating production Lua off the legacy
+shim onto the declaration-gated bridge) is eykuh.4's job. The **end state** is
+symmetric: both runtimes grant only declared capabilities. This spec delivers the
+binary half and defines the shared invariant; eykuh.4 delivers the Lua half.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- Fail **closed at load** when a *binary* plugin's code can consume a non-exempt
+  `host.v1` capability its manifest does not declare.
+- Define **INV-PLUGIN-54** (binary; **bound now** by this spec's tests) and
+  **INV-PLUGIN-55** (Lua; **`pending`** until eykuh.4 binds it) — two single-clause
+  invariants, not one multi-clause entry (see §4).
+- Make the existing `wholesystem` census the enforcement point for the binary
+  half — no bolt-on, test-only guard with a separately-maintained mapping.
+
+**Non-goals**
+
+- **The Lua half.** Migrating production Lua off the legacy `hostfunc` shim onto
+  the declaration-gated bridge is **holomush-eykuh.4** and is out of scope here.
+  This spec MUST NOT claim Lua is already compliant.
+- Changing the runtime interceptor (call-time enforcement stays as-is; this is
+  defense-in-depth *earlier* in the lifecycle).
+- Detecting Lua-script capability *usage* statically (not knowable from Go;
+  Lua's fail-closed mechanism is not-wired-if-not-declared, which arrives with
+  eykuh.4's bridge migration).
+- Migrating plugin manifests (already done for the only affected plugin,
+  `core-scenes`, in PR #4434).
+
+## 3. Design
+
+### 3.1 Capability injection becomes manifest-gated (binary)
+
+`pkg/plugin/sdk.go::pluginServerAdapter.Init` MUST consult the manifest's
+declared capabilities before injecting host-capability clients. For each
+`*Aware` interface the provider implements, the adapter resolves the non-exempt
+capability token(s) that interface grants and:
+
+1. **Validate (fail-closed at load):** if any granted non-exempt token is **not**
+   in the declared-capability set, `Init` MUST return an error
+   (`CAPABILITY_NOT_DECLARED`-class, naming the capability token and the `*Aware`
+   interface). A non-nil `Init` error fails plugin load.
+2. **Gate (parity with eykuh.4's Lua end state):** the adapter MUST inject a
+   host-capability client **only** when its capability is declared. In the
+   validated, healthy case every implemented `*Aware` interface's capability is
+   declared, so injection is unchanged; gating only matters on the error path and
+   keeps behavior coherent if validation is ever bypassed.
+
+**Decision — gate + validate (not validate-only).** Validate-only would fail load
+but still inject by `*Aware`, leaving binary's wiring model divergent from the
+declaration-gated end state. Gating injection on declaration matches the target
+model (least-privilege: a plugin receives only what it declared); the load-time
+error makes binary fail *loud* — a property binary can afford because its
+consumption is statically declared via `*Aware` interfaces (Lua, post-eykuh.4,
+will fail quiet: binding absent).
+
+### 3.2 Host → plugin channel for declared capabilities
+
+The binary plugin process learns its declared capabilities from the host via the
+existing `InitRequest.ServiceConfig` (which already carries `required_services`).
+A new repeated string field — **`declared_capabilities`** — MUST be added to
+`ServiceConfig` in `api/proto/holomush/plugin/v1/plugin.proto`, populated by the
+host from `manifest.RequiredCapabilities()` at Init dispatch. This is a proto
+change and therefore MUST include: `buf generate` regeneration of the Go
+bindings, a doc comment on the field (per the proto-doc-comment gate), and a
+green `task lint:proto`. No new transport; one new field on an existing message.
+
+### 3.3 The `*Aware` → capability-token registry
+
+A single, centralized map co-located with the injection site relates each
+host-capability `*Aware` interface to the capability token(s) it grants:
+
+| `*Aware` interface | Capability token(s) | Exempt? |
+| --- | --- | --- |
+| `EventSinkAware` | `emit` | **exempt** (emit fence) |
+| `FocusClientAware` | `focus`, `stream.history` | no |
+| `HostEvaluatorAware` | `eval` | no |
+| `SettingsClientAware` | `settings` | no |
+| `SnapshotDecryptorAware` | `audit` | no |
+| `CommandListerAware` | `command-registry` | **exempt** (dispatch subject) |
+
+Exempt tokens (`declarationExemptCapabilities` = `emit`, `command-registry`) are
+self-gated by their own mechanisms and MUST NOT require declaration — consistent
+with the interceptor.
+
+**Multi-token interfaces (`FocusClientAware`).** `FocusClientAware`
+(`pkg/plugin/focus_client.go:215`) is a single interface backed by **both**
+`FocusServiceClient` and `StreamHistoryServiceClient` (the `pluginHostFocusClient`
+impl at `pkg/plugin/focus_client.go:220-236`), granting both `focus` and
+`stream.history`. Because the one interface confers access to both tokens, a
+provider implementing `FocusClientAware` MUST declare **both** `focus` **and**
+`stream.history`, even if it only calls Focus RPCs — validation treats the
+interface's full token set as required. (`core-scenes` already declares both, so
+the current tree stays green.) Splitting `FocusClientAware` into two narrower
+`*Aware` interfaces for finer-grained least privilege is a noted future
+refinement, **out of scope** here.
+
+The registry MUST be the single source of truth shared by the validation logic;
+adding a new host-capability `*Aware` interface MUST add its row (enforced by
+§3.6 testing so the map cannot silently drift).
+
+### 3.4 Lua half — deferred to eykuh.4 (no change here)
+
+Production Lua is **not** yet declaration-gated (§1.1). This spec MUST NOT alter
+Lua wiring. **INV-PLUGIN-55** (the Lua invariant) is satisfied when
+**holomush-eykuh.4** migrates production Lua off the legacy `hostfunc` shim onto
+the declaration-gated `luabridge` path (which already gates host-cap bindings on
+`manifest.RequiredCapabilities()`); at that point an undeclared capability's
+binding is never injected into the Lua VM. Until then INV-PLUGIN-55 stays
+`pending` (no `asserted_by`). This spec SHOULD leave a cross-reference note on
+eykuh.4 so its plan binds INV-PLUGIN-55.
+
+### 3.5 Census becomes the guard (binary half)
+
+Because the binary validation fails `Init` (and thus load), the existing
+`test/integration/wholesystem` census — which loads **all** in-tree plugins via
+the real `Manager.LoadAll` / `setup.PluginSubsystem` path — becomes the
+enforcement point for free: a misdeclared in-tree binary plugin fails the census.
+No separate AST/reflection meta-test is introduced (the rejected alternative; see
+§5).
+
+### 3.6 Testing
+
+- **Unit (binary, `pkg/plugin`):** a provider implementing `FocusClientAware`
+  with a config whose `declared_capabilities` omits `focus` (or `stream.history`)
+  → `Init` returns `CAPABILITY_NOT_DECLARED`; with both declared → injects and
+  succeeds. Exempt-only providers (`EventSinkAware`/`CommandListerAware`) load
+  with no declaration. **Binds INV-PLUGIN-54.**
+- **Registry completeness meta-test:** assert every host-capability `*Aware`
+  interface in `pkg/plugin` has a row in the §3.3 map (prevents drift when a new
+  capability client is added).
+- **Integration:** the wholesystem census passes for the current (fixed) tree
+  and fails if a fixture binary plugin under-declares (negative arm).
+- **Lua (INV-PLUGIN-55):** **deferred to eykuh.4** — that sub-spec's tests bind
+  INV-PLUGIN-55.
+
+## 4. Invariants
+
+This guarantee splits into **two single-clause invariants** (one per runtime) so
+each is bound by its own test. The registry binds an entry as a whole — a `bound`
+entry whose test proves only one clause of a multi-clause statement is the
+"partial binding" hazard flagged in `.claude/rules/invariants.md`, and a
+`binding: pending` entry MUST NOT carry `asserted_by` (the `TestProvenanceGuard`
+meta-test rejects it). A single split entry therefore cannot honestly represent
+"binary proven now, Lua not yet." Two entries can. Register both in
+`docs/architecture/invariants.yaml`, scope PLUGIN, `origin_spec` this document:
+
+- **INV-PLUGIN-54 (binary):** A binary plugin's `Init` fails closed when its
+  provider implements a host-capability `*Aware` interface for a non-exempt
+  capability absent from the manifest; capability clients are injected only for
+  declared capabilities. `emit` and `command-registry` are self-gated and exempt.
+  → `binding: bound` once §3.6's unit + census tests land (this spec), with
+  `asserted_by` listing them.
+
+- **INV-PLUGIN-55 (Lua):** A Lua plugin is wired only the capabilities its
+  manifest declares. → `binding: pending` **with no `asserted_by`**; bound by
+  holomush-eykuh.4 when production Lua moves onto the declaration-gated bridge and
+  adds its binding test.
+
+Two entries (not one split entry) is the registry-honest representation: the
+binary guarantee is proven now; the Lua guarantee is genuinely unverified until
+eykuh.4.
+
+## 5. Alternatives considered (rejected)
+
+- **Reflection-based meta-test** instantiating each plugin's provider and
+  type-asserting `*Aware` interfaces: blocked — binary plugins are `package
+  main`, their provider types are not importable into a test.
+- **AST/source-scan meta-test** mapping SDK client calls to tokens: CI-only
+  (outside the trust boundary, violating runtime-symmetry's spirit), advisory not
+  enforcing, requires a hand-maintained map living in test code, and is redundant
+  once §3.5 makes the census the guard. Rejected because — with no blast-radius
+  or effort constraint — the design-aligned enforcement (§3.1) is strictly
+  better.
+
+## 6. Risks / open questions
+
+- **`ServiceConfig.declared_capabilities` proto change:** greenfield, no external
+  plugins, so no wire-compat concern; the execution hazard is the regen + doc +
+  `task lint:proto` gate (§3.2), not compatibility.
+- **Forwarding `*Aware` interfaces:** `core-scenes` forwards injected clients from
+  its `scenePlugin` to its inner `SceneServiceImpl`; the validation keys on the
+  outer provider's `*Aware` implementations (the injection site in `sdk.go`),
+  which is correct — confirm no plugin injects via a non-`*Aware` path that would
+  escape the check.
+
+## 7. Out of scope
+
+- The **Lua half** (holomush-eykuh.4).
+- Splitting `FocusClientAware` into finer-grained interfaces (§3.3, future).
+- Manifest backfill (done in PR #4434).
+- Runtime interceptor changes.
+<!-- adr-capture: sha256=8f1630d250be01a5; session=cli; ts=2026-06-13T18:52:12Z; adrs=holomush-m4ac3,holomush-toh7a,holomush-1psri,holomush-wlyzs,holomush-nk46j -->


### PR DESCRIPTION
Design-lifecycle artifacts for **enforcing plugin capability declaration at load** (epic `holomush-si3zs`). Docs-only; implementation is tracked as 7 beads under the epic and lands separately.

## What & why

The eykuh.3 capability interceptor denies undeclared `host.v1` capability calls at *call* time, but binary plugins still **load** with undeclared capabilities — the gap that caused the eykuh.3 scenes CI regression (PR #4434). This design closes it at **load** time: the binary SDK `Init` gate+validates host-capability client injection against `manifest.RequiredCapabilities()`, failing closed when a provider implements a non-exempt `*Aware` interface it didn't declare. That brings binary plugins to parity with Lua's already-declaration-driven wiring (the Lua production migration is deferred to `holomush-eykuh.4`).

## Contents

- **Spec** — `docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md` (design-reviewer READY, 3 rounds)
- **Plan** — `docs/superpowers/plans/2026-06-13-plugin-capability-declaration-enforcement.md` (plan-reviewer READY, 2 rounds; 7 bite-sized TDD tasks)
- **5 ADRs** — `docs/adr/holomush-{m4ac3,toh7a,1psri,wlyzs,nk46j}-*.md` (gate+validate; unconditional binary Init; two single-clause invariants; census-as-guard; binary-now/Lua-deferred)
- **Invariants** — `INV-PLUGIN-54` (binary) + `INV-PLUGIN-55` (Lua) registered `binding: pending`; INV-PLUGIN-54 flips to `bound` when the implementation tests land, INV-PLUGIN-55 binds via eykuh.4

## Validation

`task pr-prep` fast lane green (bats, schema, license, plugin build, lint, fmt, unit tests incl. the registry meta-tests).

Implementation: epic `holomush-si3zs` → `bd ready --parent holomush-si3zs` (si3zs.1 + si3zs.2 ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)