### PR TITLE
docs(spec+plan+adr): Lua stub generator design, plan, and ADRs (holomush-eykuh.9)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Scope Lua stub generator to static build-time surfaces only](holomush-vhz3h-scope-lua-stub-generator-static-build-time-surfaces-only.md) | 2026-06-16 | Accepted | `holomush-vhz3h` |
+| [Source ambient stdlib annotations from a parity-tested Go decl table](holomush-nc5v1-source-ambient-stdlib-annotations-from-parity-tested-go-decl.md) | 2026-06-16 | Accepted | `holomush-nc5v1` |
 | [Atomic (big-bang) plugin-capability cutover over phased allowlist rollout](holomush-40ssh-atomic-big-bang-plugin-capability-cutover-over-phased-allowl.md) | 2026-06-14 | Accepted | `holomush-40ssh` |
 | [Resolver Grants set as the single least-privilege gate authority](holomush-vpg8l-resolver-grants-set-as-single-least-privilege-gate-authority.md) | 2026-06-14 | Accepted | `holomush-vpg8l` |
 | [o262d DAG-resolution failures stay always-fatal behind a named policy-function seam](holomush-ptf7b-o262d-dag-resolution-failures-stay-always-fatal-behind-named.md) | 2026-06-14 | Accepted | `holomush-ptf7b` |

--- a/docs/adr/holomush-nc5v1-source-ambient-stdlib-annotations-from-parity-tested-go-decl.md
+++ b/docs/adr/holomush-nc5v1-source-ambient-stdlib-annotations-from-parity-tested-go-decl.md
@@ -1,0 +1,41 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-nc5v1; do not edit manually; use `/adr update holomush-nc5v1` -->
+
+# Source ambient stdlib annotations from a parity-tested Go decl table
+
+**Date:** 2026-06-16
+**Status:** Accepted
+**Decision:** holomush-nc5v1
+**Deciders:** Sean Brandt
+
+## Context
+
+The ambient holomush.* and holo.* hostfuncs are registered imperatively via SetField calls scattered across functions.go and stdlib.go — there is no structured metadata (no proto descriptors, no reflection API) to introspect their parameter / return types. The Lua stub generator (holomush-eykuh.9) must source annotations for the ambient surface from somewhere, and that source becomes the going-forward contract for how the ambient surface is documented.
+
+## Decision
+
+The ambient decl table (internal/plugin/luabridge/gen/ambient.go) is the single source of truth for ambient annotations. Its (Module, Name) set is held exactly equal to the live runtime registrations by a CI parity test that invokes the production hostfunc.Register entrypoint on a real LState, walks the resulting holomush/holo tables, and asserts set equality.
+
+## Rationale
+
+- No structured metadata exists for the ambient surface — descriptor introspection is impossible by construction.
+- A hand-authored .lua fragment provides no drift safety net; the parity test closes the gap on the name-set dimension.
+- Invoking the production entrypoint (not a duplicated name list) means the test exercises real registration code, giving genuine anti-drift value (spec §5.2).
+- The parity test deliberately excludes RegisterSessionFuncs so the truth set is not polluted with out-of-scope capability-gated functions (holo.session.*).
+
+## Alternatives Considered
+
+- **Go decl table + live-runtime parity test (chosen):** machine-checkable name-set parity in CI; type annotations colocated with the generator in Go and reviewable alongside implementation changes.
+- **Hand-authored .lua fragment, no parity test (rejected):** no automated drift detection — a removed hostfunc lingers in the stub, a new one stays invisible until someone hand-edits.
+- **Descriptor introspection (rejected):** structurally impossible — the ambient surface has no proto descriptors to introspect.
+
+## Consequences
+
+- Positive: adding/removing an ambient hostfunc without updating the decl table fails CI; type annotations live in Go, colocated with the generator.
+- Negative: param/return TYPE accuracy is not machine-checked — only the name set is parity-tested (mitigated by a required per-function signature-verification step in the plan); the gen test suite couples to internal/plugin/hostfunc.
+- Neutral: the decl table covers four dotted modules (holomush, holomush.config, holo.fmt, holo.emit); each entry carries Module, Name, Doc, Params, Returns.

--- a/docs/adr/holomush-vhz3h-scope-lua-stub-generator-static-build-time-surfaces-only.md
+++ b/docs/adr/holomush-vhz3h-scope-lua-stub-generator-static-build-time-surfaces-only.md
@@ -1,0 +1,41 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-vhz3h; do not edit manually; use `/adr update holomush-vhz3h` -->
+
+# Scope Lua stub generator to static build-time surfaces only
+
+**Date:** 2026-06-16
+**Status:** Accepted
+**Decision:** holomush-vhz3h
+**Deciders:** Sean Brandt
+
+## Context
+
+The Lua host-call surface has two distinct populations: statically-registered host.v1 capability namespaces (visible at build time via protoregistry) and provider / plugin→plugin services that only exist at load time, per-plugin. A third population — capability-gated hostfunc families like holo.session.* and the cap_*.go surfaces — is neither descriptor-driven nor always-on ambient. The editor-stub generator (holomush-eykuh.9) must commit to a scope before its architecture is fixed.
+
+## Decision
+
+The stub generator is scoped to statically-visible surfaces only: descriptor-driven host.v1 namespaces and the always-on ambient stdlib (holomush.* / holomush.config / holo.fmt / holo.emit). Provider service stubs and capability-gated hostfunc families (holo.session.*, world_query, property) are explicitly deferred to a future load-time path.
+
+## Rationale
+
+- Provider descriptors are visible only at plugin load time, per-plugin — a static generator structurally cannot see them without a separate runtime mechanism.
+- Capability-gated hostfunc families are neither descriptor-driven nor always-on; covering them needs the same load-time path and raises the same drift risk with no parity-test anchor.
+- Static scope enables the committed-artifact model (pkg/plugin/luastubs/holomush.lua in VCS) with deterministic regenerate-and-diff drift checking in pr-prep.
+- YAGNI: no concrete consumer need for provider or capability-gated stubs exists today.
+
+## Alternatives Considered
+
+- **Static build-time generator only (chosen):** reuses the existing luabridge/gen descriptor walk; no runtime wiring; mechanically drift-checkable. Cannot cover provider or capability-gated surfaces.
+- **Load-time / per-plugin generation (rejected):** could cover provider descriptors, but requires a fundamentally different architecture (runtime hook, per-plugin dynamic output, no single committed artifact) — heavy infrastructure for a dev-aid.
+- **Single hand-authored .lua file, no generator (rejected):** zero tooling, but drifts immediately as host.v1 evolves with no automated detection.
+
+## Consequences
+
+- Positive: generator is a simple build-time go:generate with no runtime wiring; committed artifact enables a stable LuaLS workspace.library path; drift fully detectable by pr-prep.
+- Negative: authors writing against provider services or capability-gated hostfuncs get no autocomplete there; a future load-time path will be a materially different architecture.
+- Neutral: the descriptor-driven session host.v1 namespace IS covered (it is a statically-registered host.v1 service); only the hand-written holo.session.* hostfuncs are excluded.

--- a/docs/superpowers/plans/2026-06-16-lua-stub-generator.md
+++ b/docs/superpowers/plans/2026-06-16-lua-stub-generator.md
@@ -1,0 +1,1020 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Lua Binding Stub Generator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit a committed lua-language-server (LuaLS) `---@meta` definition file describing the Lua host-call surface (descriptor-driven `host.v1` capability namespaces + the ambient `holomush.*`/`holo.*` stdlib) purely for editor autocomplete/hover/go-to-def.
+
+**Architecture:** Extend the existing descriptor-walking generator at `internal/plugin/luabridge/gen` so one `go run ./gen` emits both the runtime `bindings_gen.go` (unchanged) and a new `pkg/plugin/luastubs/holomush.lua` stub. The descriptor half reuses `collectServices`; the ambient half is driven by a structured Go decl table whose names are held equal to the live registrations by a parity test. A `pr-prep` regenerate-and-diff guards both outputs against drift.
+
+**Tech Stack:** Go, `google.golang.org/protobuf/reflect/protoreflect` + `protoregistry`, `text/template`, `gopher-lua` (test-side enumeration), LuaLS annotations, go-task.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-lua-stub-generator-design.md`
+
+---
+
+## File structure
+
+| Path | Responsibility | Create/Modify |
+| --- | --- | --- |
+| `internal/plugin/luabridge/gen/luatype.go` | proto `FieldDescriptor` → LuaLS type string (scalars, repeated, map, message ref, optional) | Create |
+| `internal/plugin/luabridge/gen/luatype_test.go` | table-driven type-mapper tests | Create |
+| `internal/plugin/luabridge/gen/ambient.go` | `ambientFn` type + the ambient decl table (single source of truth for `holomush.*`/`holomush.config`/`holo.fmt`/`holo.emit`) | Create |
+| `internal/plugin/luabridge/gen/ambient_parity_test.go` | builds the live runtime surface via `hostfunc.Register` and asserts it equals the decl table | Create |
+| `internal/plugin/luabridge/gen/luastub.go` | collect request/response messages + render the `---@meta` stub via `text/template` | Create |
+| `internal/plugin/luabridge/gen/luastub_test.go` | structural sanity test of generated output | Create |
+| `internal/plugin/luabridge/gen/main.go` | wire the stub emitter into `main()` after `bindings_gen.go` | Modify |
+| `internal/plugin/luabridge/doc.go` | document the second generated artifact | Modify |
+| `pkg/plugin/luastubs/holomush.lua` | the committed generated stub | Create (generated) |
+| `Taskfile.yaml` | `generate:luabridge` `generates:` + the two drift-check blocks cover the `.lua` output | Modify |
+| `site/src/content/docs/extending/how-to/lua-editor-setup.md` | document the `Lua.workspace.library` setting | Create |
+
+---
+
+## Phase 1: Generator building blocks
+
+### Task 1: Proto → LuaLS type mapper
+
+**Files:**
+
+- Create: `internal/plugin/luabridge/gen/luatype.go`
+- Test: `internal/plugin/luabridge/gen/luatype_test.go`
+
+The generator is `package main`. This task adds a pure function mapping a single
+`protoreflect.FieldDescriptor` to a LuaLS type string, per spec §3.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/plugin/luabridge/gen/luatype_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// fieldByPath looks up a field descriptor on a host.v1 message by message +
+// field name, using the registered descriptors.
+func fieldByPath(t *testing.T, msgFullName, field string) protoreflect.FieldDescriptor {
+	t.Helper()
+	d, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(msgFullName))
+	if err != nil {
+		t.Fatalf("descriptor %s: %v", msgFullName, err)
+	}
+	md, ok := d.(protoreflect.MessageDescriptor)
+	if !ok {
+		t.Fatalf("%s is not a message", msgFullName)
+	}
+	fd := md.Fields().ByName(protoreflect.Name(field))
+	if fd == nil {
+		t.Fatalf("field %s not found on %s", field, msgFullName)
+	}
+	return fd
+}
+
+func TestLuaTypeMapsScalarStringField(t *testing.T) {
+	// EmitEventRequest.stream is a proto string.
+	fd := fieldByPath(t, "holomush.plugin.host.v1.EmitEventRequest", "stream")
+	assert.Equal(t, "string", luaType(fd))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestLuaTypeMapsScalarStringField ./internal/plugin/luabridge/gen/`
+Expected: FAIL — `undefined: luaType`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/plugin/luabridge/gen/luatype.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// luaType maps a proto field to a LuaLS type string (spec §3). Repeated and map
+// fields are detected before scalar kind. Message fields render as the namespaced
+// class name from luaClassName.
+func luaType(fd protoreflect.FieldDescriptor) string {
+	// Map must be checked before IsList: a proto map is a repeated synthetic
+	// message, so IsMap() is the discriminator.
+	if fd.IsMap() {
+		k := scalarLuaType(fd.MapKey())
+		v := luaTypeNoCollection(fd.MapValue())
+		return fmt.Sprintf("table<%s, %s>", k, v)
+	}
+	if fd.IsList() {
+		return luaTypeNoCollection(fd) + "[]"
+	}
+	return luaTypeNoCollection(fd)
+}
+
+// luaTypeNoCollection maps the element type, ignoring list/map wrapping.
+func luaTypeNoCollection(fd protoreflect.FieldDescriptor) string {
+	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind {
+		return luaClassName(fd.Message())
+	}
+	return scalarLuaType(fd)
+}
+
+// scalarLuaType maps a proto scalar kind to a LuaLS primitive.
+func scalarLuaType(fd protoreflect.FieldDescriptor) string {
+	switch fd.Kind() {
+	case protoreflect.StringKind, protoreflect.BytesKind:
+		return "string"
+	case protoreflect.BoolKind:
+		return "boolean"
+	case protoreflect.FloatKind, protoreflect.DoubleKind:
+		return "number"
+	case protoreflect.EnumKind:
+		return "integer"
+	default:
+		// All int/uint/sint/fixed kinds.
+		return "integer"
+	}
+}
+
+// luaClassName returns the namespaced LuaLS @class name for a message descriptor,
+// e.g. holomush.host.emit is the namespace; the class is suffixed with the message
+// name. The token segment is derived from the message's parent package + message
+// name; collisions are avoided by including the full message name.
+func luaClassName(md protoreflect.MessageDescriptor) string {
+	return "holomush.msg." + string(md.Name())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestLuaTypeMapsScalarStringField ./internal/plugin/luabridge/gen/`
+Expected: PASS.
+
+- [ ] **Step 5: Add the remaining mapping cases**
+
+Append to `luatype_test.go` (one subtest per spec §3 row), then run the whole test:
+
+```go
+func TestLuaTypeMapsRepeatedAndMessageAndOptional(t *testing.T) {
+	// QueryStreamHistoryResponse.events is repeated Event (message) → Event class[].
+	events := fieldByPath(t, "holomush.plugin.host.v1.QueryStreamHistoryResponse", "events")
+	assert.Equal(t, "holomush.msg.Event[]", luaType(events))
+
+	// EmitEventRequest.event_type is string.
+	et := fieldByPath(t, "holomush.plugin.host.v1.EmitEventRequest", "event_type")
+	assert.Equal(t, "string", luaType(et))
+}
+```
+
+> Verify the exact field/message names against the real protos before asserting:
+> `rg -n 'message (EmitEventRequest|QueryStreamHistoryResponse|Event)\b' api/proto/holomush/plugin/host/v1/*.proto`
+> and adjust the message/field names in the test to match. The assertion VALUES
+> (the LuaLS type strings) are fixed by §3; only the proto field references adapt.
+
+Run: `task test -- -run TestLuaType ./internal/plugin/luabridge/gen/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+### Task 2: Ambient decl table + parity test
+
+**Files:**
+
+- Create: `internal/plugin/luabridge/gen/ambient.go`
+- Test: `internal/plugin/luabridge/gen/ambient_parity_test.go`
+
+Per spec §4.2 + §5.2: a structured decl table is the single source of truth for the
+always-on ambient surface; a parity test holds it equal to the live registrations
+built by the production entrypoint `hostfunc.Register`.
+
+- [ ] **Step 1: Write the decl table (the data the parity test will validate)**
+
+Create `internal/plugin/luabridge/gen/ambient.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+// ambientParam is one parameter of an ambient stdlib function.
+type ambientParam struct {
+	Name string
+	Type string // LuaLS type string
+}
+
+// ambientFn declares one ambient host function for the stub. Module is the dotted
+// path of the table the function lives on (spec §4.2). The (Module, Name) set MUST
+// equal the live registration set — enforced by TestAmbientDeclTableMatchesRegistrations.
+type ambientFn struct {
+	Module  string // "holomush" | "holomush.config" | "holo.fmt" | "holo.emit"
+	Name    string
+	Doc     string
+	Params  []ambientParam
+	Returns []string // LuaLS return type strings
+}
+
+// ambientDecls is the single source of truth for ambient-surface annotations.
+// The NAME set is verified against runtime registration (§5.2); the param/return
+// types are hand-authored (no machine source exists). Authoritative ambient
+// boundary: internal/plugin/hostfunc/functions.go:268-287 + RegisteredFunctionsForAudit().
+// Signatures below are GROUNDED against the actual Lua arg-parsing in each
+// implementation (see the source map in Step 1b). Do NOT alter a signature without
+// re-reading the corresponding function — the parity test (Step 2) checks NAME
+// equality only, so a wrong arity/order here ships green and misleads authors.
+var ambientDecls = []ambientFn{
+	// functions.go logFn:416-417 → (level, message).
+	{Module: "holomush", Name: "log", Doc: "Write a structured log line.",
+		Params: []ambientParam{{"level", "string"}, {"message", "string"}}},
+	{Module: "holomush", Name: "new_request_id", Doc: "Return a fresh request-scoped ULID string.",
+		Returns: []string{"string"}},
+	// commands.go listCommandsFn:55-59 → (character_id) [ignored for authz]; returns (table, err?).
+	{Module: "holomush", Name: "list_commands", Doc: "List commands visible to the subject. character_id is accepted for call-signature compatibility but IGNORED for authorization.",
+		Params: []ambientParam{{"character_id", "string"}}, Returns: []string{"table", "string?"}},
+	// commands.go getCommandHelpFn:145-150 → (command_name, character_id) [character_id ignored]; returns (table, err?).
+	{Module: "holomush", Name: "get_command_help", Doc: "Return help info for a command. character_id is accepted for compatibility but IGNORED.",
+		Params: []ambientParam{{"command_name", "string"}, {"character_id", "string"}}, Returns: []string{"table", "string?"}},
+	// stdlib_streams.go addSessionStreamFn:42-44 → (session_id, stream).
+	{Module: "holomush", Name: "add_session_stream", Doc: "Subscribe a session to a stream.",
+		Params: []ambientParam{{"session_id", "string"}, {"stream", "string"}}},
+	// stdlib_streams.go removeSessionStreamFn:70-72 → (session_id, stream).
+	{Module: "holomush", Name: "remove_session_stream", Doc: "Unsubscribe a session from a stream.",
+		Params: []ambientParam{{"session_id", "string"}, {"stream", "string"}}},
+	// stdlib_focus.go queryStreamHistoryFn:342-345 → single table arg {stream, count?, not_before_ms?, cursor?}; returns (table, err?).
+	{Module: "holomush", Name: "query_stream_history", Doc: "Read recent events from a stream. Pass a table: {stream=string, count?=integer, not_before_ms?=integer, cursor?=string}.",
+		Params: []ambientParam{{"args", "table"}}, Returns: []string{"table", "string?"}},
+	// stdlib_audit.go decryptOwnAuditRowsImpl:60 → (rows: array of row tables); returns (table, err?).
+	{Module: "holomush", Name: "decrypt_own_audit_rows", Doc: "Decrypt audit rows the plugin owns. rows is an array of row tables.",
+		Params: []ambientParam{{"rows", "table"}}, Returns: []string{"table", "string?"}},
+	// functions.go:326-330 → (event_type); returns true.
+	{Module: "holomush", Name: "register_emit_type", Doc: "Declare a plugin-owned event type (Load-time; INV-PLUGIN-32).",
+		Params: []ambientParam{{"event_type", "string"}}, Returns: []string{"boolean"}},
+
+	// config.go: every accessor is (key); require_* error if absent. Non-require return optional.
+	{Module: "holomush.config", Name: "string", Params: []ambientParam{{"key", "string"}}, Returns: []string{"string?"}, Doc: "Read a string config value."},
+	{Module: "holomush.config", Name: "require_string", Params: []ambientParam{{"key", "string"}}, Returns: []string{"string"}, Doc: "Read a required string config value (errors if absent)."},
+	{Module: "holomush.config", Name: "int", Params: []ambientParam{{"key", "string"}}, Returns: []string{"integer?"}, Doc: "Read an integer config value."},
+	{Module: "holomush.config", Name: "require_int", Params: []ambientParam{{"key", "string"}}, Returns: []string{"integer"}, Doc: "Read a required integer config value."},
+	{Module: "holomush.config", Name: "bool", Params: []ambientParam{{"key", "string"}}, Returns: []string{"boolean?"}, Doc: "Read a boolean config value."},
+	{Module: "holomush.config", Name: "require_bool", Params: []ambientParam{{"key", "string"}}, Returns: []string{"boolean"}, Doc: "Read a required boolean config value."},
+	{Module: "holomush.config", Name: "duration", Params: []ambientParam{{"key", "string"}}, Returns: []string{"integer?"}, Doc: "Read a duration config value (nanoseconds)."},
+	{Module: "holomush.config", Name: "require_duration", Params: []ambientParam{{"key", "string"}}, Returns: []string{"integer"}, Doc: "Read a required duration config value (nanoseconds)."},
+
+	// stdlib.go fmt*: all (text) → string, EXCEPT color (color, text) and list/pairs/table (table arg), separator ().
+	{Module: "holo.fmt", Name: "bold", Params: []ambientParam{{"text", "string"}}, Returns: []string{"string"}, Doc: "Wrap text in bold styling."},
+	{Module: "holo.fmt", Name: "italic", Params: []ambientParam{{"text", "string"}}, Returns: []string{"string"}, Doc: "Wrap text in italic styling."},
+	{Module: "holo.fmt", Name: "dim", Params: []ambientParam{{"text", "string"}}, Returns: []string{"string"}, Doc: "Wrap text in dim styling."},
+	{Module: "holo.fmt", Name: "underline", Params: []ambientParam{{"text", "string"}}, Returns: []string{"string"}, Doc: "Wrap text in underline styling."},
+	// stdlib.go fmtColor:84-85 → (color, text) — NOTE the order.
+	{Module: "holo.fmt", Name: "color", Params: []ambientParam{{"color", "string"}, {"text", "string"}}, Returns: []string{"string"}, Doc: "Colorize text. Argument order is (color, text)."},
+	{Module: "holo.fmt", Name: "list", Params: []ambientParam{{"items", "table"}}, Returns: []string{"string"}, Doc: "Format a list."},
+	{Module: "holo.fmt", Name: "pairs", Params: []ambientParam{{"kv", "table"}}, Returns: []string{"string"}, Doc: "Format key/value pairs."},
+	{Module: "holo.fmt", Name: "table", Params: []ambientParam{{"rows", "table"}}, Returns: []string{"string"}, Doc: "Format a table."},
+	{Module: "holo.fmt", Name: "separator", Returns: []string{"string"}, Doc: "Return a horizontal separator."},
+	{Module: "holo.fmt", Name: "header", Params: []ambientParam{{"text", "string"}}, Returns: []string{"string"}, Doc: "Format a header."},
+	{Module: "holo.fmt", Name: "parse", Params: []ambientParam{{"markup", "string"}}, Returns: []string{"string"}, Doc: "Parse holo markup into rendered text."},
+
+	// stdlib.go emitLocation:287-289 / emitCharacter:309-312 / emitGlobal:332-334 → (id..., event_type, payload table).
+	{Module: "holo.emit", Name: "location", Params: []ambientParam{{"location_id", "string"}, {"event_type", "string"}, {"payload", "table"}}, Doc: "Emit an event to a location."},
+	{Module: "holo.emit", Name: "character", Params: []ambientParam{{"character_id", "string"}, {"event_type", "string"}, {"payload", "table"}}, Doc: "Emit an event to a character."},
+	{Module: "holo.emit", Name: "global", Params: []ambientParam{{"event_type", "string"}, {"payload", "table"}}, Doc: "Emit a global event."},
+	{Module: "holo.emit", Name: "flush", Doc: "Flush buffered emit calls."},
+}
+```
+
+- [ ] **Step 1b: Verify every signature against its implementation (REQUIRED — not optional)**
+
+The parity test (Step 2) checks the function NAME set only; it cannot catch a wrong
+arity, param order, or return shape. Those errors ship green and actively mislead
+plugin authors — which inverts the entire value of an editor stub. So before
+proceeding, open each implementation and confirm the decl-table `Params`/`Returns`
+match the Lua arg-parsing exactly. Source map:
+
+| Decl entry | Implementation | Confirm |
+| --- | --- | --- |
+| `holomush.log` | `functions.go` `logFn` (~:414-417) | `CheckString(1)`=level, `CheckString(2)`=message |
+| `holomush.list_commands` | `commands.go` `listCommandsFn` (~:55-59) | `CheckString(1)`=character_id (ignored); returns (table, err) |
+| `holomush.get_command_help` | `commands.go` `getCommandHelpFn` (~:145-150) | `CheckString(1)`=command_name, `CheckString(2)`=character_id |
+| `holomush.add_session_stream` / `remove_session_stream` | `stdlib_streams.go` (~:42-44, :70-72) | `(session_id, stream)` |
+| `holomush.query_stream_history` | `stdlib_focus.go` `queryStreamHistoryFn` (~:342-345) | one `CheckTable(1)` with `stream`/`count`/`not_before_ms`/`cursor` |
+| `holomush.decrypt_own_audit_rows` | `stdlib_audit.go` `decryptOwnAuditRowsImpl` (~:60) | one rows-array table |
+| `holomush.register_emit_type` | `functions.go` (~:326-330) | `(event_type)` → true |
+| `holomush.config.*` | `config.go` (~:30-152) | every accessor is `(key)`; require_* error if absent |
+| `holo.fmt.*` | `stdlib.go` `fmt*` (~:51-166) | all `(text)` EXCEPT `color`=`(color, text)` (:84-85), `list`/`pairs`/`table`=`(table)`, `separator`=`()` |
+| `holo.emit.*` | `stdlib.go` `emit*` (~:286-334) | `location`/`character`=`(id, event_type, payload-table)`, `global`=`(event_type, payload-table)`, `flush`=`()` |
+
+Any drift between the decl table and the implementation MUST be corrected in the decl
+table now. (Line numbers are approximate — confirm by reading.)
+
+- [ ] **Step 2: Write the failing parity test**
+
+Create `internal/plugin/luabridge/gen/ambient_parity_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"sort"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+)
+
+// liveAmbientNames builds the production ambient surface in a real LState (via the
+// SAME entrypoint production uses, hostfunc.Register — which installs holomush.* and
+// calls RegisterStdlib for holo.fmt/holo.emit) and returns the set of
+// "module.name" keys for every function-valued field. It MUST NOT call
+// RegisterSessionFuncs (holo.session is capability-gated, out of scope — spec §1).
+func liveAmbientNames(t *testing.T) map[string]bool {
+	t.Helper()
+	L := lua.NewState()
+	defer L.Close()
+
+	// nil KVStore is fine: Register installs no kv_* functions (kv is a retired
+	// capability, host-brokered now — spec §2 authoritative boundary).
+	f := hostfunc.New(nil)
+	f.Register(L, "stub-gen")
+
+	got := map[string]bool{}
+	for _, global := range []string{"holomush", "holo"} {
+		tbl, ok := L.GetGlobal(global).(*lua.LTable)
+		require.True(t, ok, "global %q must be a table", global)
+		collectFnNames(global, tbl, got)
+	}
+	return got
+}
+
+// collectFnNames recursively records module.name for every *LFunction field; it
+// descends into subtables (e.g. holomush.config, holo.fmt) building the dotted path.
+func collectFnNames(prefix string, tbl *lua.LTable, out map[string]bool) {
+	tbl.ForEach(func(k, v lua.LValue) {
+		name, ok := k.(lua.LString)
+		if !ok {
+			return
+		}
+		switch vv := v.(type) {
+		case *lua.LFunction:
+			out[prefix+"."+string(name)] = true
+		case *lua.LTable:
+			collectFnNames(prefix+"."+string(name), vv, out)
+		}
+	})
+}
+
+func declNames() map[string]bool {
+	out := map[string]bool{}
+	for _, d := range ambientDecls {
+		out[d.Module+"."+d.Name] = true
+	}
+	return out
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestAmbientDeclTableMatchesRegistrations is the §5.2 drift guard: the decl
+// table's (Module, Name) set MUST equal the live ambient registration set. A
+// registered ambient fn missing from the table, or a table entry with no live
+// registration, fails here.
+func TestAmbientDeclTableMatchesRegistrations(t *testing.T) {
+	live := liveAmbientNames(t)
+	decl := declNames()
+	assert.Equal(t, keys(live), keys(decl),
+		"ambient decl table must exactly match live holomush.*/holo.* function registrations")
+}
+```
+
+- [ ] **Step 3: Run the parity test**
+
+Run: `task test -- -run TestAmbientDeclTableMatchesRegistrations ./internal/plugin/luabridge/gen/`
+Expected: PASS if the decl table (Step 1) is complete and correct. If it FAILS, the
+assertion diff names the exact missing/extra `module.name` entries — reconcile the
+decl table against the live set (add missing, remove extra) until green. This is the
+intended TDD loop: the live runtime is the source of truth for the name set.
+
+- [ ] **Step 4: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+### Task 3: Message-class collection for the descriptor surface
+
+**Files:**
+
+- Modify: `internal/plugin/luabridge/gen/main.go` (extend `methodData` with `ResponseGoType`)
+- Create: `internal/plugin/luabridge/gen/luastub.go` (message collection; emission added in Task 4)
+- Test: `internal/plugin/luabridge/gen/luastub_test.go`
+
+The existing `methodData` carries only `RequestGoType`. The stub needs the response
+type and the full set of messages (transitively) reachable as a request/response, to
+emit one `---@class` per message.
+
+- [ ] **Step 1: Extend methodData with the response type**
+
+In `internal/plugin/luabridge/gen/main.go`, modify the `methodData` struct (currently
+`internal/plugin/luabridge/gen/main.go:104-107`) and `collectMethods` (`:175-197`):
+
+```go
+// methodData is the template input for one unary RPC.
+type methodData struct {
+	GoName        string // e.g. Get
+	RequestGoType string // e.g. GetRequest
+	ResponseGoType string // e.g. GetResponse
+}
+```
+
+In `collectMethods`, set the response type alongside the request:
+
+```go
+		out = append(out, methodData{
+			GoName:         string(md.Name()),
+			RequestGoType:  reqGoType,
+			ResponseGoType: goTypeName(md.Output().Name()),
+		})
+```
+
+- [ ] **Step 2: Write the failing message-collection test**
+
+Create `internal/plugin/luabridge/gen/luastub_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectStubMessagesIncludesRequestAndResponse(t *testing.T) {
+	services, err := collectServices()
+	require.NoError(t, err)
+
+	msgs, err := collectStubMessages(services)
+	require.NoError(t, err)
+
+	names := map[string]bool{}
+	for _, m := range msgs {
+		names[m.ClassName] = true
+	}
+	// EmitService.EmitEvent has request EmitEventRequest + response EmitEventResponse.
+	assert.True(t, names["holomush.msg.EmitEventRequest"], "request message class present")
+	assert.True(t, names["holomush.msg.EmitEventResponse"], "response message class present")
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `task test -- -run TestCollectStubMessages ./internal/plugin/luabridge/gen/`
+Expected: FAIL — `undefined: collectStubMessages`.
+
+- [ ] **Step 4: Implement collectStubMessages**
+
+Create `internal/plugin/luabridge/gen/luastub.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"sort"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// stubField is one field of a message class in the stub.
+type stubField struct {
+	Name     string // proto field name (snake_case, as Lua sees it)
+	Type     string // LuaLS type string
+	Optional bool   // emitted as "name?"
+	Doc      string // leading proto comment, if any
+}
+
+// stubMessage is one generated ---@class for a proto message.
+type stubMessage struct {
+	ClassName string
+	Fields    []stubField
+}
+
+// collectStubMessages walks every request/response message of the collected
+// services, transitively following message-typed fields, and returns one
+// stubMessage per distinct message. Oneof variants are flattened to optional
+// fields (spec §3).
+func collectStubMessages(services []serviceData) ([]stubMessage, error) {
+	seen := map[string]bool{}
+	var out []stubMessage
+
+	var visit func(md protoreflect.MessageDescriptor)
+	visit = func(md protoreflect.MessageDescriptor) {
+		cn := luaClassName(md)
+		if seen[cn] {
+			return
+		}
+		seen[cn] = true
+
+		var fields []stubField
+		fs := md.Fields()
+		for i := 0; i < fs.Len(); i++ {
+			fd := fs.Get(i)
+			optional := fd.HasOptionalKeyword() || fd.ContainingOneof() != nil
+			fields = append(fields, stubField{
+				Name:     string(fd.Name()),
+				Type:     luaType(fd),
+				Optional: optional,
+			})
+			if (fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind) && !fd.IsMap() {
+				visit(fd.Message())
+			}
+			if fd.IsMap() {
+				mv := fd.MapValue()
+				if mv.Kind() == protoreflect.MessageKind {
+					visit(mv.Message())
+				}
+			}
+		}
+		out = append(out, stubMessage{ClassName: cn, Fields: fields})
+	}
+
+	for _, sd := range services {
+		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(sd.ServiceName))
+		if err != nil {
+			return nil, err
+		}
+		svc := desc.(protoreflect.ServiceDescriptor)
+		methods := svc.Methods()
+		for i := 0; i < methods.Len(); i++ {
+			m := methods.Get(i)
+			if m.IsStreamingClient() || m.IsStreamingServer() {
+				continue
+			}
+			visit(m.Input())
+			visit(m.Output())
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ClassName < out[j].ClassName })
+	return out, nil
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `task test -- -run TestCollectStubMessages ./internal/plugin/luabridge/gen/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+## Phase 2: Emission, wiring, and the committed artifact
+
+### Task 4: Render the `---@meta` stub
+
+**Files:**
+
+- Modify: `internal/plugin/luabridge/gen/luastub.go` (add `renderLuaStub`)
+- Test: `internal/plugin/luabridge/gen/luastub_test.go` (extend)
+
+- [ ] **Step 1: Write the failing render test**
+
+Append to `internal/plugin/luabridge/gen/luastub_test.go`:
+
+```go
+import "strings" // add to the import block
+
+func TestRenderLuaStubProducesMetaAndNamespaces(t *testing.T) {
+	services, err := collectServices()
+	require.NoError(t, err)
+	msgs, err := collectStubMessages(services)
+	require.NoError(t, err)
+
+	out, err := renderLuaStub(services, msgs, ambientDecls)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(out, "---@meta"), "stub MUST begin with ---@meta")
+	assert.Contains(t, out, "---@class holomush.host.emit")
+	assert.Contains(t, out, "function emit.EmitEvent(req)")
+	assert.Contains(t, out, "---@class holomush.msg.EmitEventRequest")
+	assert.Contains(t, out, "---@class holomush.config")
+	assert.Contains(t, out, "function holo.fmt.bold(text)")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestRenderLuaStub ./internal/plugin/luabridge/gen/`
+Expected: FAIL — `undefined: renderLuaStub`.
+
+- [ ] **Step 3: Implement renderLuaStub**
+
+Append to `internal/plugin/luabridge/gen/luastub.go` (add `bytes`, `fmt`, `strings`,
+`text/template` to its import block):
+
+```go
+// luaStubTmpl renders the full ---@meta definition file. Capability namespaces are
+// emitted as bare globals (spec §3 naming note); messages as @class; ambient globals
+// grouped by Module.
+const luaStubTmpl = `---@meta holomush
+-- Code generated by internal/plugin/luabridge/gen; DO NOT EDIT.
+-- Regenerate with: go generate ./internal/plugin/luabridge/...
+-- Editor setup: point lua-language-server's Lua.workspace.library at pkg/plugin/luastubs/
+
+{{range .Messages}}
+---@class {{.ClassName}}
+{{- range .Fields}}
+---@field {{.Name}}{{if .Optional}}?{{end}} {{.Type}}{{if .Doc}} {{.Doc}}{{end}}
+{{- end}}
+{{end}}
+{{range .Services}}
+---@class holomush.host.{{.Token}}
+{{.Token}} = {}
+{{- range .Methods}}
+---@param req {{$.ClassPrefix}}{{.RequestGoType}}
+---@return {{$.ClassPrefix}}{{.ResponseGoType}}
+function {{.Token}}.{{.GoName}}(req) end
+{{- end}}
+{{end}}
+{{range .AmbientModules}}
+---@class {{.Module}}
+{{.Module}} = {}
+{{- range .Fns}}
+---{{.Doc}}
+{{- range .Params}}
+---@param {{.Name}} {{.Type}}
+{{- end}}
+{{- range .Returns}}
+---@return {{.}}
+{{- end}}
+function {{.Parent}}.{{.Name}}({{paramList .Params}}) end
+{{- end}}
+{{end}}`
+
+// ambientModule groups ambientFns by their Module for templating.
+type ambientModule struct {
+	Module string
+	Fns    []ambientFnTmpl
+}
+
+type ambientFnTmpl struct {
+	ambientFn
+	Parent string // the table identifier the function is set on (== Module)
+}
+
+// methodTmpl carries the Token onto each method so the template can name the global.
+type serviceTmpl struct {
+	serviceData
+}
+
+func renderLuaStub(services []serviceData, messages []stubMessage, ambient []ambientFn) (string, error) {
+	// Group ambient fns by module, preserving the decl-table order.
+	order := []string{}
+	byMod := map[string][]ambientFnTmpl{}
+	for _, d := range ambient {
+		if _, ok := byMod[d.Module]; !ok {
+			order = append(order, d.Module)
+		}
+		byMod[d.Module] = append(byMod[d.Module], ambientFnTmpl{ambientFn: d, Parent: d.Module})
+	}
+	mods := make([]ambientModule, 0, len(order))
+	for _, m := range order {
+		mods = append(mods, ambientModule{Module: m, Fns: byMod[m]})
+	}
+
+	data := struct {
+		ClassPrefix    string
+		Messages       []stubMessage
+		Services       []serviceData
+		AmbientModules []ambientModule
+	}{
+		ClassPrefix:    "holomush.msg.",
+		Messages:       messages,
+		Services:       services,
+		AmbientModules: mods,
+	}
+
+	tmpl := template.Must(template.New("luastub").Funcs(template.FuncMap{
+		"paramList": func(ps []ambientParam) string {
+			names := make([]string, 0, len(ps))
+			for _, p := range ps {
+				names = append(names, p.Name)
+			}
+			return strings.Join(names, ", ")
+		},
+	}).Parse(luaStubTmpl))
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("rendering lua stub: %w", err)
+	}
+	return buf.String(), nil
+}
+```
+
+> Note: the template references `.Token` on methods via the parent service range
+> (`{{.Token}}.{{.GoName}}`), which works because Go templates re-scope `.` inside
+> `range .Services` to each `serviceData` (which has `Token`); the inner
+> `range .Methods` re-scopes again, so the method block uses `{{$.ClassPrefix}}` for
+> the prefix and the service's `.Token` is captured by emitting the function line
+> inside the service scope. If the template engine complains about `.Token` inside
+> the method range, hoist the token via a `with` or restructure to a precomputed
+> `[]serviceStub{Token, []methodStub{Global, Name, ReqClass, RespClass}}` — adjust
+> until `TestRenderLuaStub` passes.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestRenderLuaStub ./internal/plugin/luabridge/gen/`
+Expected: PASS. Iterate on the template until the structural assertions hold.
+
+- [ ] **Step 5: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+### Task 5: Wire the emitter into `main()` and produce the committed artifact
+
+**Files:**
+
+- Modify: `internal/plugin/luabridge/gen/main.go` (`main()`, around `:109-132`)
+- Modify: `internal/plugin/luabridge/doc.go`
+- Create (generated): `pkg/plugin/luastubs/holomush.lua`
+
+- [ ] **Step 1: Emit the stub from main()**
+
+In `internal/plugin/luabridge/gen/main.go`, after the existing block that writes
+`bindings_gen.go` (ends `internal/plugin/luabridge/gen/main.go:131` with the
+`fmt.Printf("wrote %s ...")`), add:
+
+```go
+	// Second output: the LuaLS editor stub (holomush-eykuh.9). Off the runtime
+	// path — purely for editor autocomplete/hover.
+	messages, err := collectStubMessages(services)
+	if err != nil {
+		log.Fatalf("collecting stub messages: %v", err)
+	}
+	stub, err := renderLuaStub(services, messages, ambientDecls)
+	if err != nil {
+		log.Fatalf("rendering lua stub: %v", err)
+	}
+	stubPath := filepath.Join(root, "pkg", "plugin", "luastubs", "holomush.lua")
+	if mkErr := os.MkdirAll(filepath.Dir(stubPath), 0o755); mkErr != nil {
+		log.Fatalf("creating luastubs dir: %v", mkErr)
+	}
+	if wErr := os.WriteFile(stubPath, []byte(stub), 0o600); wErr != nil {
+		log.Fatalf("writing %s: %v", stubPath, wErr)
+	}
+	fmt.Printf("wrote %s\n", stubPath)
+```
+
+- [ ] **Step 2: Update the package doc**
+
+In `internal/plugin/luabridge/doc.go`, extend the generated-artifacts description to
+mention the second output (`pkg/plugin/luastubs/holomush.lua`, the LuaLS editor stub).
+Keep it factual; one or two sentences.
+
+- [ ] **Step 3: Generate the committed artifact**
+
+Run: `go generate ./internal/plugin/luabridge/...`
+Expected: prints `wrote .../bindings_gen.go (N services)` and `wrote .../pkg/plugin/luastubs/holomush.lua`. Confirm the file exists:
+
+Run: `test -f pkg/plugin/luastubs/holomush.lua && head -20 pkg/plugin/luastubs/holomush.lua`
+Expected: file exists; begins with `---@meta holomush` and the generated header.
+
+- [ ] **Step 4: Verify nothing else regressed**
+
+Run: `task test -- ./internal/plugin/luabridge/...`
+Expected: PASS (bindings_gen.go output is unchanged; only the new file added).
+
+- [ ] **Step 5: Commit** (include the generated `pkg/plugin/luastubs/holomush.lua`)
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+### Task 6: Structural sanity test for the generated stub
+
+**Files:**
+
+- Test: `internal/plugin/luabridge/gen/luastub_test.go` (extend)
+
+Per spec §5.4: assert the rendered stub is structurally valid — begins with
+`---@meta`, every `@class` referenced by a `@field`/`@param`/`@return` is declared,
+no field has an empty type.
+
+- [ ] **Step 1: Write the structural test**
+
+Append to `internal/plugin/luabridge/gen/luastub_test.go`:
+
+```go
+import "regexp" // add to the import block
+
+func TestRenderedStubIsStructurallyValid(t *testing.T) {
+	services, err := collectServices()
+	require.NoError(t, err)
+	msgs, err := collectStubMessages(services)
+	require.NoError(t, err)
+	out, err := renderLuaStub(services, msgs, ambientDecls)
+	require.NoError(t, err)
+
+	require.True(t, strings.HasPrefix(out, "---@meta"))
+
+	// Collect declared classes.
+	declRe := regexp.MustCompile(`(?m)^---@class (\S+)`)
+	declared := map[string]bool{}
+	for _, m := range declRe.FindAllStringSubmatch(out, -1) {
+		declared[m[1]] = true
+	}
+
+	// Every referenced holomush.msg.* class MUST be declared.
+	refRe := regexp.MustCompile(`holomush\.msg\.\w+`)
+	for _, ref := range refRe.FindAllString(out, -1) {
+		assert.Truef(t, declared[ref], "referenced class %q is not declared", ref)
+	}
+
+	// No @field / @param with an empty type (would be "---@field name" with no type token).
+	assert.NotRegexp(t, regexp.MustCompile(`(?m)^---@(field|param)\s+\S+\s*$`), out,
+		"every @field/@param MUST carry a type")
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `task test -- -run TestRenderedStubIsStructurallyValid ./internal/plugin/luabridge/gen/`
+Expected: PASS. If a referenced class is undeclared, `collectStubMessages` missed a
+transitive message — extend the walk (Task 3) until green.
+
+- [ ] **Step 3: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+## Phase 3: Drift guard and documentation
+
+### Task 7: Extend the pr-prep drift gate to cover the stub
+
+**Files:**
+
+- Modify: `Taskfile.yaml` (`generate:luabridge` `generates:` list `:382-395`; both
+  drift-check blocks `:837-846` and `:968-975`)
+
+Per spec §5.1: `go run ./gen` leaving EITHER `bindings_gen.go` OR
+`pkg/plugin/luastubs/holomush.lua` modified MUST fail the check.
+
+- [ ] **Step 1: Add the stub to the generate task's outputs**
+
+In `Taskfile.yaml`, the `generate:luabridge` task's `generates:` block (currently
+lists `internal/plugin/luabridge/bindings_gen.go` at `:395`) — add the stub path:
+
+```yaml
+    generates:
+      - internal/plugin/luabridge/bindings_gen.go
+      - pkg/plugin/luastubs/holomush.lua
+```
+
+- [ ] **Step 2: Extend both drift-check blocks**
+
+There are two copies of the "Verifying Lua host-cap bindings are current" block
+(`Taskfile.yaml:837-846` in the fast lane and `:968-975` in `pr-prep:run`). Each
+computes a sha of `BINDINGS=internal/plugin/luabridge/bindings_gen.go` before/after
+`task generate:luabridge` and fails on diff. In **each** block, also guard the stub —
+change the shell body to hash both files. Concretely, replace the single-file check
+with:
+
+```bash
+          BINDINGS=internal/plugin/luabridge/bindings_gen.go
+          STUB=pkg/plugin/luastubs/holomush.lua
+          BEFORE=$(sha256sum "$BINDINGS" "$STUB" | sha256sum)
+          go generate ./internal/plugin/luabridge/...
+          AFTER=$(sha256sum "$BINDINGS" "$STUB" | sha256sum)
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "ERROR: Lua bindings or editor stub out of sync. Run 'task generate:luabridge' and commit."
+            exit 1
+          fi
+```
+
+> Read the exact current shell of each block first (`sed -n '837,846p' Taskfile.yaml`
+> and `sed -n '968,975p' Taskfile.yaml`) and preserve its invocation style (it may
+> call `task generate:luabridge` rather than `go generate`; keep whichever it uses).
+> Apply the same two-file hashing to both copies.
+
+- [ ] **Step 3: Verify the gate passes clean**
+
+Run: `task generate:luabridge && git diff --quiet pkg/plugin/luastubs/holomush.lua internal/plugin/luabridge/bindings_gen.go && echo CLEAN`
+Expected: `CLEAN` (regeneration is idempotent on a committed-up-to-date tree).
+
+- [ ] **Step 4: Verify the gate CATCHES drift**
+
+Run: `printf '\n-- drift\n' >> pkg/plugin/luastubs/holomush.lua && task generate:luabridge && git diff --quiet pkg/plugin/luastubs/holomush.lua && echo CLEAN || echo "DRIFT CAUGHT"`
+Expected: `DRIFT CAUGHT` (regeneration overwrites the manual edit; the diff is dirty until committed). Then restore: `git checkout pkg/plugin/luastubs/holomush.lua` (or re-run generate).
+
+- [ ] **Step 5: Run the bats lane to confirm Taskfile YAML is valid**
+
+Run: `task lint:yaml`
+Expected: PASS (no YAML syntax error introduced).
+
+- [ ] **Step 6: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+### Task 8: Contributor documentation
+
+**Files:**
+
+- Create: `site/src/content/docs/extending/how-to/lua-editor-setup.md`
+
+- [ ] **Step 1: Write the doc**
+
+Create the doc in `site/src/content/docs/extending/how-to/` (the `extending/` dir is
+organized into `explanation/`/`how-to/`/`reference/`/`tutorials/` subdirs — an editor-
+setup page is a how-to). Match an existing `how-to/` sibling's **file extension**
+(`.md` vs `.mdx`) and Starlight frontmatter shape (`title`/`description` keys); adjust
+the filename extension accordingly. Content MUST cover:
+
+- What the stub is (a generated LuaLS `---@meta` definition file for the Lua host-call
+  surface; editor-only, not loaded at runtime).
+- The setting: point lua-language-server at the stub directory, e.g.
+
+  ```jsonc
+  // .luarc.json (or editor settings)
+  { "workspace.library": ["pkg/plugin/luastubs"] }
+  ```
+
+- That it is generated (`task generate:luabridge`) and committed; authors do not edit
+  it by hand.
+- Scope note: covers `host.v1` capability namespaces (`emit`, `kv`, `focus`, …) and
+  the ambient `holomush.*` / `holo.*` stdlib; does NOT cover provider (plugin→plugin)
+  services or the capability-gated `holo.session.*` (out of scope per the design).
+
+- [ ] **Step 2: Verify docs lint**
+
+Run: `task lint:markdown`
+Expected: PASS.
+
+- [ ] **Step 3: Verify the docs IA / symmetry check**
+
+Run: `task lint:docs-symmetry`
+Expected: PASS. If the new page must be registered in a nav/sidebar config, add it
+where sibling `extending/` pages are listed and re-run.
+
+- [ ] **Step 4: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+
+---
+
+## Verification (whole-feature)
+
+- [ ] `task test -- ./internal/plugin/luabridge/...` — all generator unit + parity + structural tests pass.
+- [ ] `task generate:luabridge` then `git diff --quiet` on both generated files — idempotent (no drift).
+- [ ] `task lint` — YAML, markdown, docs-symmetry green.
+- [ ] `task pr-prep` — fast lane green (includes the extended bindings/stub drift block).
+- [ ] Manual spot-check: open `pkg/plugin/luastubs/holomush.lua`; confirm it begins with `---@meta`, declares `emit`/`kv`/… namespaces, the `holomush.msg.*` classes, and the `holomush`/`holomush.config`/`holo.fmt`/`holo.emit` ambient tables; confirm `holo.session.*` and `kv_*` are ABSENT.
+<!-- adr-capture: sha256=03e645456223de5c; session=cli; ts=2026-06-16T15:09:50Z; adrs=holomush-vhz3h,holomush-nc5v1 -->

--- a/docs/superpowers/specs/2026-06-16-lua-stub-generator-design.md
+++ b/docs/superpowers/specs/2026-06-16-lua-stub-generator-design.md
@@ -1,0 +1,290 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Lua Binding Stub Generator (editor/LSP dev-aid) — Design
+
+- **Bead:** holomush-eykuh.9
+- **Epic:** holomush-eykuh (Plugin capability & dependency architecture)
+- **Status:** design
+- **Date:** 2026-06-16
+- **Follow-on to:** sub-spec 3 / holomush-eykuh.2 (descriptor-driven Lua host-cap bindings)
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are
+to be interpreted as described in RFC 2119 and RFC 8174.
+
+## 1. Problem & goal
+
+Plugin authors writing Lua against the host call surface get no editor support:
+the `namespace.Method{…}` bridge bindings and the ambient `holomush.*` stdlib are
+invisible to lua-language-server (LuaLS), so there is no autocomplete, hover, or
+go-to-definition for host calls.
+
+**Goal:** emit a committed LuaLS **definition file** (`---@meta`) describing the
+Lua host-call surface, purely as an editor/LSP discoverability aid. The generated
+artifact is **off the runtime path** — it MUST NOT be loaded by any plugin runtime
+and MUST NOT change plugin behavior. It is a pure developer-experience aid.
+
+### Surfaces covered
+
+1. **`host.v1` capability namespaces** — the descriptor-driven `namespace.Method{…}`
+   bridge surface. Each capability is injected as a **bare Lua global** named by its
+   capability token (`emit`, `focus`, `kv`, `eval`, `settings`, `stream_history`,
+   `stream_subscription`, `audit`, `command_registry`) via the generated
+   `bindings_gen.go` (`L.SetGlobal("<token>", tbl)`). These are generated from the
+   **statically registered** `host.v1` FileDescriptors — the same walk that produces
+   `bindings_gen.go`.
+2. **Ambient stdlib** — the always-available in-process host functions, injected as
+   **two distinct Lua globals**. These are NOT descriptor-driven, so their
+   annotations come from a structured Go declaration table (§4.2):
+   - **`holomush.*`** (assembled by `hostfunc.Register()`, `functions.go`): `log`,
+     `new_request_id`, `list_commands`, `get_command_help`, `add_session_stream`,
+     `remove_session_stream`, `query_stream_history`, `decrypt_own_audit_rows`,
+     `register_emit_type`, plus the **`holomush.config`** subtable (typed accessors:
+     `string`/`int`/`bool`/`duration` and their `require_*` variants, from
+     `registerConfigTable()`).
+   - **`holo.*`** (assembled by `hostfunc.RegisterStdlib()` in `stdlib.go`, which is
+     itself invoked from the production `hostfunc.Register()`): `holo.fmt.*` (`bold`,
+     `italic`, `dim`, `underline`, `color`, `list`, `pairs`, `table`, `separator`,
+     `header`, `parse`) and `holo.emit.*` (`location`, `character`, `global`,
+     `flush`). The `holo.emit.*` functions are always *registered* as fields (they
+     raise at call-time only if the emitter is unwired), so they belong in the stub.
+
+   > **`kv_*` is NOT ambient.** The legacy `holomush.kv_get`/`kv_set`/`kv_delete`
+   > hostfuncs were retired in the atomic capability cutover (ADR `holomush-05f3v`)
+   > and are now only wired in tests. KV access is the `kv` capability namespace
+   > (surface 1), not an ambient function. The decl table MUST NOT include them.
+   >
+   > **`holo.session.*` is NOT ambient.** It is added only by
+   > `hostfunc.RegisterSessionFuncs()`, which has **no production caller** (test-only)
+   > and requires a `session.Access` — i.e. it is capability-gated, not always-on. It
+   > is out of scope (see "Out of scope" below), NOT in the ambient decl table.
+
+   The decl table is the **single source of truth** for the ambient annotations; the
+   set of declared names is held equal to the actually-registered names by the
+   parity test (§5.2). The authoritative registration sites are
+   `internal/plugin/hostfunc/functions.go` (`holomush.*` + `holomush.config`; it also
+   calls `RegisterStdlib`) and `stdlib.go` (`holo.fmt`/`holo.emit`).
+
+### Out of scope (YAGNI)
+
+- **Provider (plugin→plugin) service stubs.** Provider descriptors exist only at
+  plugin **load time**, per-plugin; a static build-time generator cannot see them.
+  Deferred until a concrete need exists; would require a separate load-time path.
+- **Capability-gated hand-written hostfunc families** — e.g. `holo.session.*`
+  (`RegisterSessionFuncs`, capability-gated, no production always-on call) and the
+  `cap_*.go` Lua surfaces (`world_query`, `property`, …). These are neither the
+  descriptor-driven `host.v1` bridge (surface 1) nor always-on ambient (surface 2);
+  they are hand-written, capability-gated functions. Covering them is a separate
+  follow-on (their type metadata is also imperative, with the same drift concerns).
+  Note the **descriptor-driven** `session` host.v1 namespace (the `session` bare
+  global from `bindings_gen.go`) IS still covered by surface 1 — only the
+  hand-written `holo.session.*` hostfuncs are excluded.
+- **LuaLS configuration scaffolding** beyond documenting the `Lua.workspace.library`
+  setting authors point at the stub directory.
+- **Any runtime, loader, or binding behavior change.** This change adds a generator
+  output and a doc note; it touches no runtime code path.
+
+## 2. Grounding
+
+- **Existing generator (prior art):** `internal/plugin/luabridge/gen/main.go` walks
+  the registered `host.v1` FileDescriptors via `protoregistry.GlobalFiles`, keys
+  services by **capability token**, collects unary methods, and emits
+  `bindings_gen.go` via `text/template`. The stub generator reuses this walk.
+- **Ambient stdlib registration:** the ambient functions are registered
+  imperatively (`L.SetField(tbl, "<name>", L.NewFunction(...))`). The production
+  entrypoint is `hostfunc.Register()` (`functions.go`), which builds the `holomush.*`
+  global (plus the `holomush.config` subtable via `registerConfigTable()`) **and**
+  calls `hostfunc.RegisterStdlib()` (`stdlib.go`), which builds the `holo.*` global
+  (`holo.fmt` + `holo.emit`). `RegisterSessionFuncs()` (`holo.session`) is **not**
+  called from this production path (test-only; capability-gated) and is out of scope.
+  There is **no** structured param/return type metadata to introspect — hence the
+  decl-table source (§4.2).
+- **Authoritative ambient-surface boundary (read this before classifying):** the
+  doc comment at `internal/plugin/hostfunc/functions.go:268-287` states that, as of
+  the atomic capability cutover (ADR `holomush-05f3v`), the **ten host capabilities**
+  — `kv`, `world.query`, `world.mutation`, `property`, `session`, `session.admin`,
+  `focus`, `eval`, `settings`, `emit` — are **no longer injected as ambient
+  functions**; they flow exclusively through the host-brokered `RegisterHostCaps`
+  path. What remains ambient is logging, request-id, the `holo.*` stdlib (`fmt`/
+  `emit`), `register_emit_type`, `holomush.config`, and the command-registry / stream
+  / audit read-back surfaces. The exported `Functions.RegisteredFunctionsForAudit()`
+  (same file, ~line 396) is a **structured enumeration** of exactly this ambient
+  `holomush.*` set and is the canonical anchor. Consequence: `kv_*` and the
+  `session` family (incl. `holo.session.*`) are **NOT ambient** — do not add them to
+  the decl table regardless of the existence of `kvGetFn`/`RegisterSessionFuncs`
+  symbols (those are wired only via `export_test.go` / capability paths, never the
+  production `Register()` body at lines 288-335).
+- **Output format (LuaLS):** per the lua-language-server wiki
+  (`https://luals.github.io/wiki/annotations`, `/definition-files`): `---@meta`
+  marks a definitions-only file; `---@class Name` + `Name = {}` declares a
+  namespace; `---@field name type doc`; `---@param`/`---@return` document
+  functions; `---@alias` declares type aliases. Optional via `name?`, unions via
+  `A|B`, arrays via `T[]`, maps via `table<K,V>`.
+
+## 3. Output format
+
+A single committed LuaLS definition file. Each capability namespace becomes a
+`---@class`; each unary RPC becomes a typed function; each proto message referenced
+as a request/response becomes its own `---@class` with one `---@field` per field.
+
+```lua
+---@meta holomush
+
+---@class holomush.host.emit.EmitEventRequest
+---@field stream string
+---@field event_type string
+---@field payload string
+
+---@class holomush.host.emit.EmitEventResponse
+
+---@class holomush.host.emit
+local emit = {}
+
+---Emit an event from the plugin.
+---@param req holomush.host.emit.EmitEventRequest
+---@return holomush.host.emit.EmitEventResponse
+function emit.EmitEvent(req) end
+```
+
+> **Naming note:** capability namespaces are accessed at runtime as **bare Lua
+> globals** (`emit.EmitEvent(...)`, `kv.Get(...)`) — the `emit` global is injected by
+> `bindings_gen.go` via `L.SetGlobal("emit", …)`. The `holomush.host.<token>.*`
+> class-name prefix above is **only** a LuaLS class-naming convention to avoid
+> collisions in the `@class` namespace; it is not how the table is reached in Lua.
+> The generated `local <token> = {}` table MUST be exported so LuaLS resolves the
+> bare global (e.g. annotate it as the global, not a file-local). Ambient globals
+> `holomush` and `holo` are likewise declared as their bare global names.
+
+### Proto → Lua type mapping (normative)
+
+| Proto | Lua annotation |
+| --- | --- |
+| `string`, `bytes` | `string` |
+| `bool` | `boolean` |
+| `int32/int64/uint*/sint*/fixed*` | `integer` |
+| `float`, `double` | `number` |
+| `enum` | `integer` (MAY emit an `---@alias` of the enum value names in a later iteration; not required for v1) |
+| message `M` | a generated `---@class` for `M` |
+| `repeated T` | `T[]` |
+| `map<K,V>` | `table<K, V>` |
+| proto3 `optional` field | `name?` (optional field) |
+| `oneof { a; b; c }` | each variant emitted as a **mutually-exclusive optional** `---@field` (`a?`, `b?`, `c?`), with a comment naming the oneof group. (e.g. `CreateObjectRequest.placement` → `location_id?`/`character_id?`/`container_id?`.) A stricter union type is NOT required for v1. |
+| well-known types (`google.protobuf.Timestamp`/`Duration`/etc.) | mapped to a generated `---@class` like any other message (their fields are emitted). If none appear in the covered `host.v1` protos, no special handling is needed; the generator MUST NOT crash on encountering one. |
+
+- The generator MUST emit a `---@class` for every message reachable as a request or
+  response of a covered RPC (transitively, for nested message fields).
+- Class names MUST be namespaced to avoid collisions (e.g.
+  `holomush.host.<token>.<MessageName>`).
+- The generator SHOULD carry the proto leading doc-comment (if present in the
+  descriptor) onto the corresponding function/field as the annotation description.
+
+## 4. Components
+
+### 4.1 Generator extension — `internal/plugin/luabridge/gen`
+
+`gen/main.go` is extended so that, after emitting `bindings_gen.go`, it runs a
+second emitter over (a) the already-collected `host.v1` services and (b) the
+ambient decl table (§4.2), writing the `.lua` stub. The descriptor walk
+(`collectServices`/`collectMethods`) is **reused**; the new code is a `text/template`
+plus a proto→Lua type-mapping function. The two outputs share one `go:generate`
+invocation (`go run ./gen`).
+
+### 4.2 Ambient decl table — `internal/plugin/luabridge/gen/ambient.go`
+
+A Go slice declaring the ambient stdlib surface, the single source of truth for its
+annotations. Because the ambient surface spans nested submodules across two globals
+(`holomush`, `holomush.config`, `holo.fmt`, `holo.emit`), each entry
+carries its **dotted module path**:
+
+```go
+type ambientFn struct {
+    Module  string         // "holomush" | "holomush.config" | "holo.fmt" | "holo.emit"
+    Name    string         // "register_emit_type"
+    Doc     string         // leading description
+    Params  []ambientParam // {Name, Type}  (Type is a LuaLS type string)
+    Returns []string       // LuaLS return type strings
+}
+```
+
+The decl table MUST cover the always-on ambient surface: `holomush.*` +
+`holomush.config.*` (from `functions.go` / `registerConfigTable()`) and
+`holo.fmt.*` / `holo.emit.*` (from `stdlib.go`, invoked by `Register()`). It MUST
+NOT include `holo.session.*` (capability-gated, out of scope). The set of
+`(Module, Name)` pairs MUST equal the set actually registered by the production
+entrypoint at runtime (enforced by §5.2). Adding or removing an ambient hostfunc
+without updating this table MUST fail CI.
+
+### 4.3 Output home
+
+The generated stub MUST be committed at a stable in-repo path:
+`pkg/plugin/luastubs/holomush.lua`. **This directory is new** — it does not exist
+today and is created by this change (along with the generated file). A single
+`---@meta` file holds all surfaces (capability namespaces + both ambient globals).
+Plugin authors point lua-language-server's `Lua.workspace.library` at
+`pkg/plugin/luastubs/`. A short contributor doc note (under
+`site/src/content/docs/extending/`) MUST document the setting. The generated file
+MUST carry a "generated; do not edit" header.
+
+## 5. Verification
+
+### 5.1 Drift check (regenerate-and-diff) — pr-prep
+
+The existing generated-artifact verification in `pr-prep:run` (which already
+regenerates `bindings_gen.go` and fails on diff) MUST be extended so that
+`go run ./gen` leaving **either** `bindings_gen.go` **or**
+`pkg/plugin/luastubs/holomush.lua` modified fails the check. This guarantees the
+committed stub never drifts from the descriptors + decl table.
+
+### 5.2 Ambient decl-table drift test
+
+There is **no** exported API that returns the registered ambient names, and
+registration is spread across many imperative `SetField` calls. The parity test
+therefore MUST derive the truth set **dynamically from a live runtime**, not from a
+hand-kept Go list:
+
+1. Construct a real `gopher-lua` `LState`.
+2. Build the ambient globals by invoking the **production entrypoint**
+   `hostfunc.Register(...)` — which installs `holomush` + `holomush.config` and
+   internally calls `RegisterStdlib` (→ `holo.fmt` + `holo.emit`). The test MUST
+   invoke exactly the entrypoint(s) production uses, and MUST NOT call
+   `RegisterSessionFuncs` (it is not in the production ambient path; calling it would
+   pollute the truth set with the out-of-scope `holo.session.*`). Pass test doubles /
+   zero values for `Register`'s dependencies: the set of `SetField`'d field **names**
+   does not depend on the backing implementations, only on the registration code
+   being exercised.
+3. Recursively walk the resulting `holomush` and `holo` `LTable`s, collecting every
+   field whose value is an `*LFunction`, keyed by `(dotted-module-path, name)`.
+4. Assert that set is **exactly equal** to the `(Module, Name)` set in the decl
+   table — a registered function missing from the table, or a table entry with no
+   live registration, MUST fail.
+
+If an assembly entrypoint cannot be invoked in a unit test without heavy wiring,
+that is itself a finding to resolve during planning (e.g. extract a thin
+name-only registration shim) — the test MUST exercise real registration code, not a
+duplicated name list, or it provides no anti-drift value.
+
+### 5.3 Type-mapper unit test
+
+A table-driven Go test MUST cover the proto→Lua type mapping (§3): scalars,
+`repeated`, `map`, message references, and proto3 `optional`.
+
+### 5.4 Generator output sanity
+
+A test SHOULD assert the generated stub parses as a valid LuaLS `---@meta` file at a
+structural level (begins with `---@meta`, every referenced `@class` is declared).
+A full LuaLS-runs-clean assertion is NOT required (no LuaLS binary in CI).
+
+## 6. Risks & non-goals
+
+- **Drift is the main risk** for the ambient surface; §5.2 is the mitigation. The
+  descriptor-driven half cannot drift (regenerated from the same source as
+  `bindings_gen.go`).
+- **No new invariant** is introduced: this is a dev-aid artifact, not a system
+  guarantee. (Per `.claude/rules/invariants.md`, a generated editor-tooling stub is
+  not a registry invariant; the drift checks are PR-gate acceptance criteria, not
+  `INV-*` entries.)
+- **Not a runtime contract:** the stub is advisory for editors only. A plugin that
+  ignores it behaves identically; a stale stub is a dev-ex bug, never a correctness
+  bug.


### PR DESCRIPTION
## Summary

Design spec, 8-task TDD implementation plan, and 2 ADRs for **`holomush-eykuh.9`** — a build-time lua-language-server (LuaLS) `---@meta` editor stub for the Lua host-call surface. **Docs only**; no code. Lands canonical context on `main` ahead of implementation.

The generator (when built) covers:
- **descriptor-driven `host.v1` namespaces** (reusing the `bindings_gen.go` descriptor walk), and
- the **always-on ambient `holomush.*` / `holo.*` stdlib** (from a parity-tested Go decl table).

It is **off the runtime path** and drift-guarded by `pr-prep` regenerate-and-diff.

## Contents
- `docs/superpowers/specs/2026-06-16-lua-stub-generator-design.md` — design (3 design-review rounds; the ambient-surface boundary is grounded against `functions.go` + `RegisteredFunctionsForAudit()`)
- `docs/superpowers/plans/2026-06-16-lua-stub-generator.md` — 8 TDD tasks across 3 phases (2 plan-review rounds; ambient signatures grounded against source)
- `docs/adr/holomush-vhz3h-*.md` — **ADR:** scope the generator to static build-time surfaces only (defer provider/load-time + capability-gated `holo.session` stubs)
- `docs/adr/holomush-nc5v1-*.md` — **ADR:** source ambient annotations from a parity-tested Go decl table
- `docs/adr/README.md` — index updated

## Tracking
Materialized in bd as epic `holomush-eykuh.9` + 8 child tasks (`eykuh.9.1…9.8`) with a dependency DAG (roots: `9.1` type mapper, `9.2` ambient decl+parity). Implementation is a follow-up.

## Verification
`task pr-prep` — `status=pass` (fast lane; SPDX headers applied, markdown/license/docs-symmetry green). `adr-doctor` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)