### PR TITLE
feat(plugin): SessionAdmin broadcast backing + ADR holomush-t019a (holomush-eykuh.4.2)

### DIFF
--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -269,6 +269,13 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 		bus:       s.cfg.EventBus,
 	}
 
+	// Wire the plugin SessionAdmin broadcast backing now that the event appender
+	// exists — the brokered SessionAdminService.Broadcast emits a system event to
+	// the reserved subject over this appender (holomush-eykuh.4.2, decision
+	// holomush-t019a). Late binding: the appender is built here, after the plugin
+	// subsystem started, so this cannot be a host construction-time option.
+	s.cfg.Plugins.ConfigureSystemBroadcaster(eventStore)
+
 	// 1. Create core engine from event store.
 	engine := core.NewEngine(eventStore)
 

--- a/docs/adr/holomush-t019a-back-sessionadmin-broadcast-via-system-subject-event-emit-ke.md
+++ b/docs/adr/holomush-t019a-back-sessionadmin-broadcast-via-system-subject-event-emit-ke.md
@@ -1,0 +1,52 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-t019a; do not edit manually; use `/adr update holomush-t019a` -->
+
+# Back SessionAdmin broadcast via the system-subject event emit; keep disconnect unimplemented
+
+**Date:** 2026-06-14
+**Status:** Accepted
+**Decision:** holomush-t019a
+**Deciders:** Sean Brandt
+
+## Context
+
+The plugin-capability atomic cutover (sub-spec 5, epic `holomush-eykuh.4`) requires, per spec R5, that the host-brokered `SessionAdminService` (broadcast/disconnect) have a real backing before the atomic flip (`eykuh.4.9`), because the gated path fails closed (`codes.Unimplemented`) without one. Bead `eykuh.4.2` was blocked: no production implementor of `hostcap.SessionAdmin` (`BroadcastSystemMessage(ctx,message)` + `DisconnectSession(ctx,sessionID,reason)`) was reachable from the plugin-subsystem construction site.
+
+Grounding established the precise state:
+
+- `wall` (core-communication, the only broadcast caller) is **already non-functional in production**. It calls `session.list_active()` / `session.broadcast()` on a top-level `session` Lua global that production never registers: `SessionCapability` (`internal/plugin/hostfunc/cap_session.go`) is the only registrant and its constructor `NewSessionCapability` is **test-only**; the production `CapabilityRegistry` (`internal/plugin/setup/subsystem.go:177-178`) wires only `AuditService`; the stdlib `holo.session` namespace exposes only `find_by_name`/`set_last_whispered`. No test exercises `wall`. Consequently the flip regresses nothing.
+- `session.disconnect` has **zero callers** anywhere, and there is no core-side forcible-disconnect mechanism. Forcible connection teardown is structurally a gateway/connection-layer concern (`.claude/rules/gateway-boundary.md`).
+- A real broadcast sink **does** exist: `core.EventAppender.Append` emitting a `system`-actor `core.EventTypeSystem` event to the reserved `"system"` subject — exactly `command.Services.BroadcastSystemMessage(ctx,"system",msg)` (`internal/command/types.go:619`), used by the `shutdown` command (`internal/command/handlers/shutdown.go:42`). The appender (`busn`) is built top-level in `cmd/holomush/sub_grpc.go` and shared to the command layer and plugin manager, but is **not** threaded into `PluginSubsystemConfig`. The gap is a missing dependency *edge*, not a missing *mechanism*.
+
+## Decision
+
+1. **Broadcast — wire it via the system-subject event emit.** Back `SessionAdmin.BroadcastSystemMessage(ctx,message)` with a thin adapter over a `core.EventAppender`, threaded as a new dependency edge into `PluginSubsystemConfig`. The backing emits a `system`-actor `core.EventTypeSystem` event (built with `core.NewEvent`) to the reserved `"system"` subject — identical to `command.Services.BroadcastSystemMessage` / `shutdown`. The **host** stamps the system actor, so the plugin does not need `system` in `actor_kinds_claimable`; the privileged emit is gated by the `session.admin` capability declaration. The single backing is provided to the shared `sessionAdminServer`, so the Lua and binary runtimes reach it identically (plugin-runtime-symmetry — the gate stays at the common path). Implemented in bead `holomush-eykuh.4.2`. This makes `wall` functional for the first time once `eykuh.4.9` reconciles the Lua surface names.
+
+2. **Disconnect — keep it fail-closed `Unimplemented` plus a follow-up bead.** `SessionAdmin.DisconnectSession(ctx,sessionID,reason)` retains the existing nil-guard (`Unimplemented`). No production forcible-disconnect mechanism exists and it has zero callers; building one now is unjustified. A follow-up bead tracks a future gateway-observed eviction mechanism. The `session.admin` capability and the `SessionAdminService.Disconnect` RPC are retained (no proto churn).
+
+## Rationale
+
+- The only real broadcast sink in the codebase is the event-appender emit to the `"system"` subject; reusing it keeps broadcast event-sourced and consistent with `shutdown`, rather than reinventing a session-store fan-out that would couple the plugin subsystem to session delivery and duplicate the bus.
+- Routing through `core.EventAppender` means the dependency is an *existing* top-level object (`busn`), so the "new plumbing" is a single threaded edge, not a new mechanism.
+- A host-stamped system actor respects the `actor_kinds_claimable` gate: a plugin cannot claim `system`, so the privileged broadcast must be performed by the host on the plugin's behalf — exactly what a host-brokered capability server is for.
+- Disconnect has neither a sink nor a caller; per `gateway-boundary.md`, forcible connection teardown belongs to the gateway, not core. Keeping it `Unimplemented` is honest and fail-closed; a follow-up bead tracks the real mechanism without blocking the cutover.
+- Because `wall` is already unbacked, none of this is *required* to make the `4.9` flip safe — but wiring broadcast properly is small and converts dead scaffolding into a working capability, so it is worth doing in-epic rather than deferring.
+
+## Alternatives Considered
+
+- **Broadcast via session-store fan-out (rejected):** iterate `ListActive` and push per session. Wrong shape for an event-sourced system, couples the plugin subsystem to session delivery, and reimplements the bus.
+- **Defer broadcast; keep Unimplemented (rejected):** legitimate since the flip is safe regardless, but it leaves `wall` broken and the capability vestigial when the fix is a single dependency edge.
+- **Retire the `session.admin` broadcast capability entirely (rejected):** would push `wall` onto a host-command path and remove the plugin-facing broadcast surface; more proto/vocab churn than wiring the existing sink, and forecloses plugin-authored privileged broadcasts.
+- **Build a disconnect mechanism now (rejected):** an eviction-flag / disconnect-event observed by the gateway is real future work but out of `eykuh.4`'s scope, with zero current callers to justify it.
+- **Remove `DisconnectSession` from the interface + vocab (rejected):** YAGNI-pure, but touches the proto `SessionAdminService` and the `session.admin` vocab for no functional gain; the fail-closed stub + follow-up bead is lower churn.
+
+## Consequences
+
+- **Positive:** `wall` becomes functional (after `4.9` surface reconciliation); `SessionAdminService` gains a real, symmetric, event-sourced broadcast backing; the R5 precondition for the flip is genuinely satisfied (not stubbed); disconnect's gap is tracked rather than faked.
+- **Negative:** `PluginSubsystemConfig` gains a new dependency edge (a `core.EventAppender`, or a narrow `SystemBroadcaster` over it); the broadcast subject string `"system"` becomes a shared constant the plugin path and command path must agree on.
+- **Neutral:** `session.admin` continues to bundle broadcast + disconnect at current vocab granularity; a `session.admin`-declaring plugin gets a working broadcast and a fail-closed disconnect until the follow-up lands. For `wall` to actually work end-to-end, `4.9` must also (a) add `session.admin` to core-communication's manifest (R7) and (b) reconcile the Lua call sites (`session.list_active`/`session.broadcast`, snake_case) against the brokered surface (`ListActive`/`Broadcast`, PascalCase) — broadcast wiring alone does not make `wall` green.

--- a/internal/command/handlers/shutdown.go
+++ b/internal/command/handlers/shutdown.go
@@ -13,6 +13,7 @@ import (
 	"github.com/samber/oops"
 
 	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/core"
 )
 
 // ShutdownHandler initiates a graceful server shutdown.
@@ -39,7 +40,7 @@ func ShutdownHandler(ctx context.Context, exec *command.CommandExecution) error 
 
 	// Broadcast warning to all players
 	message := formatShutdownMessage(delaySeconds)
-	exec.Services().BroadcastSystemMessage(ctx, "system", message)
+	exec.Services().BroadcastSystemMessage(ctx, core.SystemBroadcastSubject, message)
 
 	// Log admin action
 	slog.InfoContext(

--- a/internal/core/event.go
+++ b/internal/core/event.go
@@ -182,6 +182,16 @@ var WorldServiceActorULID = ulid.ULID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 // changes (string → ULID-string).
 var ActorSystemID = SystemActorULID.String()
 
+// SystemBroadcastSubject is the reserved stream (the `stream` argument to
+// NewEvent) for grid-wide system broadcasts — server announcements and the
+// admin `wall` command. The event appender qualifies it to
+// events.<game_id>.system at the emit boundary. Both the command-layer
+// broadcast path (command.Services.BroadcastSystemMessage / the shutdown
+// command) and the plugin-host SessionAdmin broadcast backing
+// (hostcap.NewSystemBroadcaster, decision holomush-t019a) MUST agree on this
+// value so a plugin `wall` and a host announcement land on the same subject.
+const SystemBroadcastSubject = "system"
+
 // IsSentinelULID returns true iff id is a system actor sentinel ULID:
 // first 15 bytes zero, last byte in [0x01, 0xFF]. Used by IdentityRegistry
 // bootstrap (sentinel-collision detection on plugin row load) and by

--- a/internal/plugin/hostcap/session.go
+++ b/internal/plugin/hostcap/session.go
@@ -5,6 +5,7 @@ package hostcap
 
 import (
 	"context"
+	"errors"
 
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/grpc/codes"
@@ -135,6 +136,13 @@ func (s *sessionAdminServer) Disconnect(ctx context.Context, req *hostv1.Disconn
 		return nil, status.Errorf(codes.Unimplemented, "session admin not supported")
 	}
 	if err := admin.DisconnectSession(ctx, req.GetSessionId(), req.GetReason()); err != nil {
+		// A backing with no forcible-disconnect mechanism (the production
+		// systemBroadcaster) reports ErrDisconnectUnsupported; surface that as
+		// Unimplemented — semantically the same fail-closed signal as the nil
+		// (unwired) case above (decision holomush-t019a; follow-up holomush-obo44).
+		if errors.Is(err, ErrDisconnectUnsupported) {
+			return nil, status.Errorf(codes.Unimplemented, "session disconnect not supported")
+		}
 		errutil.LogErrorContext(ctx, "session.disconnect failed", err, "plugin", s.pluginName)
 		return nil, status.Errorf(codes.Internal, "internal error")
 	}

--- a/internal/plugin/hostcap/session_test.go
+++ b/internal/plugin/hostcap/session_test.go
@@ -345,6 +345,23 @@ func TestSessionAdminServerDisconnect(t *testing.T) {
 			},
 		},
 		{
+			// The production systemBroadcaster backs broadcast but not disconnect
+			// (no forcible-disconnect mechanism exists — decision holomush-t019a,
+			// follow-up holomush-obo44). Its DisconnectSession returns the
+			// ErrDisconnectUnsupported sentinel, which the server maps to
+			// Unimplemented rather than the generic Internal — so a wired-but-
+			// unsupported backing is indistinguishable to the caller from the
+			// unwired nil case.
+			name:  "returns Unimplemented when backing reports disconnect unsupported",
+			admin: &fakeSessionAdmin{disconnectErr: hostcap.ErrDisconnectUnsupported},
+			check: func(t *testing.T, _ *fakeSessionAdmin, err error) {
+				require.Error(t, err)
+				st, ok := status.FromError(err)
+				require.True(t, ok)
+				assert.Equal(t, codes.Unimplemented, st.Code(), "an unsupported-disconnect backing must surface Unimplemented, not Internal")
+			},
+		},
+		{
 			name:  "fails closed with Unimplemented when SessionAdmin is nil",
 			admin: nil,
 			check: func(t *testing.T, _ *fakeSessionAdmin, err error) {

--- a/internal/plugin/hostcap/system_broadcaster.go
+++ b/internal/plugin/hostcap/system_broadcaster.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/core"
+)
+
+// ErrDisconnectUnsupported is returned by SessionAdmin.DisconnectSession backings
+// that have no forcible-disconnect mechanism. The sessionAdminServer maps it to
+// codes.Unimplemented so a wired-but-unsupported backing is indistinguishable to
+// the caller from the unwired nil case. Forcible session disconnect is a
+// gateway-layer concern with no core sink today (decision holomush-t019a;
+// follow-up holomush-obo44).
+var ErrDisconnectUnsupported = errors.New("session disconnect is not supported")
+
+// systemBroadcaster backs hostcap.SessionAdmin by emitting a system-actor system
+// event to the reserved broadcast subject via a core.EventAppender — the same
+// mechanism as command.Services.BroadcastSystemMessage and the shutdown command
+// (decision holomush-t019a). The host stamps the system actor, so a broadcasting
+// plugin does not need `system` in its actor_kinds_claimable: the privileged emit
+// is performed by the host on the plugin's behalf, gated by the session.admin
+// capability declaration at the brokered SessionAdminService boundary.
+//
+// DisconnectSession is intentionally unbacked (ErrDisconnectUnsupported): no
+// production forcible-disconnect mechanism exists and none has a caller; it is a
+// gateway concern tracked in holomush-obo44.
+type systemBroadcaster struct {
+	appender core.EventAppender
+}
+
+// NewSystemBroadcaster builds a SessionAdmin broadcast backing over appender.
+// Returned as the SessionAdmin interface so callers cannot reach the struct.
+func NewSystemBroadcaster(appender core.EventAppender) SessionAdmin {
+	return &systemBroadcaster{appender: appender}
+}
+
+// BroadcastSystemMessage emits a single system-actor system event carrying
+// message to the reserved broadcast subject. Mirrors the {"message": ...} payload
+// shape of command.Services.BroadcastSystemMessage so terminal/web clients render
+// host announcements and plugin `wall` announcements identically.
+func (b *systemBroadcaster) BroadcastSystemMessage(ctx context.Context, message string) error {
+	//nolint:errcheck // json.Marshal cannot fail for map[string]string
+	payload, _ := json.Marshal(map[string]string{"message": message})
+	event := core.NewEvent(
+		core.SystemBroadcastSubject,
+		core.EventTypeSystem,
+		core.Actor{Kind: core.ActorSystem, ID: core.ActorSystemID},
+		payload,
+	)
+	if err := b.appender.Append(ctx, event); err != nil {
+		return oops.Code("SYSTEM_BROADCAST_FAILED").Wrap(err)
+	}
+	return nil
+}
+
+// DisconnectSession is unsupported — see ErrDisconnectUnsupported.
+func (b *systemBroadcaster) DisconnectSession(_ context.Context, _, _ string) error {
+	return ErrDisconnectUnsupported
+}

--- a/internal/plugin/hostcap/system_broadcaster_test.go
+++ b/internal/plugin/hostcap/system_broadcaster_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/hostcap"
+)
+
+// fakeEventAppender captures appended events for assertion and can be made to
+// fail. It satisfies core.EventAppender.
+type fakeEventAppender struct {
+	events []core.Event
+	err    error
+}
+
+func (f *fakeEventAppender) Append(_ context.Context, e core.Event) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.events = append(f.events, e)
+	return nil
+}
+
+// TestSystemBroadcasterBroadcastAppendsSystemEventToReservedSubject proves the
+// SessionAdmin broadcast backing emits a single system-actor system event to the
+// reserved broadcast subject — the same shape as command.Services.Broadcast-
+// SystemMessage / the shutdown command (ADR holomush-t019a). The host stamps the
+// system actor so the plugin needs no `system` in actor_kinds_claimable.
+func TestSystemBroadcasterBroadcastAppendsSystemEventToReservedSubject(t *testing.T) {
+	app := &fakeEventAppender{}
+	b := hostcap.NewSystemBroadcaster(app)
+
+	err := b.BroadcastSystemMessage(context.Background(), "Server restart in 5 minutes.")
+
+	require.NoError(t, err)
+	require.Len(t, app.events, 1)
+	ev := app.events[0]
+	assert.Equal(t, core.SystemBroadcastSubject, ev.Stream, "broadcast must target the reserved system subject")
+	assert.Equal(t, core.EventTypeSystem, ev.Type)
+	assert.Equal(t, core.ActorSystem, ev.Actor.Kind, "host stamps the system actor")
+	assert.Equal(t, core.ActorSystemID, ev.Actor.ID)
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(ev.Payload, &payload))
+	assert.Equal(t, "Server restart in 5 minutes.", payload["message"])
+}
+
+// TestSystemBroadcasterBroadcastWrapsAppenderFailure proves a sink failure is
+// surfaced (the sessionAdminServer then maps it to an opaque Internal status).
+func TestSystemBroadcasterBroadcastWrapsAppenderFailure(t *testing.T) {
+	app := &fakeEventAppender{err: errors.New("bus unavailable")}
+	b := hostcap.NewSystemBroadcaster(app)
+
+	err := b.BroadcastSystemMessage(context.Background(), "hi")
+
+	require.Error(t, err)
+	assert.Empty(t, app.events)
+}
+
+// TestSystemBroadcasterDisconnectReturnsUnsupportedSentinel proves forcible
+// disconnect is NOT backed (no production mechanism; gateway concern — decision
+// holomush-t019a, follow-up holomush-obo44). It returns the sentinel and appends
+// nothing; the sessionAdminServer maps the sentinel to codes.Unimplemented.
+func TestSystemBroadcasterDisconnectReturnsUnsupportedSentinel(t *testing.T) {
+	app := &fakeEventAppender{}
+	b := hostcap.NewSystemBroadcaster(app)
+
+	err := b.DisconnectSession(context.Background(), "01ABC", "idle timeout")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, hostcap.ErrDisconnectUnsupported)
+	assert.Empty(t, app.events, "disconnect must not append any event")
+}

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -69,6 +69,12 @@ type Host struct {
 	// existing tests). A non-nil map is authoritative: only tokens present
 	// in pluginGrants[name] are passed to RegisterHostCaps.
 	pluginGrants map[string][]string
+	// sessionAdmin is the broadcast/disconnect backing threaded into the
+	// hostCapAdapter so the brokered SessionAdminService serves real broadcasts.
+	// Wired at construction (WithSessionAdmin) or late (SetSessionAdmin);
+	// production wires it late, after the event appender exists
+	// (holomush-eykuh.4.2). nil ⇒ the sessionAdminServer fails closed.
+	sessionAdmin hostcap.SessionAdmin
 }
 
 // HostOption customizes Host construction.
@@ -176,6 +182,15 @@ func grantedSubset(requested, granted []string) []string {
 	return out
 }
 
+// WithSessionAdmin configures the host with the broadcast/disconnect backing for
+// the brokered SessionAdminService (holomush-eykuh.4.2). Production wires the
+// backing late via SetSessionAdmin (the event appender does not exist at host
+// construction); this option is the construction-time equivalent for tests and
+// in-process wiring. nil leaves the sessionAdminServer fail-closed.
+func WithSessionAdmin(sa hostcap.SessionAdmin) HostOption {
+	return func(h *Host) { h.sessionAdmin = sa }
+}
+
 // NewHost creates a new Lua plugin host without host functions.
 func NewHost(opts ...HostOption) *Host {
 	h := &Host{
@@ -199,14 +214,16 @@ func NewHostWithFunctions(hf *hostfunc.Functions, opts ...HostOption) *Host {
 		panic("lua.NewHostWithFunctions: hostFuncs cannot be nil")
 	}
 	h := &Host{
-		factory:        NewStateFactory(),
-		hostFuncs:      hf,
-		hostCapAdapter: newLuaHostCapAdapter(hf),
-		plugins:        make(map[string]*luaPlugin),
+		factory:   NewStateFactory(),
+		hostFuncs: hf,
+		plugins:   make(map[string]*luaPlugin),
 	}
 	for _, opt := range opts {
 		opt(h)
 	}
+	// Build the adapter AFTER options apply so WithSessionAdmin (and any future
+	// adapter-affecting option) is reflected in the per-plugin capability servers.
+	h.hostCapAdapter = newLuaHostCapAdapterWithSessionAdmin(hf, h.sessionAdmin)
 	return h
 }
 
@@ -274,6 +291,21 @@ func (h *Host) SetSettingsStores(
 func (h *Host) SetHistoryReader(hr plugins.HistoryReader) {
 	if h.hostFuncs != nil {
 		h.hostFuncs.SetHistoryReader(hr)
+	}
+}
+
+// SetSessionAdmin injects the broadcast/disconnect backing into the host-cap
+// adapter so the brokered SessionAdminService serves real broadcasts
+// (holomush-eykuh.4.2). Called once during startup wiring, before any plugin
+// dispatch — the event appender the backing wraps is not available until the
+// EventBus subsystem starts (after the plugin subsystem builds this host), so a
+// construction-time option cannot reach it. Same startup-ordered late-binding
+// contract as SetHistoryReader / SetEventEmitter. No-op when the host was built
+// without host functions (NewHost path — no capability adapter).
+func (h *Host) SetSessionAdmin(sa hostcap.SessionAdmin) {
+	h.sessionAdmin = sa
+	if a, ok := h.hostCapAdapter.(*luaHostCapAdapter); ok {
+		a.setSessionAdmin(sa)
 	}
 }
 

--- a/internal/plugin/lua/hostcap_adapter.go
+++ b/internal/plugin/lua/hostcap_adapter.go
@@ -11,10 +11,11 @@
 //   - IssueEmitToken: Lua returns an unsupported error (no forgery surface).
 //   - IdentityRegistrySnapshot: Lua returns nil (no token forgery surface).
 //   - EventEmitter: Lua returns nil (emissions flow through Lua hostfuncs, not gRPC).
-//   - SessionAdmin: Lua returns nil until a broadcast/disconnect backing is wired
-//     for the bufconn endpoint (holomush-eykuh.4.2). The server-side
-//     nil-guard in sessionAdminServer keeps this fail-closed (Unimplemented),
-//     so a nil here is safe for both runtimes.
+//   - SessionAdmin: Lua wires a broadcast/disconnect backing (a
+//     hostcap.NewSystemBroadcaster over the event appender) via
+//     lua.Host.SetSessionAdmin (holomush-eykuh.4.2); binary returns nil because
+//     SessionAdminService is Lua-only (not in BinaryDefaultSet). When unwired the
+//     server-side nil-guard in sessionAdminServer keeps this fail-closed.
 package lua
 
 import (
@@ -52,14 +53,36 @@ var _ hostcap.HostCapabilities = (*luaHostCapAdapter)(nil)
 // INV-PLUGIN-27). This keeps a single wiring point: SetSettingsStores.
 type luaHostCapAdapter struct {
 	f *hostfunc.Functions
+	// sessionAdmin backs the SessionAdminService broadcast/disconnect RPCs. It is
+	// the WIDE admin surface that Functions does not hold (Functions stores only
+	// the narrow session.Access). Wired at lua.Host construction (WithSessionAdmin)
+	// or late via lua.Host.SetSessionAdmin — the production path, since the event
+	// appender the backing wraps does not exist until the EventBus subsystem starts
+	// (holomush-eykuh.4.2). nil ⇒ the sessionAdminServer nil-guard fails closed.
+	sessionAdmin hostcap.SessionAdmin
 }
 
-// newLuaHostCapAdapter creates a Lua HostCapabilities adapter wrapping f.
+// newLuaHostCapAdapter creates a Lua HostCapabilities adapter wrapping f with no
+// SessionAdmin backing (the sessionAdminServer nil-guards and fails closed).
 // Settings stores and the focus coordinator are recovered on demand from f's
 // settingsOps / focusOps seams, so callers wire them once via
 // lua.Host.SetSettingsStores / SetFocusCoordinator.
 func newLuaHostCapAdapter(f *hostfunc.Functions) *luaHostCapAdapter {
-	return &luaHostCapAdapter{f: f}
+	return newLuaHostCapAdapterWithSessionAdmin(f, nil)
+}
+
+// newLuaHostCapAdapterWithSessionAdmin creates the adapter with a SessionAdmin
+// broadcast/disconnect backing (holomush-eykuh.4.2). A nil sa is equivalent to
+// newLuaHostCapAdapter.
+func newLuaHostCapAdapterWithSessionAdmin(f *hostfunc.Functions, sa hostcap.SessionAdmin) *luaHostCapAdapter {
+	return &luaHostCapAdapter{f: f, sessionAdmin: sa}
+}
+
+// setSessionAdmin updates the SessionAdmin backing after construction. Called by
+// lua.Host.SetSessionAdmin during startup wiring (before any plugin dispatch),
+// mirroring the other late-bound host deps (SetHistoryReader, SetEventEmitter).
+func (a *luaHostCapAdapter) setSessionAdmin(sa hostcap.SessionAdmin) {
+	a.sessionAdmin = sa
 }
 
 // --- hostcap.HostCapabilities implementation --------------------------------
@@ -230,15 +253,15 @@ func (a *luaHostCapAdapter) SessionAccess() session.Access {
 	return a.f.GetSessionAccess()
 }
 
-// SessionAdmin returns nil: the broadcast/disconnect admin surface is the WIDE
-// hostfunc.SessionAccess shim, which is NOT held by Functions (Functions stores
-// only the narrow session.Access via WithSessionAccess). Wiring the wide surface
-// would require threading a new dependency through lua.Host construction, which is
-// deferred to a future migration task (holomush-eykuh.4.2). Returning nil is safe:
-// sessionAdminServer.Broadcast/Disconnect nil-guard this port and fail closed with
-// Unimplemented (session.go), protecting both runtimes.
+// SessionAdmin returns the wired broadcast/disconnect backing, or nil when none
+// is wired (the sessionAdminServer nil-guards and fails closed with Unimplemented).
+// In production this is a hostcap.NewSystemBroadcaster over the event appender,
+// wired late via lua.Host.SetSessionAdmin (holomush-eykuh.4.2, decision
+// holomush-t019a): broadcast emits a system event to the reserved subject;
+// disconnect reports ErrDisconnectUnsupported → Unimplemented (no production
+// forcible-disconnect mechanism; follow-up holomush-obo44).
 func (a *luaHostCapAdapter) SessionAdmin() hostcap.SessionAdmin {
-	return nil
+	return a.sessionAdmin
 }
 
 // --- focusOpsCoordinatorAdapter -------------------------------------------

--- a/internal/plugin/lua/session_admin_test.go
+++ b/internal/plugin/lua/session_admin_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package lua
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+)
+
+// stubSessionAdmin is a no-op hostcap.SessionAdmin for wiring assertions.
+type stubSessionAdmin struct{}
+
+func (stubSessionAdmin) BroadcastSystemMessage(context.Context, string) error    { return nil }
+func (stubSessionAdmin) DisconnectSession(context.Context, string, string) error { return nil }
+
+// TestLuaAdapterSessionAdminReturnsBackingWhenWired proves the Lua adapter
+// surfaces a wired SessionAdmin backing (holomush-eykuh.4.2) — the production
+// path for the brokered SessionAdminService over the Lua bufconn endpoint.
+func TestLuaAdapterSessionAdminReturnsBackingWhenWired(t *testing.T) {
+	a := newLuaHostCapAdapterWithSessionAdmin(hostfunc.New(nil), stubSessionAdmin{})
+	require.NotNil(t, a.SessionAdmin())
+}
+
+// TestLuaAdapterSessionAdminNilWhenUnset proves the adapter still returns nil
+// when no backing is wired — the sessionAdminServer nil-guard then fails closed
+// with Unimplemented (the pre-4.2 behavior, preserved for the unwired case).
+func TestLuaAdapterSessionAdminNilWhenUnset(t *testing.T) {
+	a := newLuaHostCapAdapter(hostfunc.New(nil))
+	assert.Nil(t, a.SessionAdmin())
+}
+
+// TestHostWithSessionAdminOptionWiresAdapter proves the construction-time
+// WithSessionAdmin option threads the backing into the adapter the per-plugin
+// bufconn endpoint consumes.
+func TestHostWithSessionAdminOptionWiresAdapter(t *testing.T) {
+	h := NewHostWithFunctions(hostfunc.New(nil), WithSessionAdmin(stubSessionAdmin{}))
+	require.NotNil(t, h.HostCapabilitiesAdapter().SessionAdmin())
+}
+
+// TestHostSetSessionAdminLateWiresAdapter proves the late setter wires the
+// backing after construction — the production path, because the event appender
+// the backing wraps does not exist until the EventBus subsystem starts (after
+// the plugin subsystem builds the Lua host). Mirrors SetHistoryReader /
+// SetEventEmitter late binding.
+func TestHostSetSessionAdminLateWiresAdapter(t *testing.T) {
+	h := NewHostWithFunctions(hostfunc.New(nil))
+	require.Nil(t, h.HostCapabilitiesAdapter().SessionAdmin(), "unset before late wiring")
+
+	h.SetSessionAdmin(stubSessionAdmin{})
+
+	require.NotNil(t, h.HostCapabilitiesAdapter().SessionAdmin(), "SetSessionAdmin must wire the adapter post-construction")
+}

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -26,6 +26,7 @@ import (
 	"github.com/holomush/holomush/internal/lifecycle"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/goplugin"
+	"github.com/holomush/holomush/internal/plugin/hostcap"
 	"github.com/holomush/holomush/internal/plugin/hostfunc"
 	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
@@ -128,6 +129,7 @@ type PluginSubsystemConfig struct {
 type PluginSubsystem struct {
 	cfg               PluginSubsystemConfig
 	manager           *plugins.Manager
+	luaHost           *pluginlua.Host // built in Start; SessionAdmin backing wired late via ConfigureSystemBroadcaster
 	cmdRegistry       *command.Registry
 	commandQuerier    *commandquery.Querier
 	registry          *plugins.ServiceRegistry
@@ -211,6 +213,10 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		// (plugin-runtime-symmetry); it is the resolver the ABAC engine reads.
 		pluginlua.WithDispatchAttributeResolver(s.cfg.ABAC.AttributeResolver()),
 	)
+	// Retain the Lua host so the gRPC subsystem can wire the SessionAdmin
+	// broadcast backing late, once the event appender exists
+	// (ConfigureSystemBroadcaster, holomush-eykuh.4.2).
+	s.luaHost = luaHost
 
 	// 4. Create service registry for proto service resolution.
 	s.registry = plugins.NewServiceRegistry()
@@ -459,6 +465,24 @@ func (s *PluginSubsystem) Manager() *plugins.Manager {
 		panic("plugin/setup: Manager() called before Start()")
 	}
 	return s.manager
+}
+
+// ConfigureSystemBroadcaster wires the SessionAdmin broadcast backing — a
+// system-event emit over appender — into the Lua host so the brokered
+// SessionAdminService serves real broadcasts (holomush-eykuh.4.2, decision
+// holomush-t019a). It MUST be called from the gRPC subsystem's Start once the
+// event appender exists: the appender is built after the plugin subsystem starts,
+// so a construction-time option cannot reach it (same late-binding rationale as
+// Manager.ConfigureEventEmitter / ConfigureFocusDeps). No-op when the Lua host is
+// not yet built or the appender is nil (leaves the server fail-closed). The
+// binary host needs no equivalent: SessionAdminService is Lua-only (not in
+// hostcap.BinaryDefaultSet). Disconnect stays Unimplemented — no production
+// forcible-disconnect mechanism (follow-up holomush-obo44).
+func (s *PluginSubsystem) ConfigureSystemBroadcaster(appender core.EventAppender) {
+	if s.luaHost == nil || appender == nil {
+		return
+	}
+	s.luaHost.SetSessionAdmin(hostcap.NewSystemBroadcaster(appender))
 }
 
 // CommandRegistry returns the command Registry. Panics if called before Start().

--- a/internal/plugin/setup/system_broadcaster_test.go
+++ b/internal/plugin/setup/system_broadcaster_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package setup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
+)
+
+// noopAppender is a core.EventAppender that discards events — enough to assert
+// the SessionAdmin backing is wired (the backing's behavior is covered by the
+// hostcap broadcaster tests).
+type noopAppender struct{}
+
+func (noopAppender) Append(context.Context, core.Event) error { return nil }
+
+// TestConfigureSystemBroadcasterWiresLuaHostBackingFromAppender proves the late
+// production wiring (holomush-eykuh.4.2): ConfigureSystemBroadcaster builds a
+// system-broadcaster over the appender and threads it into the Lua host so the
+// brokered SessionAdminService serves real broadcasts.
+func TestConfigureSystemBroadcasterWiresLuaHostBackingFromAppender(t *testing.T) {
+	s := &PluginSubsystem{
+		luaHost: pluginlua.NewHostWithFunctions(hostfunc.New(nil)),
+	}
+	require.Nil(t, s.luaHost.HostCapabilitiesAdapter().SessionAdmin(), "unset before wiring")
+
+	s.ConfigureSystemBroadcaster(noopAppender{})
+
+	require.NotNil(t, s.luaHost.HostCapabilitiesAdapter().SessionAdmin(),
+		"ConfigureSystemBroadcaster must wire the Lua host's SessionAdmin from the appender")
+}
+
+// TestConfigureSystemBroadcasterNoopWhenLuaHostUnset proves the call is safe
+// before Start has built the Lua host (defensive nil-guard, mirroring
+// Manager.ConfigureFocusDeps).
+func TestConfigureSystemBroadcasterNoopWhenLuaHostUnset(t *testing.T) {
+	s := &PluginSubsystem{}
+	require.NotPanics(t, func() { s.ConfigureSystemBroadcaster(noopAppender{}) })
+}

--- a/test/integration/pluginparity/session_admin_broadcast_test.go
+++ b/test/integration/pluginparity/session_admin_broadcast_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package pluginparity
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/hostcap"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	"github.com/holomush/holomush/internal/plugin/lua"
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
+// captureAppender records appended events for assertion. The mutex guards the
+// slice against the bufconn server goroutine writing while the spec reads.
+type captureAppender struct {
+	mu     sync.Mutex
+	events []core.Event
+}
+
+func (c *captureAppender) Append(_ context.Context, e core.Event) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+	return nil
+}
+
+func (c *captureAppender) captured() []core.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]core.Event(nil), c.events...)
+}
+
+var _ = Describe("SessionAdmin broadcast backing over the Lua bufconn path (holomush-eykuh.4.2)", func() {
+	// End-to-end proof that a brokered SessionAdminService.Broadcast — the surface
+	// the migrated `wall` command reaches after the cutover — emits a system event
+	// to the reserved subject through the production backing. It drives the REAL
+	// Lua host-cap adapter, the REAL sessionAdminServer (LuaDefaultSet), and the
+	// REAL hostcap.NewSystemBroadcaster over the SAME in-process transport
+	// production uses, wired via the production late path (Host.SetSessionAdmin).
+	It("emits a system event to the reserved subject when a plugin broadcasts", func() {
+		app := &captureAppender{}
+
+		luaHost := lua.NewHostWithFunctions(hostfunc.New(nil))
+		DeferCleanup(func() { _ = luaHost.Close(context.Background()) })
+		// Production wires the backing late, after the event appender exists.
+		luaHost.SetSessionAdmin(hostcap.NewSystemBroadcaster(app))
+
+		srv := grpc.NewServer()
+		hostcap.RegisterCapabilities(srv, hostcap.NewBase(luaHost.HostCapabilitiesAdapter(), parityPluginName), hostcap.LuaDefaultSet)
+		conn, err := plugins.NewInProcessConn(srv)
+		Expect(err).NotTo(HaveOccurred(), "lua in-process conn must stand up")
+		DeferCleanup(func() { _ = conn.Close() })
+
+		client := hostv1.NewSessionAdminServiceClient(conn)
+
+		_, err = client.Broadcast(context.Background(), &hostv1.BroadcastRequest{
+			Message: "Server restart in 5 minutes.",
+		})
+		Expect(err).NotTo(HaveOccurred(), "brokered SessionAdminService.Broadcast must succeed with a wired backing")
+
+		events := app.captured()
+		Expect(events).To(HaveLen(1), "broadcast must emit exactly one event")
+		ev := events[0]
+		Expect(ev.Stream).To(Equal(core.SystemBroadcastSubject), "broadcast must target the reserved system subject")
+		Expect(ev.Type).To(Equal(core.EventTypeSystem))
+		Expect(ev.Actor.Kind).To(Equal(core.ActorSystem), "host stamps the system actor on the plugin's behalf")
+		Expect(ev.Actor.ID).To(Equal(core.ActorSystemID))
+
+		var payload map[string]string
+		Expect(json.Unmarshal(ev.Payload, &payload)).To(Succeed())
+		Expect(payload["message"]).To(Equal("Server restart in 5 minutes."))
+	})
+
+	// Forcible disconnect has no production sink (decision holomush-t019a;
+	// follow-up holomush-obo44). Even with the broadcast backing wired, the
+	// brokered Disconnect fails closed with Unimplemented.
+	It("fails closed with Unimplemented for forcible disconnect", func() {
+		luaHost := lua.NewHostWithFunctions(hostfunc.New(nil))
+		DeferCleanup(func() { _ = luaHost.Close(context.Background()) })
+		luaHost.SetSessionAdmin(hostcap.NewSystemBroadcaster(&captureAppender{}))
+
+		srv := grpc.NewServer()
+		hostcap.RegisterCapabilities(srv, hostcap.NewBase(luaHost.HostCapabilitiesAdapter(), parityPluginName), hostcap.LuaDefaultSet)
+		conn, err := plugins.NewInProcessConn(srv)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = conn.Close() })
+
+		client := hostv1.NewSessionAdminServiceClient(conn)
+
+		_, err = client.Disconnect(context.Background(), &hostv1.DisconnectRequest{
+			SessionId: "01ABCDEF",
+			Reason:    "idle timeout",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Unimplemented),
+			"disconnect has no production backing — the broadcaster reports unsupported, mapped to Unimplemented")
+	})
+})


### PR DESCRIPTION
## What

Resolves design decision **holomush-t019a** and implements **holomush-eykuh.4.2** — the R5 backing precondition for the plugin-capability atomic cutover. Wires a production backing for the host-brokered `SessionAdminService` broadcast/disconnect surface (Lua bufconn path), which previously returned `nil` → `codes.Unimplemented`.

## Decision (ADR holomush-t019a)

Grounding established that the brokered `SessionAdminService` had **no** production backing on either path, and the legacy `wall` path was already non-functional in production (the top-level `session` Lua global is registered only by a test-only `SessionCapability`; prod's `CapabilityRegistry` wires only `AuditService`). So the upcoming 4.9 flip regresses nothing — this fills the gap properly:

- **Broadcast** → emit a `system`-actor `EventTypeSystem` event to the reserved `"system"` subject via a `core.EventAppender` — the same mechanism as `command.Services.BroadcastSystemMessage` / the `shutdown` command. The **host** stamps the system actor, so a broadcasting plugin needs no `system` in `actor_kinds_claimable`; the privileged emit is gated by the `session.admin` capability.
- **Disconnect** → stays `Unimplemented`: no production forcible-disconnect mechanism exists, and it is structurally a gateway concern (`gateway-boundary.md`). The backing returns `ErrDisconnectUnsupported`, which the server maps to `Unimplemented`. Deferred to follow-up **holomush-obo44**.

Full rationale: `docs/adr/holomush-t019a-back-sessionadmin-broadcast-via-system-subject-event-emit-ke.md`.

## Implementation

- `hostcap.NewSystemBroadcaster(appender)` — `SessionAdmin` backing over `core.EventAppender`.
- `sessionAdminServer.Disconnect` maps `ErrDisconnectUnsupported` → `Unimplemented`.
- `lua.Host`: `WithSessionAdmin` option + `SetSessionAdmin` late setter; the host-cap adapter is built after options apply.
- `PluginSubsystem.ConfigureSystemBroadcaster` — late production wiring from the event appender (built after the plugin subsystem starts), invoked in `cmd/holomush/sub_grpc.go`. Mirrors the established `ConfigureEventEmitter`/`ConfigureFocusDeps` late-binding pattern.
- `shutdown` command and the broadcaster share the new `core.SystemBroadcastSubject` constant.

The **binary host needs no backing**: `SessionAdminService` is Lua-only (in `LuaDefaultSet`, not `BinaryDefaultSet`) — a pre-existing, documented service-set boundary, not a new privilege gradient.

## Testing

- Unit (TDD, `-race`): `internal/plugin/hostcap`, `internal/plugin/lua`, `internal/plugin/setup`.
- Integration (`test/integration/pluginparity`): end-to-end over the **real** bufconn → Lua adapter → `sessionAdminServer` → `systemBroadcaster` → appender, plus the disconnect-Unimplemented path.
- `task pr-prep` (fast lane) **pass**; `wholesystem` + `pluginparity` integration suites **pass**; adversarial `code-reviewer` **READY**.

## Follow-up

- **holomush-obo44** — gateway-observed forcible-disconnect mechanism (deferred).
- 4.9 (atomic flip) must still add `session.admin` to `core-communication`'s manifest and reconcile the Lua surface names before `wall` is green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)