### PR TITLE
fix(luabridge): namespace colliding stub @class names by proto package (holomush-t4tye)

### DIFF
--- a/internal/plugin/luabridge/gen/luastub.go
+++ b/internal/plugin/luabridge/gen/luastub.go
@@ -34,40 +34,19 @@ type stubMessage struct {
 // stubMessage per distinct message. Oneof variants are flattened to optional
 // fields (spec §3).
 func collectStubMessages(services []serviceData) ([]stubMessage, error) {
-	seen := map[string]bool{}
-	var out []stubMessage
-
-	var visit func(md protoreflect.MessageDescriptor)
-	visit = func(md protoreflect.MessageDescriptor) {
-		cn := luaClassName(md)
-		if seen[cn] {
-			return
-		}
-		seen[cn] = true
-
-		var fields []stubField
-		fs := md.Fields()
-		for i := 0; i < fs.Len(); i++ {
-			fd := fs.Get(i)
-			optional := fd.HasOptionalKeyword() || fd.ContainingOneof() != nil
-			fields = append(fields, stubField{
-				Name:     string(fd.Name()),
-				Type:     luaType(fd),
-				Optional: optional,
-			})
-			if (fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind) && !fd.IsMap() {
-				visit(fd.Message())
-			}
-			if fd.IsMap() {
-				mv := fd.MapValue()
-				if mv.Kind() == protoreflect.MessageKind {
-					visit(mv.Message())
-				}
-			}
-		}
-		out = append(out, stubMessage{ClassName: cn, Fields: fields})
+	descs, err := reachableMessages(services)
+	if err != nil {
+		return nil, err
 	}
+	return buildStubMessages(descs), nil
+}
 
+// reachableMessages returns every message reachable as a request, response, or
+// transitively-nested message field of the collected services' unary methods,
+// deduplicated by proto full name (see walkMessages). It gathers each unary
+// method's request/response message as a walk root.
+func reachableMessages(services []serviceData) ([]protoreflect.MessageDescriptor, error) {
+	var roots []protoreflect.MessageDescriptor
 	for _, sd := range services {
 		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(sd.ServiceName))
 		if err != nil {
@@ -83,13 +62,119 @@ func collectStubMessages(services []serviceData) ([]stubMessage, error) {
 			if m.IsStreamingClient() || m.IsStreamingServer() {
 				continue
 			}
-			visit(m.Input())
-			visit(m.Output())
+			roots = append(roots, m.Input(), m.Output())
+		}
+	}
+	return walkMessages(roots), nil
+}
+
+// walkMessages returns roots plus every transitively message-typed field,
+// deduplicated by proto full name. Keying dedup on the full name (not the short
+// @class name) is the core of holomush-t4tye: two distinct messages that share a
+// short name are both retained rather than the second being silently dropped.
+func walkMessages(roots []protoreflect.MessageDescriptor) []protoreflect.MessageDescriptor {
+	seen := map[protoreflect.FullName]bool{}
+	var out []protoreflect.MessageDescriptor
+
+	var visit func(md protoreflect.MessageDescriptor)
+	visit = func(md protoreflect.MessageDescriptor) {
+		if seen[md.FullName()] {
+			return
+		}
+		seen[md.FullName()] = true
+		out = append(out, md)
+
+		fs := md.Fields()
+		for i := 0; i < fs.Len(); i++ {
+			fd := fs.Get(i)
+			if (fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind) && !fd.IsMap() {
+				visit(fd.Message())
+			}
+			if fd.IsMap() {
+				mv := fd.MapValue()
+				if mv.Kind() == protoreflect.MessageKind {
+					visit(mv.Message())
+				}
+			}
 		}
 	}
 
+	for _, r := range roots {
+		visit(r)
+	}
+	return out
+}
+
+// buildStubMessages renders one stubMessage per reachable descriptor, naming
+// classes via a collision-aware classNamer so message-field references and
+// @class declarations agree even across same-short-name messages. Output is
+// sorted by class name for deterministic generation.
+//
+// Scope: only message-field references (rendered via luaType) are namer-aware.
+// Service-method @param/@return references are rendered separately by the
+// template from the hardcoded "holomush.msg." ClassPrefix + the short Go type
+// name, so a disambiguated collider reachable as an RPC request/response would
+// produce a dangling reference there. That path is latent today (no collider is
+// RPC-reachable) and guarded by TestRenderedStubIsStructurallyValid; the fuller
+// fix (threading the namer into the service-method render path) is tracked in
+// holomush-lfy04.
+func buildStubMessages(descs []protoreflect.MessageDescriptor) []stubMessage {
+	namer := newClassNamer(descs)
+	out := make([]stubMessage, 0, len(descs))
+	for _, md := range descs {
+		var fields []stubField
+		fs := md.Fields()
+		for i := 0; i < fs.Len(); i++ {
+			fd := fs.Get(i)
+			optional := fd.HasOptionalKeyword() || fd.ContainingOneof() != nil
+			fields = append(fields, stubField{
+				Name:     string(fd.Name()),
+				Type:     luaType(fd, namer.className),
+				Optional: optional,
+			})
+		}
+		out = append(out, stubMessage{ClassName: namer.className(md), Fields: fields})
+	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ClassName < out[j].ClassName })
-	return out, nil
+	return out
+}
+
+// classNamer assigns each reachable message a LuaLS @class name keyed on its
+// proto full name. A message whose short name is unique across the reachable
+// set keeps the canonical holomush.msg.<ShortName> convention; only messages
+// whose short name collides with another reachable message are disambiguated by
+// full name (holomush-t4tye). Resolving by full name guarantees a reference to
+// either collider names that specific class, never the wrong one.
+type classNamer struct {
+	byFull map[protoreflect.FullName]string
+}
+
+// newClassNamer computes the class-name assignment for the reachable set,
+// detecting short-name collisions in a first pass before naming.
+func newClassNamer(descs []protoreflect.MessageDescriptor) *classNamer {
+	shortCount := map[string]int{}
+	for _, md := range descs {
+		shortCount[string(md.Name())]++
+	}
+	byFull := make(map[protoreflect.FullName]string, len(descs))
+	for _, md := range descs {
+		if shortCount[string(md.Name())] > 1 {
+			byFull[md.FullName()] = disambiguatedClassName(md)
+		} else {
+			byFull[md.FullName()] = luaClassName(md)
+		}
+	}
+	return &classNamer{byFull: byFull}
+}
+
+// className returns the assigned class name for md, falling back to the
+// canonical short form for any descriptor not in the precomputed set (defensive;
+// every field-referenced message is reachable and thus precomputed).
+func (c *classNamer) className(md protoreflect.MessageDescriptor) string {
+	if n, ok := c.byFull[md.FullName()]; ok {
+		return n
+	}
+	return luaClassName(md)
 }
 
 // luaStubTmpl renders the full ---@meta definition file. Capability namespaces whose

--- a/internal/plugin/luabridge/gen/luastub_test.go
+++ b/internal/plugin/luabridge/gen/luastub_test.go
@@ -10,7 +10,102 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	// Imported for its side effect: registers the holomush.plugin.v1
+	// FileDescriptors so this package's tests can resolve the cross-package
+	// DecryptOwnAuditRows* collision pair (holomush-t4tye).
+	_ "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
+
+// mustMessageDesc resolves a registered message descriptor by full name.
+func mustMessageDesc(t *testing.T, fullName string) protoreflect.MessageDescriptor {
+	t.Helper()
+	d, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(fullName))
+	require.NoErrorf(t, err, "descriptor %s", fullName)
+	md, ok := d.(protoreflect.MessageDescriptor)
+	require.Truef(t, ok, "%s is not a message", fullName)
+	return md
+}
+
+// TestBuildStubMessagesDisambiguatesCrossPackageShortNameCollision proves the
+// holomush-t4tye fix: when two distinct full-name messages that share a short
+// name are both reachable, neither is silently dropped (FullName-keyed dedup)
+// and each gets a distinct, package-disambiguated @class name. Non-colliding
+// messages keep the canonical holomush.msg.<ShortName> convention.
+func TestBuildStubMessagesDisambiguatesCrossPackageShortNameCollision(t *testing.T) {
+	// DecryptOwnAuditRowsRequest exists in BOTH packages; short names collide.
+	hostReq := mustMessageDesc(t, "holomush.plugin.host.v1.DecryptOwnAuditRowsRequest")
+	pluginReq := mustMessageDesc(t, "holomush.plugin.v1.DecryptOwnAuditRowsRequest")
+	// EmitEventRequest has a unique short name across the reachable set.
+	emit := mustMessageDesc(t, "holomush.plugin.host.v1.EmitEventRequest")
+
+	// AuditRow is the message-typed field of both colliders (rows = repeated
+	// holomush.plugin.v1.AuditRow); include it so field-type resolution is
+	// exercised, not just @class naming.
+	auditRow := mustMessageDesc(t, "holomush.plugin.v1.AuditRow")
+
+	msgs := buildStubMessages([]protoreflect.MessageDescriptor{hostReq, pluginReq, emit, auditRow})
+
+	byClass := map[string]*stubMessage{}
+	for i := range msgs {
+		byClass[msgs[i].ClassName] = &msgs[i]
+	}
+
+	// No silent drop: all four messages survive as distinct classes.
+	require.Len(t, msgs, 4, "every distinct full-name message MUST be emitted")
+	assert.Contains(t, byClass, "holomush.msg.plugin.host.v1.DecryptOwnAuditRowsRequest",
+		"host.v1 collider class present")
+	assert.Contains(t, byClass, "holomush.msg.plugin.v1.DecryptOwnAuditRowsRequest",
+		"plugin.v1 collider class present")
+	// Non-colliding messages keep the canonical short form.
+	assert.Contains(t, byClass, "holomush.msg.EmitEventRequest",
+		"non-colliding message keeps holomush.msg.<ShortName>")
+
+	// Field-type resolution within a collider flows through the namer: the
+	// host.v1 collider's `rows` field references AuditRow (unique short name),
+	// so it resolves to the canonical class — proving the field path is
+	// namer-routed, not hardcoded.
+	host := byClass["holomush.msg.plugin.host.v1.DecryptOwnAuditRowsRequest"]
+	require.NotNil(t, host)
+	require.Len(t, host.Fields, 1)
+	assert.Equal(t, "holomush.msg.AuditRow[]", host.Fields[0].Type,
+		"message-typed field within a collider resolves via the classNamer")
+}
+
+// TestWalkMessagesDedupsByFullNameNotShortName pins the core holomush-t4tye
+// fix at the walk layer: when two distinct full-name messages that share a
+// short name are both walk roots, both survive. Keying dedup on the short
+// @class name (the original bug) would silently drop the second root.
+func TestWalkMessagesDedupsByFullNameNotShortName(t *testing.T) {
+	hostReq := mustMessageDesc(t, "holomush.plugin.host.v1.DecryptOwnAuditRowsRequest")
+	pluginReq := mustMessageDesc(t, "holomush.plugin.v1.DecryptOwnAuditRowsRequest")
+
+	got := walkMessages([]protoreflect.MessageDescriptor{hostReq, pluginReq})
+
+	fulls := map[protoreflect.FullName]bool{}
+	for _, md := range got {
+		fulls[md.FullName()] = true
+	}
+	assert.True(t, fulls["holomush.plugin.host.v1.DecryptOwnAuditRowsRequest"],
+		"host.v1 root retained")
+	assert.True(t, fulls["holomush.plugin.v1.DecryptOwnAuditRowsRequest"],
+		"plugin.v1 root retained (short-name dedup would have dropped it)")
+}
+
+// TestClassNamerFallsBackToCanonicalForUnknownDescriptor covers className's
+// defensive fallback: a descriptor not in the precomputed set resolves to the
+// canonical holomush.msg.<ShortName> form rather than panicking.
+func TestClassNamerFallsBackToCanonicalForUnknownDescriptor(t *testing.T) {
+	emit := mustMessageDesc(t, "holomush.plugin.host.v1.EmitEventRequest")
+	unknown := mustMessageDesc(t, "holomush.plugin.host.v1.DecryptOwnAuditRowsRequest")
+
+	namer := newClassNamer([]protoreflect.MessageDescriptor{emit})
+
+	assert.Equal(t, "holomush.msg.DecryptOwnAuditRowsRequest", namer.className(unknown),
+		"unknown descriptor falls back to canonical short form")
+}
 
 func TestCollectStubMessagesIncludesRequestAndResponse(t *testing.T) {
 	services, err := collectServices()
@@ -73,8 +168,10 @@ func TestRenderedStubIsStructurallyValid(t *testing.T) {
 		declared[m[1]] = true
 	}
 
-	// Every referenced holomush.msg.* class MUST be declared.
-	refRe := regexp.MustCompile(`holomush\.msg\.\w+`)
+	// Every referenced holomush.msg.* class MUST be declared. The class token
+	// may be dotted (package-disambiguated colliders, holomush-t4tye), so match
+	// a run of identifier chars and dots — stops at the trailing [] of a list.
+	refRe := regexp.MustCompile(`holomush\.msg\.[\w.]+`)
 	for _, ref := range refRe.FindAllString(out, -1) {
 		assert.Truef(t, declared[ref], "referenced class %q is not declared", ref)
 	}

--- a/internal/plugin/luabridge/gen/luatype.go
+++ b/internal/plugin/luabridge/gen/luatype.go
@@ -5,31 +5,34 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // luaType maps a proto field to a LuaLS type string (spec §3). Repeated and map
-// fields are detected before scalar kind. Message fields render as the namespaced
-// class name from luaClassName.
-func luaType(fd protoreflect.FieldDescriptor) string {
+// fields are detected before scalar kind. Message fields render as the class
+// name resolved by nameFor, which the stub collector makes collision-aware
+// (holomush-t4tye) so a reference to one of two same-short-name messages from
+// different packages resolves to that message's distinct class.
+func luaType(fd protoreflect.FieldDescriptor, nameFor func(protoreflect.MessageDescriptor) string) string {
 	// Map must be checked before IsList: a proto map is a repeated synthetic
 	// message, so IsMap() is the discriminator.
 	if fd.IsMap() {
 		k := scalarLuaType(fd.MapKey())
-		v := luaTypeNoCollection(fd.MapValue())
+		v := luaTypeNoCollection(fd.MapValue(), nameFor)
 		return fmt.Sprintf("table<%s, %s>", k, v)
 	}
 	if fd.IsList() {
-		return luaTypeNoCollection(fd) + "[]"
+		return luaTypeNoCollection(fd, nameFor) + "[]"
 	}
-	return luaTypeNoCollection(fd)
+	return luaTypeNoCollection(fd, nameFor)
 }
 
 // luaTypeNoCollection maps the element type, ignoring list/map wrapping.
-func luaTypeNoCollection(fd protoreflect.FieldDescriptor) string {
+func luaTypeNoCollection(fd protoreflect.FieldDescriptor, nameFor func(protoreflect.MessageDescriptor) string) string {
 	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind {
-		return luaClassName(fd.Message())
+		return nameFor(fd.Message())
 	}
 	return scalarLuaType(fd)
 }
@@ -51,10 +54,22 @@ func scalarLuaType(fd protoreflect.FieldDescriptor) string {
 	}
 }
 
-// luaClassName returns the LuaLS @class name for a message descriptor as
-// holomush.msg.<ShortName>. The short name is used deliberately for this task;
-// fully-qualified namespacing (spec §3's holomush.host.<token>.<MessageName>)
-// is applied downstream by the stub collector (plan Task 3/4), not here.
+// luaClassName returns the canonical LuaLS @class name for a message descriptor
+// as holomush.msg.<ShortName>. This is the name every non-colliding message
+// keeps; the stub collector's classNamer overrides it only for messages whose
+// short name collides with another reachable message from a different package
+// (see disambiguatedClassName, holomush-t4tye).
 func luaClassName(md protoreflect.MessageDescriptor) string {
 	return "holomush.msg." + string(md.Name())
+}
+
+// disambiguatedClassName returns a collision-free @class name derived from the
+// message's full name. It strips the redundant leading "holomush." root (which
+// the holomush.msg prefix already implies) and keeps the remaining
+// package+message path, so two same-short-name messages from different packages
+// (e.g. holomush.plugin.host.v1.DecryptOwnAuditRowsRequest vs
+// holomush.plugin.v1.DecryptOwnAuditRowsRequest) yield distinct classes. The
+// full name is unique per message, so the result is too.
+func disambiguatedClassName(md protoreflect.MessageDescriptor) string {
+	return "holomush.msg." + strings.TrimPrefix(string(md.FullName()), "holomush.")
 }

--- a/internal/plugin/luabridge/gen/luatype_test.go
+++ b/internal/plugin/luabridge/gen/luatype_test.go
@@ -33,17 +33,17 @@ func fieldByPath(t *testing.T, msgFullName, field string) protoreflect.FieldDesc
 func TestLuaTypeMapsScalarStringField(t *testing.T) {
 	// EmitEventRequest.stream is a proto string.
 	fd := fieldByPath(t, "holomush.plugin.host.v1.EmitEventRequest", "stream")
-	assert.Equal(t, "string", luaType(fd))
+	assert.Equal(t, "string", luaType(fd, luaClassName))
 }
 
 func TestLuaTypeMapsRepeatedMessageAndScalarFields(t *testing.T) {
 	// QueryStreamHistoryResponse.events is repeated Event (message) → Event class[].
 	events := fieldByPath(t, "holomush.plugin.host.v1.QueryStreamHistoryResponse", "events")
-	assert.Equal(t, "holomush.msg.Event[]", luaType(events))
+	assert.Equal(t, "holomush.msg.Event[]", luaType(events, luaClassName))
 
 	// EmitEventRequest.event_type is string.
 	et := fieldByPath(t, "holomush.plugin.host.v1.EmitEventRequest", "event_type")
-	assert.Equal(t, "string", luaType(et))
+	assert.Equal(t, "string", luaType(et, luaClassName))
 }
 
 // Map-branch (table<K,V>) coverage is deferred: host.v1 exposes no map field.
@@ -65,7 +65,7 @@ func TestLuaTypeMapsScalarKindsEnumAndOptional(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fd := fieldByPath(t, tt.msg, tt.field)
-			assert.Equal(t, tt.expected, luaType(fd))
+			assert.Equal(t, tt.expected, luaType(fd, luaClassName))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes `holomush-t4tye`: the Lua stub generator keyed its message-dedup map on the **short** `@class` name (`holomush.msg.<ShortName>`), discarding the proto package. Two distinct full-name messages that share a short name — e.g. the latent pair `DecryptOwnAuditRows{Request,Response}` present in **both** `holomush.plugin.host.v1` and `holomush.plugin.v1` — would have the second silently dropped, and emission would render duplicate/ambiguous classes.

- Split `collectStubMessages` into `reachableMessages` (walk, dedup keyed on `md.FullName()` — distinct messages are never conflated) + `buildStubMessages` (naming).
- Added a collision-aware `classNamer`: unique short names keep the canonical `holomush.msg.<Short>` convention; only true colliders are disambiguated via `disambiguatedClassName` (derived from the full name).
- `luaType`/`luaTypeNoCollection` now take a `nameFor` resolver so message-field references resolve to the same class as the `@class` declaration.
- Hardened `TestRenderedStubIsStructurallyValid`'s reference regex to match dotted (disambiguated) class names.

**Out-of-scope respected:** the collision-free real surface regenerates byte-identical — `pkg/plugin/luastubs/holomush.lua` and `bindings_gen.go` are unchanged.

**Known latent gap (follow-up `holomush-lfy04`):** service-method `@param`/`@return` references still use the short-name prefix; latent today and guarded by `TestRenderedStubIsStructurallyValid`.

## Test Plan

- [x] `task test -- ./internal/plugin/luabridge/gen/` — 12 pass, incl. new `TestBuildStubMessagesDisambiguatesCrossPackageShortNameCollision`
- [x] `task lint:go` — 0 issues
- [x] `task pr-prep` (fast lane) — `status=pass exit=0`
- [x] `go generate ./internal/plugin/luabridge/...` — no diff to generated artifacts
- [x] in-session `code-reviewer` — READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)