### PR TITLE
fix(ci): scope Renovate gomod manager to root go.mod (holomush-nr63n)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,8 +9,7 @@
   "platformAutomerge": true,
   "gomod": {
     "managerFilePatterns": [
-      "/(^|/)go\\.mod$/",
-      "/(^|/)go\\.tool(-lint)?\\.mod$/"
+      "/(^|/)go\\.mod$/"
     ]
   },
   "packageRules": [

--- a/go.tool-lint.mod
+++ b/go.tool-lint.mod
@@ -6,8 +6,9 @@
 // tools resolve self-consistently together.
 //
 // Run via `GOWORK=off go tool -modfile=go.tool-lint.mod <name>` (see
-// Taskfile.yaml GO_TOOL_LINT). Renovate tracks this via the `gomod` manager
-// fileMatch in .github/renovate.json.
+// Taskfile.yaml GO_TOOL_LINT). Renovate does NOT manage this modfile — its
+// `gomod` manager is scoped to the root go.mod only; see go.tool.mod for why
+// (holomush-nr63n). Lint tool deps here are bumped manually.
 module github.com/holomush/holomush/tools-lint
 
 go 1.26

--- a/go.tool.mod
+++ b/go.tool.mod
@@ -14,8 +14,12 @@
 // GOWORK=off is required because go.work enables workspace mode, which is
 // incompatible with -modfile.
 //
-// Renovate tracks this via the `gomod` manager fileMatch in
-// .github/renovate.json.
+// Renovate does NOT manage this modfile. Its `gomod` manager is scoped to the
+// root go.mod only (.github/renovate.json), because Renovate's artifact step
+// runs `go get -modfile=go.tool.mod -t ./...` from the repo root and the `./...`
+// sweep re-namespaces every main-module package under this module's identity,
+// failing to resolve their internal/ + pkg/ imports (holomush-nr63n). Tool deps
+// here are bumped manually.
 module github.com/holomush/holomush/tools
 
 go 1.26


### PR DESCRIPTION
## Problem

Closes #4452. Renovate-generated Go dependency PRs fail their `renovate/artifacts` step with an incomplete `go.sum`, blocking the three `[SECURITY]` PRs: #4447 (x/crypto), #4448 (x/net), #4449 (x/sys).

## Root cause (corrected from the issue)

Renovate's gomod artifact step runs `go get -modfile=go.tool.mod -t ./...` **from the repo root**. `go.tool.mod` / `go.tool-lint.mod` live at the repo **root** (not a `tools/` subdir) and declare `module github.com/holomush/holomush/tools`. The `./...` sweep therefore re-namespaces every **main-module** package (e.g. `cmd/holomush`) under the *tools* module identity, making its `internal/` + `pkg/` imports unresolvable — the exact `cannot find module providing package` error in the issue.

Dev never hits this because every real invocation runs a *named* tool (`GOWORK=off go tool -modfile=… task`), never `./...`.

> ⚠️ The issue's **option 2** (`replace … => ../`) is wrong: the modfile is at repo root so `../` points outside the repo, and a `replace` edge wouldn't stop `./...` from mis-namespacing main packages. There are no tool-module-local Go packages, and `go.work` never referenced the tool modules.

## Fix (issue option 1)

Scope Renovate's `gomod` manager to the root `go.mod` only by dropping the `go.tool(-lint)?.mod` pattern from `managerFilePatterns`. Renovate rebases the SECURITY PRs to touch only the main `go.mod`/`go.sum` and they go green.

**Tradeoff:** tool-modfile dep bumps become manual. Acceptable — those deps are build/lint tooling and never ship in the server binary.

Also corrects the now-stale "Renovate tracks this" comments in both modfiles.

## Verification

- `task pr-prep` (fast lane): **pass**
- `renovate.json` validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)