### PR TITLE
test(e2e): stabilize multi-tab scenes spec under slow CI (holomush-mwmzt)

### DIFF
--- a/web/e2e/scenes.spec.ts
+++ b/web/e2e/scenes.spec.ts
@@ -44,11 +44,17 @@ async function currentEventCount(page: Page): Promise<number> {
  * Callers MUST capture `sinceIndex` via currentEventCount BEFORE sending
  * the command whose output they want to match. This isolates the wait
  * from any preceding events that may coincidentally match the pattern.
+ *
+ * `timeoutMs` (default 10s) is the poll deadline. Raise it only for waits
+ * that run under known event-delivery contention (e.g. a concurrent
+ * second-tab workspace load); since expect.poll resolves the instant the
+ * match appears, a larger ceiling has no happy-path cost.
  */
 async function waitForOutputMatching(
   page: Page,
   pattern: RegExp,
   sinceIndex: number,
+  timeoutMs = 10000,
 ): Promise<string> {
   const events = page.locator('[data-testid="event"]');
 
@@ -70,7 +76,7 @@ async function waitForOutputMatching(
         }
         return false;
       },
-      { timeout: 10000 },
+      { timeout: timeoutMs },
     )
     .toBe(true);
 
@@ -453,6 +459,16 @@ test.describe('Scenes workspace (E9.5)', () => {
   test('workspace open in a second tab does not disturb the terminal stream', async ({
     browser,
   }) => {
+    // This multi-tab spec chains many sequential waits — registerAndEnterTerminal
+    // (~40s of ceilings), scene create (~10s), token1 (~10s), tab-2 workspace
+    // toBeVisible (20s), then the 30s token2 poll below. Their worst-case
+    // ceilings sum past even the CI-scaled suite per-test budget (60s), so give
+    // this test its own headroom — otherwise a slow CI runner kills it mid-poll
+    // with a generic timeout instead of letting the token2 wait actually run.
+    // Happy path finishes in seconds; this only bounds the pathological-slow
+    // case (holomush-mwmzt).
+    test.setTimeout(150000);
+
     const ctx: BrowserContext = await browser.newContext();
     try {
       // ── Tab 1: register and enter terminal ──
@@ -482,7 +498,20 @@ test.describe('Scenes workspace (E9.5)', () => {
       const token2 = `iso-after-${Date.now()}`;
       const sayAfter = await currentEventCount(terminalPage);
       await sendCommand(terminalPage, `say ${token2}`);
-      await waitForOutputMatching(terminalPage, new RegExp(token2), sayAfter);
+      // token2's delivery races tab 2's just-completed workspace load
+      // (JoinFocus + DEK seed + scene-stream JetStream replay/decrypt), so under
+      // two-context CI load it occasionally needs >10s — the flake this spec
+      // exhibited (holomush-mwmzt). The 30s poll ceiling (covered by this test's
+      // raised per-test budget above) absorbs that latency WITHOUT masking a
+      // routing race: per-connection stream isolation — the terminal connection
+      // KEEPS its location subscription while the comms_hub connection focuses a
+      // scene — is pinned deterministically by two separate tests: the
+      // integration spec INV-SCENE-23
+      // (test/integration/scenes/multi_connection_visibility_test.go) and the
+      // unit test TestSendToConnection_TargetsOneConnectionOnly
+      // (internal/grpc/stream_registry_test.go). So a slow token2 here is pure
+      // delivery latency, not a dropped stream.
+      await waitForOutputMatching(terminalPage, new RegExp(token2), sayAfter, 30000);
 
       // Terminal page shows no scenes-workspace UI.
       await expect(

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -9,7 +9,13 @@ const grepInvert = process.env.HOLOMUSH_RUN_QUARANTINED === "1"
 
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 30000,
+  // Per-test budget. CI runners (Namespace + Testcontainers Cloud) deliver
+  // events markedly slower than a local box under two-BrowserContext specs
+  // (e.g. scenes.spec.ts multi-tab tests: a say → location → JetStream → WS →
+  // DOM round-trip racing a second tab's workspace load). Doubling the budget
+  // in CI tolerates that latency without masking a real failure — a genuine
+  // bug still fails, just later (holomush-mwmzt). Local runs stay at 30s.
+  timeout: process.env.CI ? 60000 : 30000,
   grepInvert,
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:8080",


### PR DESCRIPTION
## Summary

Fixes the flaky required **E2E Test** gate from `scenes.spec.ts` — *"workspace open in a second tab does not disturb the terminal stream"* (`holomush-mwmzt`).

**Root cause is CI event-delivery latency, NOT a focus-routing race.** The bead carried a P1/confidentiality framing (a same-player second connection might perturb tab 1's stream, with a mirror-risk of misrouting scene content). Investigation **excludes that hypothesis by construction and by existing deterministic coverage**:

- holomush is one-session-per-character, multi-connection: tab 2's comms_hub "alt session" reattaches as a *second connection* on tab 1's session (`internal/grpc/auth_handlers.go` `SelectCharacter`→`FindByCharacter`). The boundary is **per-connection** focus isolation.
- comms_hub focus never writes session-scoped `PresentingFocus` (D9 guard, `set_connection_focus.go:97`); `SetConnectionFocus` drives deltas only to its own connection; `AutoFocusOnJoin` (the only all-terminal fan-out) fires solely from the `scene join` command, which the `watch` path never issues.
- **Already pinned deterministically** (verified passing): the integration spec INV-SCENE-23 (`test/integration/scenes/multi_connection_visibility_test.go`) — grid connection keeps location delivery while another connection focuses a scene (availability) and scene IC does not leak to grid (confidentiality); plus the unit tests `TestSendToConnection_TargetsOneConnectionOnly` (`internal/grpc/stream_registry_test.go`) + `TestCoordinatorDrivesPerConnectionDeltas`.

So this is **stabilized, not quarantined** — the spec stays live to preserve its unique full-stack multi-tab signal.

### Changes (three parts)
- **`web/playwright.config.ts`** — suite-default per-test timeout CI-scaled to `process.env.CI ? 60000 : 30000`. A poll timeout can't exceed the remaining per-test budget, so the per-test cap is the real limit. Local stays 30s. Also helps sibling flake `holomush-0jzs`.
- **`web/e2e/scenes.spec.ts`** (per-test override) — the heavy multi-tab spec gets `test.setTimeout(150000)`. Its worst-case *sequential* wait sum (~register 40s + create 10s + token1 10s + tab-2 visible 20s + token2 30s ≈ 110s) exceeds even the 60s CI default, so without this a slow runner would kill it mid-poll with a generic timeout. (Caught in review — turn 1 findings `dmuky.1/.2/.3`.)
- **`web/e2e/scenes.spec.ts`** (helper) — `waitForOutputMatching` gains an optional `timeoutMs` (default 10s; all 16 callers unchanged); the contended post-tab-2 `token2` wait uses 30s, now covered by the raised per-test budget. Zero happy-path cost (`expect.poll` resolves on match).

CI timeout scaling was chosen over `retries` (rejected — retries mask genuine flakes, against the don't-hide-flakes stance).

## Test Plan
- [x] `task pr-prep` (fast lane) — **pass** (includes the realweb build embedding the web bundle).
- [x] Isolation unit tests — **8/8 pass** (`SendToConnection`-targets-one, per-connection deltas, `AutoFocusOnJoin` fan-out).
- [x] INV-SCENE-23 integration spec — **pass** (`task test:int` against `multi_connection_visibility_test.go`).
- [x] `web/e2e/scenes.spec.ts` + `playwright.config.ts` compile clean (`npx playwright test --list`: 14 tests).
- [x] In-session multi-aspect PR review (code/security/tests/comments/simplify/slop) — round-1 findings addressed; re-reviewed to PASS.
- [ ] CI **E2E Test** required check — the live gate for the flake itself (intermittent; not deterministically reproducible locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)