### PR TITLE
fix(plugin): PR #4430 review follow-ups — RegisterEmitType Unimplemented + test hardening (holomush-eykuh.8)

### DIFF
--- a/internal/plugin/goplugin/host_capability_servers_test.go
+++ b/internal/plugin/goplugin/host_capability_servers_test.go
@@ -39,6 +39,17 @@ func TestHostBrokerServerServesFocusService(t *testing.T) {
 	// (holomush-eykuh.1, Task 12): only the capability-scoped host.v1 services
 	// are registered on the broker now.
 	require.NotContains(t, info, "holomush.plugin.v1.PluginHostService")
+
+	// The 5 Lua-only host.v1 services are declared in the host/v1 protos but
+	// INTENTIONALLY NOT registered on the binary broker — they have no binary
+	// consumer, so BinaryDefaultSet omits them and LuaDefaultSet adds them
+	// (hostcap.register.go). Pin the omission so a future accidental addition to
+	// the binary set is caught here.
+	require.NotContains(t, info, "holomush.plugin.host.v1.PropertyService")
+	require.NotContains(t, info, "holomush.plugin.host.v1.SessionService")
+	require.NotContains(t, info, "holomush.plugin.host.v1.SessionAdminService")
+	require.NotContains(t, info, "holomush.plugin.host.v1.WorldQueryService")
+	require.NotContains(t, info, "holomush.plugin.host.v1.WorldMutationService")
 }
 
 // TestBinaryHostServerDeniesUndeclaredCapability proves the capability

--- a/internal/plugin/hostcap/servers.go
+++ b/internal/plugin/hostcap/servers.go
@@ -452,27 +452,19 @@ func (s *emitServer) RequestEmitToken(ctx context.Context, _ *hostv1.RequestEmit
 	return &hostv1.RequestEmitTokenResponse{Token: token}, nil
 }
 
-// RegisterEmitType promotes the Lua holomush.register_emit_type(type) host
-// function to the binary surface (INV-PLUGIN-32): the caller declares one bare
-// plugin-owned event type it intends to emit. Binary plugins currently declare
-// their emit-type set through InitResponse.RegisteredEmitTypes at Load time
-// (captured on the plugin record; see host.go RegisteredEmitTypes), which the
-// substrate validator checks against the manifest's crypto.emits. This RPC
-// exposes the same single-string registration channel both runtimes share. The
-// fail-closed nil-host guard mirrors every other host RPC. No host-side mutation
-// is performed here in this sub-spec — the binary SDK client wiring lands in a
-// later phase; serving the endpoint keeps both runtimes addressable through one
-// channel without a behavior change to the existing Load-time path.
-func (s *emitServer) RegisterEmitType(_ context.Context, req *hostv1.RegisterEmitTypeRequest) (*hostv1.RegisterEmitTypeResponse, error) {
-	if s.host == nil {
-		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
-	}
-	if req.GetEventType() == "" {
-		return nil, oops.Code("INVALID_ARGUMENT").
-			With("plugin", s.pluginName).
-			Errorf("event_type is required")
-	}
-	return &hostv1.RegisterEmitTypeResponse{}, nil
+// RegisterEmitType is the binary-surface counterpart of the Lua
+// holomush.register_emit_type(type) host function (INV-PLUGIN-32). No host-side
+// mutation is wired to this RPC: binary plugins declare their emit-type set at
+// Load time through InitResponse.RegisteredEmitTypes (captured on the plugin
+// record; see host.go RegisteredEmitTypes), and the Lua runtime registers through
+// the in-process holomush.register_emit_type hostfunc. The dedicated binary SDK
+// client wiring lands in a later phase. Until then the endpoint returns
+// codes.Unimplemented rather than a misleading silent-success, giving either
+// runtime's generated bridge a clear "not wired yet" contract. The handler is
+// runtime-neutral, so the contract is identical across binary and Lua
+// (plugin-runtime-symmetry).
+func (s *emitServer) RegisterEmitType(_ context.Context, _ *hostv1.RegisterEmitTypeRequest) (*hostv1.RegisterEmitTypeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "RegisterEmitType is not implemented") //nolint:wrapcheck // gRPC status errors pass through as-is
 }
 
 // --- evalServer (EvalService: Evaluate) -------------------------------------

--- a/internal/plugin/hostcap/servers_test.go
+++ b/internal/plugin/hostcap/servers_test.go
@@ -4,6 +4,7 @@
 package hostcap
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -11,10 +12,31 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/holomush/holomush/internal/core"
 	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
 )
+
+// TestEmitServerRegisterEmitTypeReturnsUnimplemented pins the staged-endpoint
+// contract (holomush-eykuh.8 item 3): the EmitService.RegisterEmitType RPC has no
+// host-side mutation wired to it — binary plugins declare their emit-type set at
+// Load via InitResponse.RegisteredEmitTypes, and the Lua runtime registers through
+// the in-process holomush.register_emit_type hostfunc. Rather than a misleading
+// silent-success, the RPC MUST return codes.Unimplemented so either runtime's
+// generated bridge surfaces a clear "not wired yet" contract.
+func TestEmitServerRegisterEmitTypeReturnsUnimplemented(t *testing.T) {
+	srv := NewEmitServer(NewBase(nil, "test-plugin"))
+
+	resp, err := srv.RegisterEmitType(context.Background(), &hostv1.RegisterEmitTypeRequest{
+		EventType: "alpha",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
+}
 
 // These tests exercise the proto↔domain conversion helpers that moved here with
 // the server bodies (holomush-eykuh.2). They were previously in

--- a/pkg/plugin/focus_client_test.go
+++ b/pkg/plugin/focus_client_test.go
@@ -29,7 +29,9 @@ import (
 var _ FocusClient = (*pluginHostFocusClient)(nil)
 
 // startFocusServiceTestServer starts an in-process gRPC server that registers
-// both FocusService and StreamHistoryService from the given test double.
+// FocusService, StreamHistoryService, and EmitService from the given test double.
+// EmitService is registered so callers can exercise an EventSink end-to-end over
+// the same broker conn (the focus tests simply never call it).
 // The returned *grpc.ClientConn is ready to use and cleaned up via t.Cleanup.
 func startFocusServiceTestServer(t *testing.T, srv *focusTestServer) *grpc.ClientConn {
 	t.Helper()
@@ -37,6 +39,7 @@ func startFocusServiceTestServer(t *testing.T, srv *focusTestServer) *grpc.Clien
 	server := grpc.NewServer() // nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection -- bufconn test server
 	hostv1.RegisterFocusServiceServer(server, srv)
 	hostv1.RegisterStreamHistoryServiceServer(server, srv)
+	hostv1.RegisterEmitServiceServer(server, srv)
 	go func() {
 		_ = server.Serve(listener)
 	}()
@@ -459,7 +462,9 @@ func TestQueryStreamHistoryRequestNotBeforeIsPassedThrough(t *testing.T) {
 type focusTestServer struct {
 	hostv1.UnimplementedFocusServiceServer
 	hostv1.UnimplementedStreamHistoryServiceServer
+	hostv1.UnimplementedEmitServiceServer
 	mu                sync.Mutex
+	emitReqs          []*hostv1.EmitEventRequest
 	joinReqs          []*hostv1.JoinFocusRequest
 	leaveReqs         []*hostv1.LeaveFocusRequest
 	leaveByTargetReqs []*hostv1.LeaveFocusByTargetRequest
@@ -485,6 +490,25 @@ func (s *focusTestServer) JoinFocus(_ context.Context, req *hostv1.JoinFocusRequ
 		return nil, s.joinErr
 	}
 	return &hostv1.JoinFocusResponse{}, nil
+}
+
+// EmitEvent records the request so an injected EventSink can be exercised
+// end-to-end (not just asserted non-nil).
+func (s *focusTestServer) EmitEvent(_ context.Context, req *hostv1.EmitEventRequest) (*hostv1.EmitEventResponse, error) {
+	s.mu.Lock()
+	s.emitReqs = append(s.emitReqs, &hostv1.EmitEventRequest{
+		Stream:    req.GetStream(),
+		EventType: req.GetEventType(),
+		Payload:   append([]byte(nil), req.GetPayload()...),
+	})
+	s.mu.Unlock()
+	return &hostv1.EmitEventResponse{}, nil
+}
+
+// RequestEmitToken returns a deterministic self-token so the SDK's
+// no-incoming-token fallback path can complete the EmitEvent round-trip.
+func (s *focusTestServer) RequestEmitToken(_ context.Context, _ *hostv1.RequestEmitTokenRequest) (*hostv1.RequestEmitTokenResponse, error) {
+	return &hostv1.RequestEmitTokenResponse{Token: "focus-test-self-tok"}, nil
 }
 
 func (s *focusTestServer) LeaveFocus(_ context.Context, req *hostv1.LeaveFocusRequest) (*hostv1.LeaveFocusResponse, error) {

--- a/pkg/plugin/service_test.go
+++ b/pkg/plugin/service_test.go
@@ -682,7 +682,8 @@ func (p *dualAwareProvider) SetEventSink(s EventSink)                           
 func (p *dualAwareProvider) SetFocusClient(c FocusClient)                            { p.focusClient = c }
 
 func TestPluginServerAdapterInitInjectsBothEventSinkAndFocusClient(t *testing.T) {
-	hostConn := startFocusServiceTestServer(t, &focusTestServer{})
+	srv := &focusTestServer{}
+	hostConn := startFocusServiceTestServer(t, srv)
 
 	provider := &dualAwareProvider{}
 	adapter := &pluginServerAdapter{
@@ -702,8 +703,25 @@ func TestPluginServerAdapterInitInjectsBothEventSinkAndFocusClient(t *testing.T)
 		},
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, provider.sink, "expected EventSink injection")
-	assert.NotNil(t, provider.focusClient, "expected FocusClient injection")
+	require.NotNil(t, provider.sink, "expected EventSink injection")
+	require.NotNil(t, provider.focusClient, "expected FocusClient injection")
+
+	// Exercise the injected sink end-to-end (not just non-nil): a real Emit MUST
+	// reach the host's EmitService over the same broker conn. The plain ctx has no
+	// incoming dispatch token, so the SDK takes the RequestEmitToken self-token
+	// fallback before EmitEvent — proving the full wired path, not just injection.
+	err = provider.sink.Emit(context.Background(), EmitIntent{
+		Subject: "scene:01SCENE",
+		Type:    EventType("system"),
+		Payload: `{"kind":"created"}`,
+	})
+	require.NoError(t, err)
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.emitReqs, 1, "expected the injected sink's Emit to reach the host")
+	assert.Equal(t, "scene:01SCENE", srv.emitReqs[0].GetStream())
+	assert.Equal(t, []byte(`{"kind":"created"}`), srv.emitReqs[0].GetPayload())
 }
 
 // --- Capability declaration enforcement ---

--- a/site/src/content/docs/extending/how-to/plugin-crypto-readback.md
+++ b/site/src/content/docs/extending/how-to/plugin-crypto-readback.md
@@ -154,11 +154,12 @@ Use `pluginsdk.DecryptOwnAuditRows` from `pkg/plugin`:
 ```go
 import (
     pluginsdk "github.com/holomush/holomush/pkg/plugin"
+    hostv1    "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
     pluginv1  "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
 
 // rows is []*pluginv1.AuditRow loaded from your audit table.
-// hostClient is the pluginv1.PluginHostServiceClient the SDK provides at Init.
+// hostClient is the hostv1.AuditServiceClient the SDK provides at Init.
 results, err := pluginsdk.DecryptOwnAuditRows(ctx, hostClient, rows)
 if err != nil {
     return fmt.Errorf("read-back decrypt: %w", err)


### PR DESCRIPTION
## Summary

Implements the four non-blocking suggestions from PR #4430's aggregate review gate. Closes `holomush-eykuh.8`.

| # | Change | File |
|---|--------|------|
| 1 | Exercise the injected `EventSink` **end-to-end** (was non-nil only): `focusTestServer` now also serves `EmitService` (+`RequestEmitToken`); the dual-injection test drives a real `sink.Emit` through the broker and asserts it reaches the host | `pkg/plugin/focus_client_test.go`, `pkg/plugin/service_test.go` |
| 2 | Pin the broker's intentional omission: 5 `NotContains` for the Lua-only host.v1 services (`Property`/`Session`/`SessionAdmin`/`WorldQuery`/`WorldMutation`) absent from `BinaryDefaultSet` | `internal/plugin/goplugin/host_capability_servers_test.go` |
| 3 | `emitServer.RegisterEmitType` returns `codes.Unimplemented` instead of silent-success — the honest staged contract (no host-side mutation wired; binary registers emit-types at Load via `InitResponse`, Lua via the in-process `holomush.register_emit_type` hostfunc). New test pins it | `internal/plugin/hostcap/servers.go`, `servers_test.go` |
| 4 | Doc fix: `DecryptOwnAuditRows` example client type `pluginv1.PluginHostServiceClient` → `hostv1.AuditServiceClient` (+ host/v1 import; `AuditRow`/`RowResult` stay `pluginv1` per the real signature) | `site/.../plugin-crypto-readback.md` |

### Item 3 — why `Unimplemented` is safe
No production path reaches this RPC: binary plugins use the SDK `EmitRegistry` (Load-time `InitResponse`), Lua plugins use the in-process `holomush.register_emit_type` hostfunc — only the auto-generated `emit.RegisterEmitType` bridge binding routes here, and nothing calls it. The handler is registered unconditionally for both runtimes, so the contract is identical across binary and Lua (plugin-runtime-symmetry).

## Verification

- 574 affected unit tests pass (`pkg/plugin`, `internal/plugin/{hostcap,goplugin,luabridge}`).
- `task pr-prep:full` green: integration (`eventbus_e2e`, `scenes`) + 84 E2E Playwright tests, "✓ All PR checks passed."
- `code-reviewer` agent — VERDICT: READY, zero blocking findings.
- TDD: item 3's contract test written failing-first, then implemented.

> Note: the `phase:design` label on this bead was a stale epic-wide inheritance; dropped (this is concrete implementation, not design-lifecycle work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)