### PR TITLE
docs(plugin): sub-spec 5 atomic capability cutover — spec, plan, ADRs (holomush-eykuh.4)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,10 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Atomic (big-bang) plugin-capability cutover over phased allowlist rollout](holomush-40ssh-atomic-big-bang-plugin-capability-cutover-over-phased-allowl.md) | 2026-06-14 | Accepted | `holomush-40ssh` |
+| [Resolver Grants set as the single least-privilege gate authority](holomush-vpg8l-resolver-grants-set-as-single-least-privilege-gate-authority.md) | 2026-06-14 | Accepted | `holomush-vpg8l` |
+| [o262d DAG-resolution failures stay always-fatal behind a named policy-function seam](holomush-ptf7b-o262d-dag-resolution-failures-stay-always-fatal-behind-named.md) | 2026-06-14 | Accepted | `holomush-ptf7b` |
+| [Retire plugin capability injection only; keep ambient stdlib ungated](holomush-05f3v-retire-plugin-capability-injection-only-keep-ambient-stdlib.md) | 2026-06-14 | Accepted | `holomush-05f3v` |
 | [Gate binary plugin capability injection on manifest declaration](holomush-m4ac3-gate-binary-plugin-capability-injection-manifest-declaration.md) | 2026-06-13 | Accepted | `holomush-m4ac3` |
 | [Make binary plugin Init unconditional to close the degenerate-manifest escape](holomush-toh7a-make-binary-plugin-init-unconditional-close-degenerate-manif.md) | 2026-06-13 | Accepted | `holomush-toh7a` |
 | [Two single-clause capability-enforcement invariants (INV-PLUGIN-54 / 55)](holomush-1psri-two-single-clause-capability-enforcement-invariants-inv-plug.md) | 2026-06-13 | Accepted | `holomush-1psri` |

--- a/docs/adr/holomush-05f3v-retire-plugin-capability-injection-only-keep-ambient-stdlib.md
+++ b/docs/adr/holomush-05f3v-retire-plugin-capability-injection-only-keep-ambient-stdlib.md
@@ -1,0 +1,39 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-05f3v; do not edit manually; use `/adr update holomush-05f3v` -->
+
+# Retire plugin capability injection only; keep ambient stdlib ungated
+
+**Date:** 2026-06-14
+**Status:** Accepted
+**Decision:** holomush-05f3v
+**Deciders:** Sean Brandt
+
+## Context
+
+At cutover, `hostfunc.Register` (`internal/plugin/hostfunc/functions.go:271`) must be partially dismantled. The question was which host functions belong behind the declaration gate (capabilities) and which remain unconditionally injected. `holomush-cryy2` established that logging and core stdlib are ambient substrate, but did not enumerate the full retirement boundary — specifically `register_emit_type` and the handler return-value emit path, which could be confused with the `emit` host capability (the brokered `EmitService` RPC).
+
+## Decision
+
+Only the 10 capability host functions (`kv`, `world.query`, `world.mutation`, `property`, `session`, `session.admin`, `focus`, `eval`, `emit`, `settings`) are stripped from `hostfunc.Register`. `holomush.log`, `holomush.new_request_id`, `holo.fmt`/`RegisterStdlib`, `register_emit_type`, and the handler return-value emit path remain unconditional and ungated.
+
+## Rationale
+
+- The ambient/capability boundary test (`cryy2`): a function is ambient if it does NOT cross the host trust boundary to touch something the plugin does not already own.
+- `register_emit_type` is a startup-time registration tied to INV-PLUGIN-32; gating it behind a capability declaration would prevent plugins from declaring their own event types.
+- The return-value emit path (`event_emitter.go::Emit`) is distinct from the brokered `EmitService` RPC; conflating them would break all event emission for plugins that have not declared the `emit` capability.
+
+## Alternatives Considered
+
+- **Capabilities-only retirement; keep ambient stdlib (chosen):** Preserves full plugin observability; `register_emit_type` stays unconditional (INV-PLUGIN-32); the return-value emit path stays separate from the `emit` capability. Cost: a maintained boundary heuristic for future host functions.
+- **Gate everything through the broker, including stdlib (rejected):** Uniform model, but gating logging incentivizes suppressing observability; `register_emit_type` is startup registration, not a runtime capability call; the return-value path is the plugin's own emission, not a host authority grant.
+
+## Consequences
+
+- Positive: all plugins remain fully observable with no manifest change; INV-PLUGIN-32 cannot be accidentally broken by the cutover; the vocabulary stays at 10 genuine authority grants.
+- Negative: the ambient/capability boundary must be documented for future host-function additions; the two emit surfaces must be kept explicitly distinct in code and tests.
+- Neutral: extends `holomush-cryy2`'s principle to the full retirement enumeration without superseding it.

--- a/docs/adr/holomush-40ssh-atomic-big-bang-plugin-capability-cutover-over-phased-allowl.md
+++ b/docs/adr/holomush-40ssh-atomic-big-bang-plugin-capability-cutover-over-phased-allowl.md
@@ -1,0 +1,39 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-40ssh; do not edit manually; use `/adr update holomush-40ssh` -->
+
+# Atomic (big-bang) plugin-capability cutover over phased allowlist rollout
+
+**Date:** 2026-06-14
+**Status:** Accepted
+**Decision:** holomush-40ssh
+**Deciders:** Sean Brandt
+
+## Context
+
+The host-brokered capability path has been gated behind a `WithHostCapBridge` opt-in allowlist (default empty) since sub-specs 1–4 landed, keeping the legacy `hostfunc.Register` unconditional injection alongside the new path. Two migration strategies were on the table: remove the allowlist in one atomic change (all plugins flip simultaneously) or extend the allowlist mechanism to let plugins opt in incrementally.
+
+## Decision
+
+The `WithHostCapBridge` allowlist is removed entirely; the declaration-gated brokered path becomes the sole host-capability-consumption path for all runtimes in one atomic change. All backing-server preconditions (eykuh.4.1 WorldMutationService, eykuh.4.2 SessionAdminService, eykuh.4.5 actor-identity interceptor) must be satisfied before the flip.
+
+## Rationale
+
+- The coexistence surface exists only to bridge implementation lag, not for permanent multi-path policy; atomic removal closes that surface completely.
+- Fail-fast boot (INV-PLUGIN-43, already live) makes the atomic approach safe: a missed declaration is a loud boot failure, not a silent degradation.
+- The whole-system load test (`WithInTreePlugins`) serves as the gate, so the risk of an incomplete manifest audit surfaces before the flip lands.
+
+## Alternatives Considered
+
+- **Big-bang atomic cutover (chosen):** Eliminates the coexistence surface in one change; no plugin can linger on the unenforced legacy path; manifest-audit completeness becomes a hard gate. Unforgiving — any missed declaration is a hard boot failure.
+- **Phased per-plugin opt-in via allowlist (rejected):** Lower per-deploy blast radius, but prolongs dual-path complexity, defers binding INV-PLUGIN-45 until all plugins migrate, and makes the allowlist itself drift surface.
+
+## Consequences
+
+- Positive: enforcement is structural (no plugin can use an undeclared capability post-cutover); INV-PLUGIN-45 bindable in the same change; dual-path complexity removed permanently.
+- Negative: any missed manifest declaration blocks the entire server from booting; all preconditions must land before the flip.
+- Neutral: the allowlist mechanism is deleted, not left disabled.

--- a/docs/adr/holomush-ptf7b-o262d-dag-resolution-failures-stay-always-fatal-behind-named.md
+++ b/docs/adr/holomush-ptf7b-o262d-dag-resolution-failures-stay-always-fatal-behind-named.md
@@ -1,0 +1,39 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-ptf7b; do not edit manually; use `/adr update holomush-ptf7b` -->
+
+# o262d DAG-resolution failures stay always-fatal behind a named policy-function seam
+
+**Date:** 2026-06-14
+**Status:** Accepted
+**Decision:** holomush-ptf7b
+**Deciders:** Sean Brandt
+
+## Context
+
+With INV-PLUGIN-43 live, DAG-resolution failures are already fatal at boot (`internal/plugin/manager.go` `resolveLoadOrder`). The remaining question for o262d was whether to let a `gracefulDegradation` flag quarantine individual plugins with unsatisfied dependencies (making fatal a policy choice) or keep fatal unconditional while making the decision point a named function. The `holomush-dfkca` ADR settled the structured-result + fail-fast default in sub-spec 1; this decision settles the factoring of the fatal decision itself.
+
+## Decision
+
+DAG-resolution failures remain unconditionally fatal. The fatal decision is extracted into an explicit policy function (`defaultResolvePolicy`) over the structured `ResolveResult`, so a future `gracefulDegradation`-gated per-plugin quarantine is a one-point swap, not a resolver rewrite. `holomush-o262d` is closed.
+
+## Rationale
+
+- `gracefulDegradation`'s scope is defined as per-plugin LOAD failures (`manager.go ~575-585`); silently extending it to DAG resolution would cross a documented boundary without a spec.
+- A named policy function costs nothing structurally and eliminates the future resolver-rewrite risk.
+- All four `ResolveDependencyOrder` error classes mapping to fatal with test coverage — the seam also improves testability of the policy decision.
+
+## Alternatives Considered
+
+- **Always-fatal with policy-function seam (chosen):** Keeps INV-PLUGIN-43 intact; the named function is a clean swap point for a future quarantine. Mild over-engineering risk (forward-looking affordance, no immediate consumer).
+- **gracefulDegradation-gated now (rejected):** Gives operators per-plugin quarantine immediately, but complicates the loader before the use-case is validated and widens `gracefulDegradation`'s documented scope as a design change, not a bug fix.
+
+## Consequences
+
+- Positive: future gracefulDegradation-gated quarantine is a one-function swap; all error-class-to-behavior mappings are explicitly tested; the scope boundary is documented, not silently widened.
+- Negative: per-plugin quarantine for unsatisfied deps remains unavailable until the future swap.
+- Neutral: the INV-PLUGIN-43 binding is unchanged; the seam is additive. Distinct from `holomush-dfkca` (which settled fail-fast); this settles the seam factoring.

--- a/docs/adr/holomush-vpg8l-resolver-grants-set-as-single-least-privilege-gate-authority.md
+++ b/docs/adr/holomush-vpg8l-resolver-grants-set-as-single-least-privilege-gate-authority.md
@@ -1,0 +1,40 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-vpg8l; do not edit manually; use `/adr update holomush-vpg8l` -->
+
+# Resolver Grants set as the single least-privilege gate authority
+
+**Date:** 2026-06-14
+**Status:** Accepted
+**Decision:** holomush-vpg8l
+**Deciders:** Sean Brandt
+
+## Context
+
+The declaration gate was split per-runtime: the Lua runtime filtered capability injection inside `RegisterHostCaps` (`internal/plugin/lua/host.go:460`) while the binary runtime derived wiring from manifest accessors independently (`internal/plugin/goplugin/host.go:806,847`). Both read the same manifest data but enforced separately, which prevented INV-PLUGIN-45 (single least-privilege gate) from being bound. Three gate architectures were evaluated.
+
+## Decision
+
+`ResolveDependencyOrder` emits a structured per-plugin `Grants[pluginName]` field (granted capabilities + plugin services). The Lua `RegisterHostCaps` shim and the binary broker-wiring loop both consume `Grants[pluginName]` instead of independently re-deriving from the manifest. The per-plugin gRPC server interceptor (R4) is identity-only, not a second gate.
+
+## Rationale
+
+- A single grant-computation point means both runtimes are denied identically on the same data — the structural requirement for INV-PLUGIN-45.
+- Moving derivation to the resolver (which already owns dependency validation) avoids duplicating manifest-reading logic across two runtime-specific sites.
+- The hostcap gRPC servers already enforce ABAC subject authorization at call time; a second runtime-side gate is redundant and creates two surfaces to keep in sync.
+
+## Alternatives Considered
+
+- **Approach A — resolver emits Grants[plugin] (chosen):** Single computation; both shims consume the same set; INV-PLUGIN-45 binds to a test driving both runtimes through the shared resolver result. Cost: a new `ResolveResult` field + two consumer updates.
+- **Interceptor-as-gate, per-call (rejected):** Defense-in-depth at call time, but does not address load-time structural asymmetry; R4 fixes the interceptor's role as identity-only, so using it as a gate creates two gates for one concern.
+- **Hybrid — Approach A + interceptor as second gate (rejected):** Recreates the split-enforcement problem the consolidation aims to remove; per-call enforcement is already provided by ABAC at the hostcap servers.
+
+## Consequences
+
+- Positive: INV-PLUGIN-45 becomes testable and bindable; manifest-reading for grants done once; future runtimes only consume `Grants[plugin]`.
+- Negative: `ResolveResult` gains a field; both shim call sites must change; the resolver now owns order and grants (scope must stay cohesive).
+- Neutral: the interceptor role is narrowed to identity-only (R4), a complementary clarification.

--- a/docs/superpowers/plans/2026-06-14-plugin-capability-atomic-cutover.md
+++ b/docs/superpowers/plans/2026-06-14-plugin-capability-atomic-cutover.md
@@ -1,0 +1,669 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin-capability atomic cutover + o262d settlement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the plugin host from coexistence (legacy unconditional Lua host-function injection + opt-in brokered allowlist) to a single declaration-gated, host-brokered capability-consumption path for both runtimes, in one atomic flip, and settle the `o262d` loader-policy bug.
+
+**Architecture:** The unified resolver becomes the single least-privilege grant authority (`ResolveResult.Grants`); both delivery shims (Lua `RegisterHostCaps`, binary broker wiring) consume that grant instead of re-deriving from the manifest (binds `INV-PLUGIN-45`). Prerequisite host-cap backings are completed (`WorldMutationService` server + `FindLocation`; `SessionAdmin` backing; bufconn actor-identity stamping) so the gated path serves every capability the migrated manifests declare. The legacy capability injection is then stripped and the `WithHostCapBridge` allowlist removed in a single flip; language stdlib stays unconditional. `o262d` fail-fast (already live) is refactored behind an explicit policy function so a future `gracefulDegradation` quarantine is a one-point swap.
+
+**Tech Stack:** Go, gRPC (`hashicorp/go-plugin` broker + in-process bufconn for Lua), gopher-lua, `oops` structured errors, testify + Ginkgo, `task` runner.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-plugin-capability-atomic-cutover-design.md`
+**Design bead:** `holomush-eykuh.4` (epic). Several tasks map to existing children — noted per task so `plan-to-beads` maps rather than duplicates.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `internal/plugin/hostcap/world.go` | `worldServer.FindLocation` + new `worldMutationServer` (CreateLocation/CreateExit/CreateObject) | 1 |
+| `internal/plugin/hostcap/register.go` | register `WorldMutationService` in `LuaDefaultSet` | 1 |
+| `internal/plugin/lua/host.go` | thread wide session-admin backing into `lua.Host`; consume resolver grants | 2, 5 |
+| `internal/plugin/lua/hostcap_adapter.go` | `SessionAdmin()` returns real backing | 2 |
+| `internal/plugin/lua/bufconn_endpoint.go` | chain an actor-stamping interceptor before the capability interceptor | 3 |
+| `internal/plugin/lua/actor_interceptor.go` (new) | unary interceptor stamping `core.WithActor` from host-established identity | 3 |
+| `internal/plugin/dependency.go` | `ResolveResult.Grants` field + per-plugin grant computation | 4 |
+| `internal/plugin/manager.go` | expose grants to the load path; o262d policy function | 5, 7 |
+| `internal/plugin/goplugin/host.go` | binary broker wiring consumes grants | 5 |
+| `plugins/core-building/plugin.yaml`, `plugins/core-objects/plugin.yaml`, `plugins/core-communication/plugin.yaml` | declare missing capabilities | 6 |
+| `internal/plugin/hostfunc/functions.go` | strip capability injection; keep stdlib | 8 |
+| `internal/plugin/luabridge/marshal_test.go` | `pushBridgeError` opacity test | 10 |
+
+---
+
+## Task 1: Implement `WorldQueryService.FindLocation` + `WorldMutationService` server
+
+> Maps existing bead **holomush-eykuh.4.1** (P1, hard blocker). Both proto + generated stubs already exist (`api/proto/holomush/plugin/host/v1/world.proto:43,58-68`; `pkg/proto/holomush/plugin/host/v1/world_grpc.pb.go`). `worldServer` (`internal/plugin/hostcap/world.go:32`) implements only the 4 query RPCs; `FindLocation` + the entire `WorldMutationService` inherit `Unimplemented`. The `WorldMutator` backing already flows to Lua via `luaHostCapAdapter.WorldMutator()` (`internal/plugin/lua/hostcap_adapter.go`) and is `world.Mutator` (`CreateLocation(ctx, string, *world.Location) error`, `CreateExit`, `CreateObject`, `FindLocationByName`).
+
+**Files:**
+
+- Modify: `internal/plugin/hostcap/world.go`
+- Modify: `internal/plugin/hostcap/register.go:53` (LuaDefaultSet branch)
+- Test: `internal/plugin/hostcap/world_test.go`
+
+- [ ] **Step 1: Write the failing test for `FindLocation`**
+
+In `world_test.go`, mirror the existing `QueryLocation` test setup (same file). Use a fake `WorldMutator` whose `FindLocationByName` returns a known location id for input `"plaza"` and `world.ErrNotFound` for `"void"`.
+
+```go
+func TestWorldServerFindLocationReturnsMatchedLocation(t *testing.T) {
+    s := hostcap.NewWorldQueryServer(newFakeBaseWithMutator(t, fakeMutator{
+        findByName: map[string]string{"plaza": "loc_01"},
+    }))
+    resp, err := s.FindLocation(stampPluginCtx(t, "core-building"),
+        &hostv1.FindLocationRequest{Name: "plaza"})
+    require.NoError(t, err)
+    assert.Equal(t, "loc_01", resp.GetLocationId())
+}
+
+func TestWorldServerFindLocationNotFoundIsCodesNotFound(t *testing.T) {
+    s := hostcap.NewWorldQueryServer(newFakeBaseWithMutator(t, fakeMutator{}))
+    _, err := s.FindLocation(stampPluginCtx(t, "core-building"),
+        &hostv1.FindLocationRequest{Name: "void"})
+    assert.Equal(t, codes.NotFound, status.Code(err))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestWorldServerFindLocation ./internal/plugin/hostcap/`
+Expected: FAIL — `FindLocation` returns `codes.Unimplemented`.
+
+- [ ] **Step 3: Implement `FindLocation` on `worldServer`**
+
+Add to `world.go`, mirroring `QueryLocation` (`world.go:49-85`): pull the `WorldMutator` from the base (nil → `codes.Unimplemented`, matching the query RPCs' nil-guard), stamp ABAC subject `plugin:<name>` (reuse the query path's subject stamping), call `FindLocationByName`, map `world.ErrNotFound` → `codes.NotFound`, any other inner error → log via `errutil.LogErrorContext` + `status.Errorf(codes.Internal, "internal error")` (per `.claude/rules/grpc-errors.md`).
+
+```go
+func (s *worldServer) FindLocation(ctx context.Context, req *hostv1.FindLocationRequest) (*hostv1.FindLocationResponse, error) {
+    wm := s.host.WorldMutator() // match the query RPCs' accessor (s.host, NOT s.base)
+    if wm == nil {
+        return nil, status.Errorf(codes.Unimplemented, "world mutation not supported")
+    }
+    loc, err := wm.FindLocationByName(ctx, req.GetName())
+    if errors.Is(err, world.ErrNotFound) {
+        return nil, status.Errorf(codes.NotFound, "location not found")
+    }
+    if err != nil {
+        errutil.LogErrorContext(ctx, "FindLocation failed", err, "name", req.GetName())
+        return nil, status.Errorf(codes.Internal, "internal error")
+    }
+    return &hostv1.FindLocationResponse{LocationId: loc.ID.String(), Name: loc.Name}, nil
+}
+```
+
+(Confirm `FindLocationByName`'s exact return shape via `mcp__probe__extract_code FindLocationByName` before writing; adjust field access to match `world.Location`.)
+
+- [ ] **Step 4: Run the FindLocation tests to verify they pass**
+
+Run: `task test -- -run TestWorldServerFindLocation ./internal/plugin/hostcap/`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test for the `WorldMutationService` server**
+
+```go
+func TestWorldMutationServerCreateLocationDelegatesToMutator(t *testing.T) {
+    fm := &fakeMutator{}
+    s := hostcap.NewWorldMutationServer(newFakeBaseWithMutator(t, fm))
+    _, err := s.CreateLocation(stampPluginCtx(t, "core-building"),
+        &hostv1.CreateLocationRequest{Name: "Atrium"})
+    require.NoError(t, err)
+    assert.Equal(t, "Atrium", fm.lastCreatedLocationName)
+}
+
+func TestWorldMutationServerCreateLocationNilMutatorIsUnimplemented(t *testing.T) {
+    s := hostcap.NewWorldMutationServer(newFakeBaseNoMutator(t))
+    _, err := s.CreateLocation(stampPluginCtx(t, "core-building"),
+        &hostv1.CreateLocationRequest{Name: "Atrium"})
+    assert.Equal(t, codes.Unimplemented, status.Code(err))
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `task test -- -run TestWorldMutationServer ./internal/plugin/hostcap/`
+Expected: FAIL — `NewWorldMutationServer` undefined.
+
+- [ ] **Step 7: Implement `worldMutationServer`**
+
+Add to `world.go`: a `worldMutationServer` struct embedding `hostv1.UnimplementedWorldMutationServiceServer` + `hostCapabilityBase`, a `NewWorldMutationServer(base hostCapabilityBase) hostv1.WorldMutationServiceServer` constructor, and `CreateLocation`/`CreateExit`/`CreateObject` methods each: nil-guard `WorldMutator()` → `Unimplemented`; stamp `plugin:<name>` subject; translate the request proto → `world.Location`/exit/object args; call the mutator; map errors per `grpc-errors.md` (opaque internal). Mirror the field translation already used by the legacy hostfunc world-write path — find it via `mcp__probe__search_code "createLocationFn"` (`internal/plugin/hostfunc/functions.go`) and reuse the same arg construction so behavior is at parity.
+
+- [ ] **Step 8: Register `WorldMutationService` in `LuaDefaultSet`**
+
+In `register.go` (`LuaDefaultSet` branch, ~line 53), add:
+
+```go
+hostv1.RegisterWorldMutationServiceServer(srv, NewWorldMutationServer(base))
+```
+
+Update the doc comment at `register.go:38-40` (currently lists four services) to include `WorldMutationService`.
+
+- [ ] **Step 9: Run hostcap tests + descriptor completeness**
+
+Run: `task test -- ./internal/plugin/hostcap/`
+Expected: PASS, including `descriptor_completeness_test.go` (it asserts every registered service has a descriptor entry — add `FindLocation`/WorldMutation entries to `descriptor.go` if it fails; `FindLocation` already has one at `descriptor.go:112`).
+
+- [ ] **Step 10: Commit**
+
+`jj describe -m "feat(plugin): hostcap WorldMutationService server + WorldQueryService.FindLocation (holomush-eykuh.4.1)"` then `jj new`.
+
+---
+
+## Task 2: Wire the `SessionAdmin` (broadcast/disconnect) backing for the Lua path
+
+> Maps existing bead **holomush-eykuh.4.2** (P2). `sessionAdminServer` already exists (`internal/plugin/hostcap/session.go:90`, nil-guards to `Unimplemented`). The gap: `luaHostCapAdapter.SessionAdmin()` returns nil (`internal/plugin/lua/hostcap_adapter.go`) because `Functions` holds only the narrow `session.Access` (via `WithSessionAccess`), not the wide broadcast/disconnect surface. The wide surface is `hostfunc.SessionAccess` shape: `BroadcastSystemMessage` / `DisconnectSession`.
+
+**Files:**
+
+- Modify: `internal/plugin/lua/host.go` (new `HostOption` + field)
+- Modify: `internal/plugin/lua/hostcap_adapter.go` (`SessionAdmin()`)
+- Modify: construction site `internal/plugin/setup/subsystem.go` (thread the backing)
+- Test: `internal/plugin/lua/hostcap_adapter_test.go`, integration in `test/integration/`
+
+- [ ] **Step 1: Identify the production broadcast/disconnect implementor**
+
+Run `mcp__probe__search_code "BroadcastSystemMessage"` and `"DisconnectSession"`. Confirm the concrete type that satisfies the wide surface and where it is available at `internal/plugin/setup/subsystem.go` construction. (Bead note flags none was found cleanly as of 2026-06-12 — resolve this first; if genuinely absent, the backing is the same `session.Manager`/coordinator that the telnet/web `wall` path uses. Record the implementor in the bead before proceeding.)
+
+- [ ] **Step 2: Write the failing adapter test**
+
+```go
+func TestLuaAdapterSessionAdminReturnsBackingWhenWired(t *testing.T) {
+    f := hostfunc.New(nil)
+    a := newLuaHostCapAdapterWithSessionAdmin(f, fakeSessionAdmin{})
+    require.NotNil(t, a.SessionAdmin())
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `task test -- -run TestLuaAdapterSessionAdmin ./internal/plugin/lua/`
+Expected: FAIL — `SessionAdmin()` returns nil / constructor missing.
+
+- [ ] **Step 4: Add the `WithSessionAdmin` host option + adapter wiring**
+
+In `host.go`, add a `sessionAdmin hostcap.SessionAdmin` field and `WithSessionAdmin(sa hostcap.SessionAdmin) HostOption`. Thread it into `newLuaHostCapAdapter`. In `hostcap_adapter.go`, change `SessionAdmin()` to return the wired backing (nil only when unset — the server still nil-guards). Replace the deferral comment with the live wiring.
+
+- [ ] **Step 5: Run adapter test to verify it passes**
+
+Run: `task test -- -run TestLuaAdapterSessionAdmin ./internal/plugin/lua/`
+Expected: PASS.
+
+- [ ] **Step 6: Thread the backing at the production construction site**
+
+In `internal/plugin/setup/subsystem.go`, pass `lua.WithSessionAdmin(<implementor from Step 1>)` where the Lua `Host` is constructed. Mirror how the binary host receives the same surface (plugin-runtime-symmetry — verify the binary side already has it; if not, file a follow-up).
+
+- [ ] **Step 7: Integration test — brokered broadcast at parity**
+
+Add a `test:int` Ginkgo spec asserting a Lua plugin calling `session.broadcast` through the brokered `SessionAdminService` reaches the same broadcast sink as the legacy `SessionCapability` hostfunc path.
+
+Run: `task test:int -- ./test/integration/<domain>/`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+`jj describe -m "feat(plugin): wire Lua SessionAdmin broadcast/disconnect backing (holomush-eykuh.4.2)"` then `jj new`.
+
+---
+
+## Task 3: Stamp actor identity across the Lua bufconn boundary
+
+> New bead **holomush-eykuh.4.5** (create at materialization). Lesson `eykuh.2.11`: `newPluginEndpoint` (`internal/plugin/lua/bufconn_endpoint.go:38-58`) builds `grpc.NewServer(grpc.ChainUnaryInterceptor(ic))` where `ic` is the capability interceptor — but no interceptor stamps `core.WithActor`. `plugins.NewInProcessConn` carries metadata, not context values, so `core.ActorFromContext` is empty server-side → token/identity-requiring caps (`emit`, `settings` GAME-scope, `eval`) fail closed. The adapter already exposes `LookupActor(ctx, pluginName) (core.Actor, string, error)` (`hostcap_adapter.go:92`).
+
+**Files:**
+
+- Create: `internal/plugin/lua/actor_interceptor.go`
+- Modify: `internal/plugin/lua/bufconn_endpoint.go:40-51`
+- Test: `internal/plugin/lua/actor_interceptor_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestActorStampInterceptorSetsActorOnContext(t *testing.T) {
+    var seen core.Actor
+    ic := newActorStampInterceptor(fakeActorLookup{actor: core.Actor{Kind: "plugin", ID: "core-communication"}}, "core-communication")
+    _, err := ic(context.Background(), nil,
+        &grpc.UnaryServerInfo{FullMethod: "/holomush.plugin.host.v1.EmitService/Emit"},
+        func(ctx context.Context, _ any) (any, error) { seen, _ = core.ActorFromContext(ctx); return nil, nil })
+    require.NoError(t, err)
+    assert.Equal(t, "core-communication", seen.ID)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestActorStampInterceptor ./internal/plugin/lua/`
+Expected: FAIL — `newActorStampInterceptor` undefined.
+
+- [ ] **Step 3: Implement the interceptor**
+
+```go
+// newActorStampInterceptor returns a unary interceptor that resolves the
+// per-plugin host-established actor and stamps it onto the request context
+// via core.WithActor before the handler (and the capability interceptor) run.
+// Identity ONLY — least-privilege gating is the resolver grant (Task 5).
+func newActorStampInterceptor(lookup actorLookup, pluginName string) grpc.UnaryServerInterceptor {
+    return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+        actor, _, err := lookup.LookupActor(ctx, pluginName)
+        if err == nil && actor.ID != "" {
+            ctx = core.WithActor(ctx, actor)
+        }
+        return handler(ctx, req)
+    }
+}
+```
+
+`actorLookup` is a one-method interface (`LookupActor`) satisfied by `*luaHostCapAdapter`. A lookup miss leaves the context unstamped — downstream caps fail closed (correct direction).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestActorStampInterceptor ./internal/plugin/lua/`
+Expected: PASS.
+
+- [ ] **Step 5: Chain it BEFORE the capability interceptor**
+
+In `bufconn_endpoint.go`, change the server construction so the actor stamp runs first (the capability interceptor and handlers need the stamped actor):
+
+```go
+actorIC := newActorStampInterceptor(adapter, pluginName)
+srv := grpc.NewServer(grpc.ChainUnaryInterceptor(actorIC, ic)) // nosemgrep: ...
+```
+
+Keep the existing `nosemgrep` comment.
+
+- [ ] **Step 6: Parity test — token-requiring cap through the bridge**
+
+Extend the `eykuh.2.11` parity test (currently proves only the token-free `kv` case) to drive `emit` through the production Lua bridge and assert it succeeds once the actor is stamped.
+
+Run: `task test:int -- ./test/integration/<domain>/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+`jj describe -m "fix(plugin): stamp actor identity across Lua bufconn boundary (holomush-eykuh.4.5)"` then `jj new`.
+
+---
+
+## Task 4: Add `ResolveResult.Grants` + per-plugin grant computation
+
+> R3 part 1. `ResolveResult` (`internal/plugin/dependency.go:21-25`) currently has `Ordered`, `Unsatisfied`, `Cycles`. The resolver already iterates every plugin's deps validating each against the vocabulary + providers (`dependency.go:51-160`). The grant set is the set of tokens that validated successfully — accumulate it in the same loop.
+
+**Files:**
+
+- Modify: `internal/plugin/dependency.go`
+- Test: `internal/plugin/dependency_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestResolveDependencyOrderEmitsGrantsForDeclaredCaps(t *testing.T) {
+    plugins := []*DiscoveredPlugin{discoveredWithRequires(t, "core-objects",
+        "capability:property", "capability:world.query")}
+    res, err := ResolveDependencyOrder(plugins, nil, DefaultCapabilityVocabulary())
+    require.NoError(t, err)
+    assert.ElementsMatch(t, []string{"property", "world.query"}, res.Grants["core-objects"])
+}
+
+func TestResolveDependencyOrderGrantsExcludeUndeclared(t *testing.T) {
+    plugins := []*DiscoveredPlugin{discoveredWithRequires(t, "core-help")}
+    res, err := ResolveDependencyOrder(plugins, nil, DefaultCapabilityVocabulary())
+    require.NoError(t, err)
+    assert.Empty(t, res.Grants["core-help"])
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestResolveDependencyOrder.*Grants ./internal/plugin/`
+Expected: FAIL — `res.Grants` field does not exist.
+
+- [ ] **Step 3: Add the field + populate it**
+
+In `dependency.go`, add to `ResolveResult`:
+
+```go
+// Grants maps plugin name → the set of dependency tokens (capability tokens
+// like "world.query" and service names) it successfully declared and that
+// resolved. This is the single least-privilege grant authority consumed by
+// both runtimes' delivery shims (INV-PLUGIN-45). A token NOT in a plugin's
+// grant set MUST NOT be wired for that plugin.
+Grants map[string][]string
+```
+
+Initialize `res.Grants = map[string][]string{}` at the top of `ResolveDependencyOrder`. In the per-dep validation loop, on the success branch (the dep resolved as a capability or service — i.e. it is NOT appended to `res.Unsatisfied`), append the dep's token to `res.Grants[p.Manifest.Name]`. Use the capability token (`dep.Capability`) for capability entries and the service name for service entries, matching what `RegisterHostCaps` / the binary wiring key on. Skip `optional` entries that didn't resolve.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestResolveDependencyOrder ./internal/plugin/`
+Expected: PASS (existing resolver tests unaffected — `Grants` is additive).
+
+- [ ] **Step 5: Commit**
+
+`jj describe -m "feat(plugin): resolver emits per-plugin Grants set (holomush-eykuh.4)"` then `jj new`.
+
+---
+
+## Task 5: Consolidate both shims onto the resolver grant set
+
+> R3 part 2. Lua derives `declaredCaps := p.manifest.RequiredCapabilities()` at three sites (`internal/plugin/lua/host.go:421,523,647`) and passes it to `RegisterHostCaps`. Binary derives `DeclaredAccessFromManifest(manifest)` + iterates `manifest.RequiredServiceNames()`/`RequiredCapabilities()` (`internal/plugin/goplugin/host.go:806,847`). Replace both manifest re-derivations with the resolver's `Grants[name]`. The resolved grants must be threaded from `Manager` (which calls `resolveLoadOrder`) into each host's `Load`.
+
+**Files:**
+
+- Modify: `internal/plugin/manager.go` (capture + expose grants)
+- Modify: `internal/plugin/lua/host.go` (consume grants instead of `RequiredCapabilities()`)
+- Modify: `internal/plugin/goplugin/host.go` (consume grants)
+- Test: `internal/plugin/lua/host_test.go`, `internal/plugin/goplugin/host_test.go`
+
+- [ ] **Step 1: Write the failing Lua-side test**
+
+Assert that when the host is given a grant set for a plugin that excludes `world.mutation`, `RegisterHostCaps` is called WITHOUT `world.mutation` even if the manifest were to list it — i.e. the grant set, not the manifest, drives injection.
+
+```go
+func TestLuaHostInjectsResolverGrantsNotManifest(t *testing.T) {
+    h := NewHostWithFunctions(testFns(t), WithPluginGrants(map[string][]string{"p": {"world.query"}}))
+    // ... deliver an event to plugin "p" whose manifest declares world.query+world.mutation ...
+    // assert only the world.query global is injected
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestLuaHostInjectsResolverGrants ./internal/plugin/lua/`
+Expected: FAIL — `WithPluginGrants` undefined.
+
+- [ ] **Step 3: Add grant plumbing to `Manager` + both hosts**
+
+- `manager.go`: after `resolveLoadOrder` returns the `ResolveResult` (refactor `resolveLoadOrder` to return the full result, or stash `res.Grants` on the Manager), pass `res.Grants` to each host's loader (`lua.WithPluginGrants(res.Grants)` / the binary equivalent).
+- `lua/host.go`: add `pluginGrants map[string][]string` field + `WithPluginGrants` option. At the three delivery sites, replace `declaredCaps := p.manifest.RequiredCapabilities()` with `declaredCaps := h.pluginGrants[name]`.
+- `goplugin/host.go`: replace BOTH binary re-derivations with the grant set for that plugin — the broker-wiring loop over `manifest.RequiredServiceNames()` (~lines 806-835) AND the `InitRequest.Config.DeclaredCapabilities: manifest.RequiredCapabilities()` field (~line 858). Both must source from `Grants[name]` so the resolver is the single authority; missing either leaves a manifest-derived path alive. Orient with `mcp__probe__extract_code` on the `Load` function before editing.
+
+- [ ] **Step 4: Run both hosts' tests**
+
+Run: `task test -- ./internal/plugin/lua/ ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full plugin package + integration**
+
+Run: `task test -- ./internal/plugin/...` then `task test:int -- ./test/integration/wholesystem/`
+Expected: PASS — all plugins still resolve and load.
+
+- [ ] **Step 6: Commit**
+
+`jj describe -m "refactor(plugin): both shims consume resolver grants, single least-privilege gate (holomush-eykuh.4.3)"` then `jj new`.
+
+---
+
+## Task 6: Audit + migrate plugin manifests
+
+> R7. Audit table (verified 2026-06-14 against `plugins/*/main.lua` + `plugin.yaml`; capability tokens from `internal/plugin/capability_vocab.go`). Re-derive from code before editing — do not trust this table blindly.
+
+| Plugin | Add to `requires:` |
+| --- | --- |
+| `core-building` | `- capability: world.query` and `- capability: world.mutation` (currently has NO `requires:` block) |
+| `core-objects` | `- capability: world.mutation` (has `property`, `world.query`) |
+| `core-communication` | `- capability: session.admin` (has `session`) |
+
+**Files:**
+
+- Modify: `plugins/core-building/plugin.yaml`, `plugins/core-objects/plugin.yaml`, `plugins/core-communication/plugin.yaml`
+- Audit only (expect no change): `plugins/core-help/`, `plugins/echo-bot/`, `plugins/core-aliases/`, and binary plugins (`plugins/core-scenes/` etc.)
+
+- [ ] **Step 1: Re-derive each plugin's actual capability usage**
+
+For every plugin, run `mcp__probe__search_code` / `rg -n "holomush\.(create_|query_|find_)|session\.(broadcast|disconnect|find_by_name)|kv_|emit|eval|settings"` over its `main.lua` (Lua) or Go source (binary), and list the capability tokens each call maps to via `capability_vocab.go`.
+
+- [ ] **Step 2: Write/extend the audit regression test**
+
+Extend the default-set resolver regression (the original `oeb4d` acceptance — find via `mcp__probe__search_code "Unsatisfied"` in `internal/plugin/*_test.go`) so it loads the REAL `plugins/*` manifests and asserts `len(res.Unsatisfied) == 0`. This will be the gate that catches an incomplete migration.
+
+Run: `task test -- -run <regression> ./internal/plugin/`
+Expected at this point: PASS (manifests not yet flipped; nothing enforces yet). The test's teeth bite after Task 8.
+
+- [ ] **Step 3: Edit the three manifests**
+
+Add the rows above. Example `plugins/core-building/plugin.yaml` (insert after the existing top-level keys, before `commands:`):
+
+```yaml
+requires:
+  - capability: world.query
+  - capability: world.mutation
+```
+
+- [ ] **Step 4: Validate manifests against the schema**
+
+Run: `task lint` (schema check validates `plugin.yaml` against `schemas/plugin.schema.json`).
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj describe -m "feat(plugin): declare capability requires for core-building/objects/communication (holomush-eykuh.4)"` then `jj new`.
+
+---
+
+## Task 7: Settle o262d — policy function + per-error-class tests
+
+> R8. Fail-fast is already live but inlined in `resolveLoadOrder` (`internal/plugin/manager.go:836-840`). Factor the fatal decision into an explicit policy function over `ResolveResult` so a future `gracefulDegradation` quarantine is a one-point swap (the foundation's stated seam — `ResolveResult`'s own doc comment at `dependency.go:19` already anticipates "per-plugin quarantine policy reads Unsatisfied/Cycles").
+
+**Files:**
+
+- Modify: `internal/plugin/manager.go`
+- Test: `internal/plugin/manager_test.go`
+- Close: `holomush-o262d`
+
+- [ ] **Step 1: Write the failing per-error-class table test**
+
+```go
+func TestResolveLoadOrderPolicyFatalPerErrorClass(t *testing.T) {
+    cases := []struct{ name string; res *ResolveResult }{
+        {"unsatisfied requires", &ResolveResult{Unsatisfied: []UnsatisfiedDep{{Reason: "UNSATISFIED_CAPABILITY"}}}},
+        {"cycle", &ResolveResult{Cycles: [][]string{{"a", "b", "a"}}}},
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            err := applyResolvePolicy(c.res, defaultResolvePolicy)
+            require.Error(t, err)
+            assert.Equal(t, "PLUGIN_DEPENDENCY_UNSATISFIED", oops.AsOops(err).Code())
+        })
+    }
+}
+
+func TestResolveLoadOrderPolicyAllowsCleanResult(t *testing.T) {
+    require.NoError(t, applyResolvePolicy(&ResolveResult{}, defaultResolvePolicy))
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestResolveLoadOrderPolicy ./internal/plugin/`
+Expected: FAIL — `applyResolvePolicy` / `defaultResolvePolicy` undefined.
+
+- [ ] **Step 3: Extract the policy function**
+
+In `manager.go`, replace the inlined check in `resolveLoadOrder` with a call to a named policy:
+
+```go
+// resolvePolicy decides loader behavior from a structured resolve result.
+// defaultResolvePolicy is fail-closed (INV-PLUGIN-43): any non-optional
+// unsatisfied dep or cycle is fatal. A future gracefulDegradation-gated
+// quarantine policy swaps in HERE without touching the resolver.
+type resolvePolicy func(*ResolveResult) error
+
+func defaultResolvePolicy(res *ResolveResult) error {
+    if len(res.Unsatisfied) > 0 || len(res.Cycles) > 0 {
+        return oops.Code("PLUGIN_DEPENDENCY_UNSATISFIED").
+            With("unsatisfied", res.Unsatisfied).With("cycles", res.Cycles).
+            Errorf("plugin dependency resolution failed; fail-closed (INV-PLUGIN-43)")
+    }
+    return nil
+}
+
+func applyResolvePolicy(res *ResolveResult, p resolvePolicy) error { return p(res) }
+```
+
+`resolveLoadOrder` calls `applyResolvePolicy(res, defaultResolvePolicy)` and returns its error. Behavior is unchanged (still always-fatal).
+
+- [ ] **Step 4: Run to verify it passes + no regression**
+
+Run: `task test -- ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Document the gracefulDegradation boundary**
+
+Add a comment near the per-plugin `gracefulDegradation` handling (`manager.go ~575-585`) stating it governs per-plugin LOAD failures only, NOT DAG resolution (which is `defaultResolvePolicy`'s fail-closed domain).
+
+- [ ] **Step 6: Close the bug**
+
+Run: `bd close holomush-o262d --reason="Fail-fast already live; refactored behind defaultResolvePolicy seam; per-error-class tests added in manager_test.go"`
+
+- [ ] **Step 7: Commit**
+
+`jj describe -m "refactor(plugin): factor o262d fail-fast into resolvePolicy seam + per-class tests (holomush-o262d)"` then `jj new`.
+
+---
+
+## Task 8: The atomic flip — strip legacy capability injection, remove the allowlist
+
+> R1/R2/R6. THE flip. `hostfunc.Register` (`internal/plugin/hostfunc/functions.go:271`) injects all host funcs unconditionally. Strip the CAPABILITY functions (`kv_*`, `query_*`, `create_*`, world/session caps); KEEP stdlib (`log`, `new_request_id`, `RegisterStdlib`/`holo.fmt`, `register_emit_type`, return-value emit). Remove `WithHostCapBridge` + the `bridgeEnabled` gating so the brokered path is unconditional (grant-gated).
+
+**Files:**
+
+- Modify: `internal/plugin/hostfunc/functions.go:271-347` (`Register`)
+- Modify: `internal/plugin/lua/host.go:92` (remove `WithHostCapBridge`), `:428,530,654` (remove `bridgeEnabled` gate; always inject via grants)
+- Test: `internal/plugin/lua/host_test.go`, whole-system integration
+
+- [ ] **Step 1: Write the failing test — capability funcs gone from legacy Register**
+
+```go
+func TestHostfuncRegisterOmitsCapabilityFunctions(t *testing.T) {
+    L := lua.NewState(); defer L.Close()
+    hostfunc.New(nil).Register(L, "core-help")
+    mod := L.GetGlobal("holomush").(*lua.LTable)
+    assert.Equal(t, lua.LNil, mod.RawGetString("query_location"), "capability fn must not be on legacy path")
+    assert.NotEqual(t, lua.LNil, mod.RawGetString("log"), "stdlib log must remain")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestHostfuncRegisterOmitsCapability ./internal/plugin/hostfunc/`
+Expected: FAIL — `query_location` is still registered.
+
+- [ ] **Step 3: Strip capability injection from `Register`**
+
+In `functions.go`, remove the capability `SetField` lines (`kv_get/set/delete`, `query_*`, `create_*`, and the session/world capability wiring) from `Register` (lines ~291-330). Keep `RegisterStdlib`, `log`, `new_request_id`, and the emit-type/return-value-emit surface. Update the `Register` doc comment to state it now installs language stdlib only; capabilities flow through the brokered path.
+
+- [ ] **Step 4: Make brokered injection unconditional (grant-gated)**
+
+In `lua/host.go`, delete `WithHostCapBridge`, the `bridgeEnabledPlugins` field, and the `bridgeEnabled` checks at the three sites. Call `luabridge.RegisterHostCaps(L, endpoint.Conn(), name, h.pluginGrants[name])` unconditionally (still gated by the grant set — empty grants inject nothing). Remove the now-stale "test-fixture-only" comments. Update callers/tests that passed `WithHostCapBridge`.
+
+- [ ] **Step 5: Naming reconciliation (R6)**
+
+Run `mcp__probe__search_code "world_ext"` and audit any legacy global whose token differs from the brokered token. Since legacy capability injection is now gone (Step 3), confirm no plugin references a retired legacy global name; if any alias must survive for compatibility, point it at the brokered surface (not a parallel one). Record findings in the bead.
+
+- [ ] **Step 6: Run the whole-system load test (the teeth)**
+
+Run: `task test:int -- ./test/integration/wholesystem/` and `task test -- ./internal/plugin/...`
+Expected: PASS — every migrated plugin loads, resolves with no `Unsatisfied`, and consumes capabilities through the brokered path. A FAIL here means a manifest declaration is missing (Task 6 incomplete) — fix the manifest, do not weaken the gate.
+
+- [ ] **Step 7: Commit**
+
+`jj describe -m "feat(plugin)!: atomic cutover — brokered capability path only, retire legacy injection (holomush-eykuh.4)"` then `jj new`.
+
+---
+
+## Task 9: Bind INV-PLUGIN-45 (single least-privilege gate)
+
+> R3 part 3. After Task 5 consolidated the gate onto the resolver grant set, prove both runtimes are denied an undeclared dependency IDENTICALLY through that one gate.
+
+**Files:**
+
+- Test: `test/integration/plugin/least_privilege_parity_test.go` (or the existing parity suite — locate via `mcp__probe__search_code "INV-PLUGIN-44"`)
+- Modify: `docs/architecture/invariants.yaml` (flip `INV-PLUGIN-45` → `bound`)
+- Generated: `docs/architecture/invariants.md` (via `cmd/inv-render`)
+
+- [ ] **Step 1: Write the cross-runtime denial test**
+
+```go
+// Verifies: INV-PLUGIN-45
+func TestUndeclaredDependencyDeniedIdenticallyAcrossRuntimes(t *testing.T) {
+    // A binary plugin and a Lua plugin, each declaring NO "world.mutation".
+    // Drive a world.mutation call through each runtime's brokered path.
+    // Assert BOTH are denied (grant set excludes world.mutation) — same gate,
+    // same denial. The grant comes from ResolveResult.Grants, not the manifest.
+}
+```
+
+Build it on the resolver grant path: construct a `ResolveResult.Grants` lacking `world.mutation` for both plugins, wire each runtime's shim from it, attempt the call, assert denial for both.
+
+- [ ] **Step 2: Run to verify it fails / then passes**
+
+Run: `task test:int -- -run TestUndeclaredDependencyDenied ./test/integration/plugin/`
+Expected: PASS once the shared-grant gate (Task 5) is in place.
+
+- [ ] **Step 3: Flip the registry binding**
+
+In `invariants.yaml`, set `INV-PLUGIN-45` `binding: bound` and add `asserted_by:` listing the test file. Add `// Verifies: INV-PLUGIN-45` above the test (Step 1 already includes it).
+
+- [ ] **Step 4: Regenerate + verify**
+
+Run: `go run ./cmd/inv-render` then `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestProvenanceGuard|TestBoundInvariantsAreGenuinelyAsserted' ./test/meta/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj describe -m "test(plugin): bind INV-PLUGIN-45 cross-runtime least-privilege gate (holomush-eykuh.4.3)"` then `jj new`.
+
+---
+
+## Task 10: Test `pushBridgeError` opacity strip
+
+> Maps existing bead **holomush-eykuh.4.4** (P3, independent — may land any time). `pushBridgeError` (`internal/plugin/luabridge/marshal.go:314-323`) runs gRPC errors through `status.Convert(...).Message()` to strip inner detail before returning `(nil, msg)` to Lua, but no test drives a `codes.Internal`-with-secret error through it.
+
+**Files:**
+
+- Test: `internal/plugin/luabridge/marshal_test.go`
+
+- [ ] **Step 1: Write the table-driven opacity test**
+
+```go
+func TestPushBridgeErrorStripsInnerDetail(t *testing.T) {
+    L := lua.NewState(); defer L.Close()
+    secret := "table users password=hunter2"
+    err := status.Error(codes.Internal, "internal error") // status.Convert keeps only this message
+    // build an error whose inner detail carries `secret` but whose status message is opaque:
+    wrapped := status.Errorf(codes.Internal, "internal error") // inner secret lives in logs, not status
+    n := luabridge.PushBridgeErrorForTest(L, wrapped) // or drive via newPluginMethodInvoker
+    msg := L.ToString(-1)
+    assert.NotContains(t, msg, "hunter2")
+    assert.Equal(t, "internal error", msg)
+    _ = err; _ = secret; _ = n
+}
+```
+
+If `pushBridgeError` is unexported and has no test seam, drive it through a generated binding via `newPluginMethodInvoker` (find via `mcp__probe__search_code "newPluginMethodInvoker"`) with a fake server returning `status.Error(codes.Internal, "internal error")` whose details carry the secret; assert the Lua second return equals the opaque `.Message()` and `NotContains` the secret.
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `task test -- -run TestPushBridgeError ./internal/plugin/luabridge/`
+Expected: PASS (the strip already works; this test pins it).
+
+- [ ] **Step 3: Commit**
+
+`jj describe -m "test(plugin): assert pushBridgeError opacity strip to Lua (holomush-eykuh.4.4)"` then `jj new`.
+
+---
+
+## Post-implementation checklist
+
+- [ ] `task pr-prep` green (fast lane: schema/license/lint/fmt/unit/build/bats).
+- [ ] `task test:int` green (Docker) — wholesystem + plugin parity suites.
+- [ ] `INV-PLUGIN-45` shows `binding: bound`; `task test -- ./test/meta/` green.
+- [ ] `holomush-o262d` closed; children `eykuh.4.1`/`.4.2`/`.4.3`/`.4.4` closed; `eykuh.4.5` created + closed.
+- [ ] No `WithHostCapBridge` references remain (`mcp__probe__search_code "WithHostCapBridge"` → empty).
+- [ ] No capability host-function `SetField` remains in `hostfunc.Register`.
+- [ ] `docs/roadmap.md` theme `plugin-capability-architecture` updated (epic complete).
+<!-- adr-capture: sha256=cc430e24167e2036; session=cli; ts=2026-06-14T14:12:13Z; adrs=holomush-40ssh,holomush-vpg8l,holomush-ptf7b,holomush-05f3v -->

--- a/docs/superpowers/specs/2026-06-14-plugin-capability-atomic-cutover-design.md
+++ b/docs/superpowers/specs/2026-06-14-plugin-capability-atomic-cutover-design.md
@@ -1,0 +1,256 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Sub-spec 5: Plugin-capability atomic cutover + o262d settlement
+
+Design bead: `holomush-eykuh.4` (epic `holomush-eykuh`, theme
+`plugin-capability-architecture`).
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in
+this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+## Overview
+
+Sub-specs 1–4 of the plugin-capability epic landed the unified resolver, the
+host-capability decomposition, the least-privilege/trust layer, and the Lua
+parity transport. They left the host in a deliberate **coexistence** state:
+
+- Legacy `hostfunc.Register` (`internal/plugin/hostfunc/functions.go:271`)
+  injects **all** host functions (`kv_*`, `query_*`, `create_*`, session, …)
+  unconditionally into **every** Lua plugin.
+- The host-brokered consumption path (`luabridge.RegisterHostCaps` /
+  `RegisterPluginService` + the `hostcap` servers) is wired in production but
+  gated behind an **opt-in allowlist** (`internal/plugin/lua/host.go:92`
+  `WithHostCapBridge`, default empty → no plugin uses it).
+
+This sub-spec performs the **atomic cutover**: it removes the allowlist, makes
+the declaration-gated host-brokered path the sole capability-consumption path
+for both runtimes, retires the legacy capability injection, and settles the
+`o262d` loader-policy bug. It is the **last** sub-spec; it depends on 1–4.
+
+The fail-fast loader policy (`INV-PLUGIN-43`) is **already live**
+(`internal/plugin/manager.go` `resolveLoadOrder`, ~816-842, returns
+`PLUGIN_DEPENDENCY_UNSATISFIED`
+fail-closed; the WARN+priority-sort fallback that masked `oeb4d` is gone). This
+makes the cutover unforgiving by design: after the flip, any capability a plugin
+*uses but does not declare* becomes a hard boot failure, not a silent
+degradation. Manifest audit completeness is therefore a hard precondition.
+
+## Requirements
+
+### R1 — Retire capability injection only; keep language stdlib
+
+The cutover MUST strip from `hostfunc.Register` only the **capability** host
+functions — those backed by a host-capability service in the vocabulary
+(`kv`, `world.query`, `world.mutation`, `property`, `session`, `session.admin`,
+`focus`, `eval`, `emit`, `settings`). It MUST retain the **language stdlib** as
+unconditional, non-gated runtime:
+
+- `holomush.log`, `holomush.new_request_id`
+- `holo.fmt` and the `RegisterStdlib` surface
+- `register_emit_type` (top-level emit-type registration, `INV-PLUGIN-32`)
+- the **handler return-value emit path** (`event_emitter.go::Emit`) — distinct
+  from the `emit` host capability (the `EmitService` brokered RPC). The
+  return-value path MUST NOT be gated by a capability declaration.
+
+### R2 — Single declaration-gated brokered path (the flip)
+
+After the cutover:
+
+- The `WithHostCapBridge` allowlist MUST be removed; the brokered path is the
+  default for all plugins, gated by declared grants (R3).
+- Every capability consumption (binary and Lua) MUST route through the one host
+  gRPC broker, authorized as `PluginSubject`, gated by the plugin's declared
+  grant set (`INV-PLUGIN-44`, already bound).
+- No plugin MAY receive a capability or plugin service it did not declare.
+
+### R3 — Consolidate the least-privilege gate (binds INV-PLUGIN-45)
+
+The declaration gate is currently **split per-runtime**: Lua filters injection
+in `RegisterHostCaps(L, conn, name, declaredCaps)`
+(`internal/plugin/lua/host.go:460`); binary derives wiring from
+`manifest.RequiredServiceNames()` / `RequiredCapabilities()`
+(`internal/plugin/goplugin/host.go:806,847`). Both read the same manifest
+accessors but enforce in two separate implementations — exactly why
+`INV-PLUGIN-45` cannot bind.
+
+The resolver MUST become the single grant authority:
+
+- `ResolveDependencyOrder` MUST emit a structured per-plugin **grant set**
+  (`Grants[pluginName]` — the granted capabilities and plugin services),
+  computed once from validated declarations against the capability vocabulary
+  and the set of providers.
+- The Lua shim (`RegisterHostCaps`) and the binary broker-wiring loop MUST both
+  consume `Grants[pluginName]` instead of independently re-deriving the declared
+  set from the manifest.
+- `INV-PLUGIN-45` MUST then be bound to the resolver grant computation: a test
+  drives a binary plugin and a Lua plugin through the shared grant and asserts an
+  **undeclared** dependency is denied **identically** for both runtimes.
+
+This is the broker/registry common-path gate the `plugin-runtime-symmetry` rule
+and the foundation spec mandate. A per-call interceptor is **not** introduced as
+a second gate (see R4 for the interceptor's narrow, identity-only role).
+
+### R4 — Actor-identity propagation across the Lua bufconn boundary
+
+The Lua bufconn endpoint (`internal/plugin/lua/bufconn_endpoint.go`) does **not**
+propagate `core.ActorFromContext` across the gRPC boundary (lesson
+`eykuh.2.11`): `NewInProcessConn` carries metadata but not context *values*, and
+ADR `holomush-elqw4` bakes only `pluginName` (not the actor) into the per-plugin
+server. Token/identity-requiring caps (`emit`, `settings` GAME-scope, `eval`)
+are therefore unreachable through the production Lua bridge — `actorFromToken →
+LookupActor → core.ActorFromContext` returns nothing.
+
+Because the cutover is **atomic** (R2) and `core-communication`/`core-objects`
+use token-requiring caps, this MUST be fixed as a precondition. A per-plugin
+server interceptor MUST stamp `core.WithActor` onto the bufconn server context
+from the host-established connection identity, before any Lua plugin opts into a
+token-requiring cap. This interceptor's role is **identity only** — it is not a
+least-privilege gate (that is the resolver, R3).
+
+### R5 — Backing-server preconditions
+
+The following host-cap servers MUST be implemented/wired before the flip,
+because the gated path fails closed (`codes.Unimplemented`) without them:
+
+- **`WorldMutationService` + `WorldQueryService.FindLocation`** in `hostcap`
+  (`holomush-eykuh.4.1`). Blocks `core-building` (`create_location`,
+  `create_exit`, `find_location`) and `core-objects` (`create_object`,
+  `create_location`). Behavior-parity with the legacy hostfunc world-write path
+  (ABAC subject `plugin:<name>`); error opacity per `grpc-errors.md`.
+- **`SessionAdminService` backing** (broadcast/disconnect) for the Lua bufconn
+  path (`holomush-eykuh.4.2`). Blocks `core-communication` (`session.broadcast`
+  in `wall`).
+
+### R6 — Naming reconciliation
+
+Legacy capability globals whose token differs in spelling from the brokered
+token (e.g. legacy `world_ext` vs brokered `world.query`; lesson `eykuh.2.9`)
+MUST be reconciled at cutover so a migrated plugin does not receive **both**
+surfaces. The retirement of legacy capability injection (R1) removes the legacy
+globals; any alias the host keeps for compatibility MUST point at the brokered
+surface, not a parallel one.
+
+### R7 — Manifest audit and migration
+
+Every plugin manifest MUST be audited against actual host-function usage and
+updated so its declared `requires` exactly covers the capabilities it consumes.
+Audit as of 2026-06-14 (capability tokens from
+`internal/plugin/capability_vocab.go`):
+
+| Plugin              | Today                              | Capability calls                                                        | Action                          |
+| ------------------- | --------------------------------- | ----------------------------------------------------------------------- | ------------------------------- |
+| `core-building`     | **none**                          | `query_location`, `find_location`, `create_location`, `create_exit`     | add `world.query`, `world.mutation` |
+| `core-objects`      | `property`, `world.query`         | `query_location`, `query_location_characters`, `create_object`, `create_location` | add `world.mutation`            |
+| `core-communication`| `session`                         | `session.find_by_name`, `session.broadcast`                             | add `session.admin`             |
+| `core-aliases`      | `service: AliasService` (optional)| none                                                                    | none (verify optional degrade)  |
+| `core-help`         | none                              | none                                                                    | none                            |
+| `echo-bot`          | none                              | none                                                                    | none (test fixture)             |
+
+Binary plugins (e.g. `core-scenes`) MUST be audited the same way; the audit MUST
+be re-derived from code at implementation time, not copied from this table.
+
+### R8 — Settle o262d (always-fatal now, policy seam for later)
+
+The loader MUST keep DAG-resolution failures (`CIRCULAR_DEPENDENCY`,
+`DUPLICATE_PLUGIN_NAME`, `DUPLICATE_SERVICE_PROVIDER`, `UNSATISFIED_REQUIRES`,
+`UNSATISFIED_DEPENDENCY` non-optional) **unconditionally fatal** at boot
+(`INV-PLUGIN-43`). To leave room for a future `gracefulDegradation`-gated
+per-plugin quarantine policy (the foundation's "policy-layer flip over the same
+result" seam), the fatal decision MUST be factored into an explicit **policy
+function over the structured resolver result** — not inlined — so the future
+policy is a swap at that one point, not a resolver rewrite.
+
+The settlement MUST:
+
+- Add tests mapping each `ResolveDependencyOrder` error class to its expected
+  loader behavior (fatal).
+- Document that `gracefulDegradation` currently governs only per-plugin **load**
+  failures (`manager.go ~575-585`), **not** DAG resolution, and why.
+- Close `holomush-o262d`.
+
+### R9 — Test for bridge-layer error opacity
+
+A `luabridge` test (`holomush-eykuh.4.4`) MUST drive a `codes.Internal` gRPC
+status carrying secret inner text through a generated binding /
+`newPluginMethodInvoker` and assert the Lua-returned error string equals the
+opaque `status.Message()` and does **not** contain the inner detail
+(`pushBridgeError`, `internal/plugin/luabridge/marshal.go:314-323`). This is
+independent and MAY land at
+any point in the sub-spec.
+
+## Non-goals
+
+- **Re-opening any sub-spec 1–4 invariant.** `INV-PLUGIN-41/42/43/44` are bound;
+  this sub-spec only adds `INV-PLUGIN-45`.
+- **Implementing the `gracefulDegradation`-gated quarantine policy.** R8 only
+  reserves the seam; the policy itself is future work.
+- **In-process gRPC performance tuning** for Lua hot paths (a sub-spec 3
+  concern, behind the invariant).
+- **External/clustered NATS or any non-plugin subsystem.**
+
+## Invariants
+
+| ID             | Status after this sub-spec | Bound by                                                              |
+| -------------- | -------------------------- | -------------------------------------------------------------------- |
+| `INV-PLUGIN-45`| `pending` → `bound`        | cross-runtime shared-grant undeclared-dependency denial test (R3)    |
+
+`INV-PLUGIN-41/42/43/44` remain `bound` (unchanged). No new invariant is minted;
+`INV-PLUGIN-45` already exists in the registry as `pending`.
+
+## Testing strategy
+
+- **Resolver grant unit tests** (`internal/plugin/dependency_test.go`): the
+  structured `Grants` shape; a declared cap/service appears in the grant, an
+  undeclared one does not; misdeclared kind still errors (`INV-PLUGIN-42`).
+- **o262d error-class table** (`internal/plugin/manager_test.go`): each
+  `ResolveDependencyOrder` error class → fatal boot; `gracefulDegradation`
+  interaction documented and asserted not to apply to DAG resolution.
+- **INV-PLUGIN-45 cross-runtime denial** (integration): one binary + one Lua
+  plugin through the shared resolver grant; an undeclared dependency is denied
+  identically. Carries `// Verifies: INV-PLUGIN-45`.
+- **Actor-identity parity** (R4): a token-requiring cap (e.g. `emit`) succeeds
+  through the production Lua bridge once the interceptor stamps the actor;
+  extends the `eykuh.2.11` parity test beyond the token-free `kv` case.
+- **Bridge opacity** (R9): the `pushBridgeError` strip test.
+- **Whole-system load** (`test/integration/wholesystem/`): all migrated
+  manifests resolve with no `Unsatisfied` and no fallback; every in-tree plugin
+  loads and registers its commands through the brokered path.
+
+## Risks
+
+- **Audit completeness is the dominant risk.** Fail-fast turns any missed
+  declaration into a hard boot failure. Mitigation: R7 audit re-derived from code
+  - the whole-system load test as the gate.
+- **Actor-identity is new surface on the critical path.** A subtle stamping bug
+  fails token-requiring caps closed (loud) rather than open — acceptable
+  direction, but it blocks `core-communication`/`core-objects` until correct.
+- **Return-value emit vs `emit` cap confusion.** Gating the wrong one breaks all
+  event emission. R1 fixes the boundary explicitly; tests MUST cover both paths.
+
+## Sequencing
+
+The atomic flip (R2) is the **last** change. Order:
+
+1. R5 backing servers (`eykuh.4.1`, `eykuh.4.2`).
+2. R4 actor-identity interceptor (new child `eykuh.4.5` — MUST be created
+   during `plan-to-beads` materialization; it does not exist yet).
+3. R3 resolver grant set + both shims consuming it.
+4. R7 manifest audit + declarations.
+5. R8 o262d policy-function refactor + tests; close `o262d`.
+6. **R2 atomic flip**: remove allowlist, strip legacy capability injection,
+   reconcile names (R6).
+7. R3 bind `INV-PLUGIN-45`; R9 opacity test (independent).
+
+## References
+
+- Foundation: `docs/superpowers/specs/2026-06-11-plugin-capability-dependency-foundation-design.md`
+- Host-cap decomposition: `docs/superpowers/specs/2026-06-11-plugin-host-capability-decomposition-design.md`
+- Least-privilege/trust: `docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md`
+- Declaration enforcement: `docs/superpowers/specs/2026-06-13-plugin-capability-declaration-enforcement-design.md`
+- Rules: `.claude/rules/plugin-runtime-symmetry.md`, `.claude/rules/plugin-manifest.md`,
+  `.claude/rules/grpc-errors.md`, `.claude/rules/invariants.md`
+- `o262d` bug; lessons `eykuh.2.9`, `eykuh.2.10`, `eykuh.2.11`
+<!-- adr-capture: sha256=7518d899f25996c0; session=cli; ts=2026-06-14T14:12:13Z; adrs=holomush-40ssh,holomush-vpg8l,holomush-ptf7b,holomush-05f3v -->


### PR DESCRIPTION
## Summary

Docs-only PR landing the **sub-spec 5** design artifacts for the plugin-capability epic (`holomush-eykuh.4`) — the final sub-spec: the atomic capability cutover + `o262d` settlement. No code changes; this lands the canonical spec/plan/ADRs so implementer sessions can read them from `main`.

## Contents

- **Spec:** `docs/superpowers/specs/2026-06-14-plugin-capability-atomic-cutover-design.md` (design-reviewer: READY)
- **Plan:** `docs/superpowers/plans/2026-06-14-plugin-capability-atomic-cutover.md` — 10 tasks (plan-reviewer: READY)
- **ADRs (4):**
  - `holomush-40ssh` — Atomic (big-bang) cutover over phased allowlist rollout
  - `holomush-vpg8l` — Resolver `Grants` set as the single least-privilege gate authority
  - `holomush-ptf7b` — o262d DAG failures stay always-fatal behind a named policy-function seam
  - `holomush-05f3v` — Retire capability injection only; keep ambient stdlib ungated

## Key decisions

- **Big-bang atomic cutover**: remove the `WithHostCapBridge` allowlist, retire legacy unconditional capability injection, and make the declaration-gated brokered path the sole capability-consumption path for both runtimes in one flip.
- **Single gate (binds INV-PLUGIN-45)**: `ResolveResult.Grants[plugin]` becomes the one least-privilege authority both shims consume.
- **o262d**: already-live fail-fast factored behind `defaultResolvePolicy` so a future `gracefulDegradation` quarantine is a one-point swap; bug closed during implementation.
- **Capabilities-only retirement**: language stdlib (`log`, `fmt`, `register_emit_type`, return-value emit) stays ungated.

## Beads

Epic `holomush-eykuh.4` materialized: children `4.1`/`4.2` (backings), `4.3` (bind INV-45), `4.4` (opacity test), new `4.5` (actor identity), `4.6` (resolver Grants), `4.7` (shim consolidation), `4.8` (manifest audit), `4.9` (atomic flip); `holomush-o262d` linked as a flip prerequisite.

## Verification

`task pr-prep` (fast lane) — **pass** (docs-only; no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
