### PR TITLE
feat(plugin): default-deny ABAC for all non-scoped host capabilities (holomush-kplrr)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -444,3 +444,34 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   a host facade seeds a crypto-participant set, the AuthGuard char-branch gates on set-membership
   alone — confirm the seed is preceded by an authz gate that ALREADY licenses decrypt, else the
   seed over-grants.
+- **Exact-wildcard cap permit vs type-match own-location (kplrr, 2026-06-18) — READY**:
+  hostcap interceptor now runs default-deny ABAC for EVERY non-exempt capability;
+  non-scoped methods eval at type level `resource=md.Resource+":*"`
+  (`interceptor.go:186`), scope-eligible keep dispatch/extract/own-location.
+  11 new `seed:plugin-cap-*` permits match the sentinel EXACTLY via
+  `resource == "<type>:*"` (ResourceExact) NOT `resource is <type>`. KEY engine
+  fact: `findApplicablePolicies` ResourceExact requires `req.Resource ==
+  *target.ResourceExact` string-equal (`engine.go:374-377`) — so `location:*`
+  permit canNOT match scoped `location:<realid>` from CreateExit/CreateObject;
+  those match ONLY `seed:plugin-world-mutation-own-location` (`resource is
+  location` + `when{resource.location.id==action.dispatch_location}`). own-location
+  also doesn't spuriously fire at `location:*` (LocationProvider returns nil for
+  wildcard → missing attr → when=false). No path writes an arbitrary existing
+  location (CreateLocation = new-only; the only existing-location mutations are
+  scope-eligible). Exempt={emit,command-registry} (`descriptor.go:48`). Subject=
+  `access.PluginSubject(d.PluginName)` host-derived; non-scoped scopeAttrs=nil +
+  unconditional permits → no attr-influence escalation. Audit flows for both
+  paths (Auditor passed to EvaluateCapabilityAccess). Completeness guard
+  `TestEverySeededCapabilityResourceHasDefaultPermit` is total for non-scoped
+  non-exempt only (skips scope-eligible — fail-closed if a scoped seed missing).
+  ONE Medium (doc-only): seed.go:411 + interceptor.go:117 claim the system forbid
+  `seed:deny-events-system-read-plugin` "still overrides" stream reads, but the
+  plugin `stream.history` handler `QueryStreamHistory` (`servers.go:818-883`) runs
+  NO instance-level ABAC on req.GetStream() — only gate is cap interceptor at
+  `stream:*`, where the `events.*.system.*` glob can't match `*`. NOT a regression
+  (pre-change the non-scoped short-circuit forwarded ungated entirely); the forbid
+  only bites paths with a concrete-name check (CoreServer query_stream_history.go).
+  Pattern: when a non-scoped capability handler lacks its own instance-level ABAC
+  check, the type-level `<type>:*` cap permit is the ONLY gate — a `when`-clause
+  forbid on concrete attrs is dead weight there. Always trace whether the served
+  handler re-checks the concrete resource before trusting a forbid to protect it.

--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -330,5 +330,103 @@ func SeedPolicies() []SeedPolicy {
 			DSLText:     `permit(principal is plugin, action in ["write"], resource is location) when { resource.location.id == action.dispatch_location };`,
 			SeedVersion: 1,
 		},
+
+		// --- Plugin host-capability default-permit seeds (holomush-kplrr; INV-PLUGIN-50) ---
+		//
+		// Every declared non-exempt capability is now authorized by a default-deny
+		// ABAC decision in the host-capability interceptor (internal/plugin/hostcap):
+		// declaration is necessary but NOT sufficient. NON-scope-eligible methods
+		// (kv, settings, world.query, property, session, focus, stream, audit, eval,
+		// and the non-scoped world.mutation CreateLocation) are evaluated at the
+		// capability TYPE level — the interceptor passes the wildcard sentinel
+		// resource "<type>:*". These seeds default-permit those type-level calls so a
+		// declared, undifferentiated capability succeeds; an operator MAY layer a
+		// `forbid(principal is plugin, ... resource is <type>)` on top to deny a
+		// declared capability (the operator-override lever INV-PLUGIN-50 promises).
+		//
+		// They match the wildcard sentinel EXACTLY (`resource == "<type>:*"`), never
+		// by type (`resource is <type>`): a type-match permit on `location` would
+		// also match the SCOPED CreateExit/CreateObject calls (resource
+		// "location:<id>") and silently defeat the own-location seed above. Exact
+		// wildcard match authorizes only the non-scoped type-level calls; scoped
+		// instance writes remain gated by their own-location seed. Every served
+		// non-exempt capability resource type MUST carry one of these — absence
+		// fails the call closed (guarded by TestEverySeededCapabilityResourceHasDefaultPermit).
+		{
+			Name:        "seed:plugin-cap-eval",
+			Description: "Default-permit a declared plugin's policy-evaluation capability at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["evaluate"], resource == "policy:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-settings",
+			Description: "Default-permit a declared plugin's settings capability at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read", "write"], resource == "setting:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-kv",
+			Description: "Default-permit a declared plugin's kv capability at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read", "write"], resource == "kv:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-world-location",
+			Description: "Default-permit a declared plugin's type-level location capability: world.query location reads AND the non-scoped CreateLocation write (creating a NEW location, no pre-existing operand). Scoped writes to EXISTING locations (CreateExit/CreateObject) stay gated by seed:plugin-world-mutation-own-location — this exact-wildcard permit cannot match their location:<id> resource (INV-PLUGIN-50)",
+			DSLText:     `permit(principal is plugin, action in ["read", "write"], resource == "location:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-world-query-character",
+			Description: "Default-permit a declared plugin's world.query reads of characters at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read"], resource == "character:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-world-query-object",
+			Description: "Default-permit a declared plugin's world.query reads of objects at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read"], resource == "object:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-property",
+			Description: "Default-permit a declared plugin's property capability at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read", "write"], resource == "property:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-session",
+			Description: "Default-permit a declared plugin's session capability (read/list/write, incl. session.admin) at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read", "list", "write"], resource == "session:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-focus",
+			Description: "Default-permit a declared plugin's focus capability at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read", "write"], resource == "focus:*");`,
+			SeedVersion: 1,
+		},
+		// seed:plugin-cap-stream interaction with the system-namespace forbid
+		// (seed:deny-events-system-read-plugin, action read, when resource.stream.name
+		// like "events.*.system.*"): the forbid's TARGET (resource is stream) does match
+		// the stream:* sentinel, but its WHEN clause evaluates resource.stream.name to the
+		// literal "*" (StreamProvider on a wildcard id), and "*" like "events.*.system.*"
+		// is false — so the forbid does not fire at this type-level gate. Instance-level
+		// system-stream protection therefore lives on paths that re-check a concrete
+		// stream name (the CoreServer player QueryStreamHistory path); the plugin
+		// stream.history handler does not currently do so (pre-existing; tracked in
+		// holomush-xakba).
+		{
+			Name:        "seed:plugin-cap-stream",
+			Description: "Default-permit a declared plugin's stream capability at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read", "write"], resource == "stream:*");`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:plugin-cap-audit",
+			Description: "Default-permit a declared plugin's audit capability (DecryptOwnAuditRows) at the type level (INV-PLUGIN-50; operator MAY forbid)",
+			DSLText:     `permit(principal is plugin, action in ["read"], resource == "audit:*");`,
+			SeedVersion: 1,
+		},
 	}
 }

--- a/internal/access/policy/seed_smoke_test.go
+++ b/internal/access/policy/seed_smoke_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/attribute"
 	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/plugin/hostcap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -997,4 +998,91 @@ func TestSeedSmokePluginDeniedEventsSystemRekeyStream(t *testing.T) {
 	assert.False(t, decision.IsAllowed(),
 		"plugin must NOT read events.*.system.rekey.* stream (ABAC seed gate A16/INV-ACCESS-7); got: %s — %s",
 		decision.Effect(), decision.Reason())
+}
+
+// Verifies: INV-PLUGIN-50
+func TestSeedSmokePluginNonScopedCapabilityPermittedByDefaultSeed(t *testing.T) {
+	// A non-scoped host capability (kv read) is evaluated at the capability type
+	// level (resource "kv:*", as the interceptor supplies it). The per-capability
+	// default-permit seed (seed:plugin-cap-kv) MUST permit it so a declared,
+	// undifferentiated capability call succeeds absent an operator forbid.
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		pluginProvider(map[string]any{"name": "core-objects"}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  access.PluginSubject("core-objects"),
+		Action:   "read",
+		Resource: "kv:*",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(),
+		"default-permit seed should authorize a declared non-scoped capability; got: %s — %s",
+		decision.Effect(), decision.Reason())
+}
+
+// Verifies: INV-PLUGIN-50
+func TestSeedSmokePluginNonScopedCapabilityDeniedByOperatorForbid(t *testing.T) {
+	// Declaration is necessary but NOT sufficient: an operator forbid policy on a
+	// capability resource type overrides the default-permit seed, making a
+	// declared non-scoped capability unreachable (INV-PLUGIN-50).
+	seeds := SeedPolicies()
+	dslTexts := make([]string, 0, len(seeds)+1)
+	for _, s := range seeds {
+		dslTexts = append(dslTexts, s.DSLText)
+	}
+	dslTexts = append(dslTexts,
+		`forbid(principal is plugin, action in ["read", "write"], resource is kv);`)
+
+	engine := createTestEngineWithPolicies(t, dslTexts, []attribute.AttributeProvider{
+		pluginProvider(map[string]any{"name": "core-objects"}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  access.PluginSubject("core-objects"),
+		Action:   "read",
+		Resource: "kv:*",
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(),
+		"operator forbid must override the default-permit seed for a declared capability; got: %s — %s",
+		decision.Effect(), decision.Reason())
+}
+
+// Verifies: INV-PLUGIN-50
+func TestEverySeededCapabilityResourceHasDefaultPermit(t *testing.T) {
+	// Drift guard: every served, non-exempt, NON-scope-eligible capability method
+	// in hostcap.Descriptors MUST be authorized by a default-permit seed at the
+	// type level (resource "<type>:*", exactly how the interceptor evaluates a
+	// non-scoped call). A capability added later without its seed would fail
+	// closed at runtime; this test catches that at build time — the seed-side
+	// analogue of the INV-PLUGIN-52 extractor-completeness meta-test.
+	//
+	// Scope-eligible methods are intentionally skipped: they are gated by the
+	// own-location seed and proven by the scoped smoke tests, which require a
+	// concrete resource + dispatch_location this type-level probe does not supply.
+	// Exempt (self-gated) capabilities short-circuit before the ABAC gate.
+	engine := createSeedEngine(t, nil) // unconditional permits resolve without providers
+
+	for token, desc := range hostcap.Descriptors {
+		if hostcap.IsDeclarationExempt(token) {
+			continue
+		}
+		for method, md := range desc.Methods {
+			if len(md.Scopes) > 0 {
+				continue
+			}
+			t.Run(token+"/"+method, func(t *testing.T) {
+				decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+					Subject:  access.PluginSubject("drift-probe"),
+					Action:   md.Action,
+					Resource: md.Resource + ":*",
+				})
+				require.NoError(t, err)
+				assert.True(t, decision.IsAllowed(),
+					"non-exempt non-scoped capability %s/%s (action=%q resource=%q) has no default-permit seed — it would fail closed at the interceptor; add a seed:plugin-cap-* permit for resource %q",
+					token, method, md.Action, md.Resource, md.Resource)
+			})
+		}
+	}
 }

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSeedPoliciesCount(t *testing.T) {
 	seeds := SeedPolicies()
-	// 28 permit + 9 forbid = 37 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history + 1 presence list_presence_same_location + 1 eykuh.3 plugin world.mutation own-location)
-	assert.Len(t, seeds, 37, "expected 37 seed policies (28 permit, 9 forbid)")
+	// 39 permit + 9 forbid = 48 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history + 1 presence list_presence_same_location + 1 eykuh.3 plugin world.mutation own-location + 11 holomush-kplrr plugin host-capability default-permit seeds)
+	assert.Len(t, seeds, 48, "expected 48 seed policies (39 permit, 9 forbid)")
 }
 
 func TestSeedPoliciesAllNamesHaveSeedPrefix(t *testing.T) {
@@ -71,7 +71,7 @@ func TestSeedPoliciesEffectDistribution(t *testing.T) {
 			forbidCount++
 		}
 	}
-	assert.Equal(t, 28, permitCount, "expected 28 permit policies")
+	assert.Equal(t, 39, permitCount, "expected 39 permit policies (+11 holomush-kplrr plugin host-capability default-permit seeds)")
 	assert.Equal(t, 9, forbidCount, "expected 9 forbid policies (+2 phase-5 sub-epic A events.*.system.crypto_totp.* denies + 2 phase-5 sub-epic D events.*.system.crypto_policy.* denies + 2 phase-5 sub-epic E events.*.system.* broad denies)")
 }
 
@@ -124,6 +124,18 @@ func TestSeedPoliciesExpectedNames(t *testing.T) {
 		"seed:staff-read-unrestricted-history",
 		// Plugin host-capability scope policy (eykuh.3; INV-PLUGIN-50)
 		"seed:plugin-world-mutation-own-location",
+		// Plugin host-capability default-permit seeds (holomush-kplrr; INV-PLUGIN-50)
+		"seed:plugin-cap-eval",
+		"seed:plugin-cap-settings",
+		"seed:plugin-cap-kv",
+		"seed:plugin-cap-world-location",
+		"seed:plugin-cap-world-query-character",
+		"seed:plugin-cap-world-query-object",
+		"seed:plugin-cap-property",
+		"seed:plugin-cap-session",
+		"seed:plugin-cap-focus",
+		"seed:plugin-cap-stream",
+		"seed:plugin-cap-audit",
 	}
 
 	seeds := SeedPolicies()

--- a/internal/plugin/hostcap/descriptor.go
+++ b/internal/plugin/hostcap/descriptor.go
@@ -50,6 +50,15 @@ var declarationExemptCapabilities = map[string]bool{
 	"command-registry": true,
 }
 
+// IsDeclarationExempt reports whether a capability token is self-gated (its
+// access is authorized by a dedicated mechanism, not by manifest declaration +
+// the default-deny ABAC decision). Exempt capabilities short-circuit before the
+// ABAC gate, so they require no default-permit seed. Exposed for the
+// seed-completeness drift guard (INV-PLUGIN-50).
+func IsDeclarationExempt(capToken string) bool {
+	return declarationExemptCapabilities[capToken]
+}
+
 // Descriptors is the single host-owned source for M1/M2/M3 per-method metadata,
 // keyed by capability token. It is the per-method companion to the sub-spec-2
 // token->service registry, covering every served host.v1 capability token (the

--- a/internal/plugin/hostcap/interceptor.go
+++ b/internal/plugin/hostcap/interceptor.go
@@ -103,20 +103,22 @@ func classifyHostMethod(fullMethod string) (capToken, method string, ok bool) {
 // undeclared capability, and denies when the plugin's declared access class does
 // not cover the method's operation class.
 //
-// Dynamic half (M1 policy + M3 scope): for a scope-eligible method (a descriptor
-// entry with non-empty Scopes), it requires a host-vouched dispatch context,
-// fails closed when the scope-eligible method has no wired extractor
-// (INV-PLUGIN-52), extracts the concrete scoped resource, builds the scope
+// Dynamic half (M1 policy + M3 scope): EVERY declared non-exempt capability is
+// authorized by the default-deny ABAC decision via
+// pluginauthz.EvaluateCapabilityAccess keyed on the plugin:<name> subject
+// (INV-PLUGIN-50) — declaration is necessary but not sufficient, so an operator
+// policy MAY forbid a declared capability. For a scope-eligible method (a
+// descriptor entry with non-empty Scopes), it requires a host-vouched dispatch
+// context, fails closed when the scope-eligible method has no wired extractor
+// (INV-PLUGIN-52), extracts the concrete scoped resource, and builds the scope
 // context from the host-vouched dispatch attributes (the acting character's
 // resolved "location" is surfaced to the policy DSL as the action attribute
-// "dispatch_location"), and runs the default-deny ABAC decision via
-// pluginauthz.EvaluateCapabilityAccess keyed on the plugin:<name> subject
-// (INV-PLUGIN-50). Non-scoped capability methods pass through after the static
-// half: this task's policy evaluation is intentionally limited to scoped methods,
-// because no default-permit operator seed exists for the read-only host
-// capabilities and running default-deny ABAC on them would deny every
-// undifferentiated capability call. The broader M1 operator-policy surface for
-// non-scoped capabilities is layered on by a later task.
+// "dispatch_location"). A non-scoped method is evaluated at the capability type
+// level (resource "<type>:*"): the per-capability default-permit seeds
+// (seed.go) match it unconditionally so undifferentiated calls succeed, while an
+// operator forbid policy overrides to deny. Every served capability resource
+// type therefore MUST carry a default-permit seed — absence fails the call
+// closed (guarded by the seed-completeness meta-test).
 func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
 	if d.DeclaredAccess == nil {
 		// Misconfigured interceptor: without a declaration lookup every gated
@@ -171,41 +173,62 @@ func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
 				With("method", method).
 				Errorf("declared access: read does not cover write method")
 		}
+		if d.PluginName == "" {
+			// Defense-in-depth, grouped with the peer static guards: access.PluginSubject
+			// (called below for both the scoped and non-scoped paths) panics on an empty
+			// name — an empty subject would bypass access control. Both production install
+			// sites source PluginName from the manifest (schema-required, non-empty), so
+			// this guards a misconfiguration only. Checked here, BEFORE the scope-eligible
+			// block, so an empty name fails closed with this specific code rather than
+			// masquerading as SCOPE_NO_DISPATCH on a scope-eligible call.
+			return nil, oops.Code("CAPABILITY_PLUGIN_NAME_MISSING").
+				With("capability", capToken).
+				With("method", method).
+				Errorf("capability interceptor misconfigured: empty plugin name")
+		}
 
-		// Dynamic half (M1 policy + M3 scope). Only scope-eligible methods are
-		// policy-evaluated in this task (see the doc comment for why).
-		if len(md.Scopes) == 0 {
-			return h(ctx, req)
-		}
+		// Dynamic half (M1 policy + M3 scope). Every declared non-exempt
+		// capability is subject to the default-deny ABAC decision (INV-PLUGIN-50):
+		// declaration is necessary but not sufficient, so an operator policy MAY
+		// forbid a declared capability. Scope-eligible methods additionally
+		// resolve a concrete scoped resource and surface the dispatch location for
+		// own-location conditions (M3); non-scoped methods evaluate at the
+		// capability type level (resource "<type>:*"), which the default-permit
+		// seeds match unconditionally and operator forbids may override.
+		scopeEligible := len(md.Scopes) > 0
+		resource := md.Resource + ":*" // type-level capability check (no instance)
+		var scopeAttrs map[string]any
 
-		dc, haveDispatch := pluginauthz.DispatchForHost(ctx)
-		if !haveDispatch || dc.Subject == "" {
-			// A scoped capability call with no host-vouched dispatch context has
-			// no acting-character location to scope against: fail closed.
-			return nil, oops.Code("SCOPE_NO_DISPATCH").
-				With("capability", capToken).
-				With("method", method).
-				Errorf("scoped capability call without dispatch context")
+		if scopeEligible {
+			dc, haveDispatch := pluginauthz.DispatchForHost(ctx)
+			if !haveDispatch || dc.Subject == "" {
+				// A scoped capability call with no host-vouched dispatch context has
+				// no acting-character location to scope against: fail closed.
+				return nil, oops.Code("SCOPE_NO_DISPATCH").
+					With("capability", capToken).
+					With("method", method).
+					Errorf("scoped capability call without dispatch context")
+			}
+			if md.Extract == nil {
+				// A scope-eligible method MUST resolve its resource through a wired
+				// extractor; a missing extractor fails closed (INV-PLUGIN-52).
+				return nil, oops.Code("SCOPE_NO_EXTRACTOR").
+					With("capability", capToken).
+					With("method", method).
+					Errorf("scope-eligible method missing extractor")
+			}
+			resourceID, ok := md.Extract(req)
+			if !ok || resourceID == "" {
+				// No concrete scoped resource present on a scope-eligible call:
+				// fail closed rather than forward unscoped (INV-PLUGIN-52).
+				return nil, oops.Code("SCOPE_NO_RESOURCE").
+					With("capability", capToken).
+					With("method", method).
+					Errorf("scope-eligible method has no scoped resource to evaluate")
+			}
+			resource = md.Resource + ":" + resourceID
+			scopeAttrs = map[string]any{"dispatch_location": dc.Attributes["location"]}
 		}
-		if md.Extract == nil {
-			// A scope-eligible method MUST resolve its resource through a wired
-			// extractor; a missing extractor fails closed (INV-PLUGIN-52).
-			return nil, oops.Code("SCOPE_NO_EXTRACTOR").
-				With("capability", capToken).
-				With("method", method).
-				Errorf("scope-eligible method missing extractor")
-		}
-		resourceID, ok := md.Extract(req)
-		if !ok || resourceID == "" {
-			// No concrete scoped resource present on a scope-eligible call:
-			// fail closed rather than forward unscoped (INV-PLUGIN-52).
-			return nil, oops.Code("SCOPE_NO_RESOURCE").
-				With("capability", capToken).
-				With("method", method).
-				Errorf("scope-eligible method has no scoped resource to evaluate")
-		}
-		resource := md.Resource + ":" + resourceID
-		scopeAttrs := map[string]any{"dispatch_location": dc.Attributes["location"]}
 
 		dec, err := pluginauthz.EvaluateCapabilityAccess(ctx, pluginauthz.CapabilityInput{
 			Engine:     d.Engine,
@@ -224,11 +247,18 @@ func NewCapabilityInterceptor(d InterceptorDeps) grpc.UnaryServerInterceptor {
 			return nil, err //nolint:wrapcheck // pluginauthz already wraps with oops context
 		}
 		if !dec.Allowed {
-			return nil, oops.Code("SCOPE_DENIED").
+			// Scope-eligible denials carry SCOPE_DENIED (instance/own-location
+			// failure); non-scoped denials carry CAPABILITY_ACCESS_DENIED (operator
+			// policy forbade a declared capability at the type level).
+			code := "CAPABILITY_ACCESS_DENIED"
+			if scopeEligible {
+				code = "SCOPE_DENIED"
+			}
+			return nil, oops.Code(code).
 				With("capability", capToken).
 				With("method", method).
 				With("resource", resource).
-				Errorf("denied by policy/scope")
+				Errorf("denied by policy")
 		}
 		return h(ctx, req)
 	}

--- a/internal/plugin/hostcap/interceptor_test.go
+++ b/internal/plugin/hostcap/interceptor_test.go
@@ -139,6 +139,72 @@ func TestInterceptorScopedCallFailsClosedWithoutDispatch(t *testing.T) {
 	errutil.AssertErrorCode(t, err, "SCOPE_NO_DISPATCH")
 }
 
+// Verifies: INV-PLUGIN-50
+func TestInterceptorNonScopedCapabilityDeniedByPolicy(t *testing.T) {
+	// A declared, access-class-permitted, NON-scoped capability (kv read) must
+	// still be subject to the default-deny ABAC decision: an operator policy that
+	// denies it makes the call unreachable despite declaration. Before option A
+	// this call passed through ungated (the len(Scopes)==0 short-circuit).
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.DenyAllEngine(),
+		PluginName:     "core-objects",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "read", true },
+	})
+	_, err := ic(ctxWithDispatch(t), &hostv1.GetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/Get",
+	}, okHandler)
+	errutil.AssertErrorCode(t, err, "CAPABILITY_ACCESS_DENIED")
+}
+
+// Verifies: INV-PLUGIN-50
+func TestInterceptorNonScopedCapabilityPermittedByPolicy(t *testing.T) {
+	// The complement: a declared non-scoped capability permitted by policy is
+	// reachable. AllowAllEngine stands in for the default-permit seed.
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		PluginName:     "core-objects",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "read", true },
+	})
+	resp, err := ic(ctxWithDispatch(t), &hostv1.GetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/Get",
+	}, okHandler)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestInterceptorEmptyPluginNameFailsClosed(t *testing.T) {
+	// Defense-in-depth: an empty PluginName (a misconfiguration — production
+	// sources it from the schema-required manifest Name) must fail closed at the
+	// ABAC gate rather than panic in access.PluginSubject. A declared, non-exempt
+	// capability call reaches the guard.
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		PluginName:     "", // misconfigured
+		DeclaredAccess: func(_, _ string) (string, bool) { return "read", true },
+	})
+	_, err := ic(ctxWithDispatch(t), &hostv1.GetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/Get",
+	}, okHandler)
+	errutil.AssertErrorCode(t, err, "CAPABILITY_PLUGIN_NAME_MISSING")
+}
+
+func TestInterceptorNilEngineFailsClosedForNonScopedMethod(t *testing.T) {
+	// Removing the non-scoped short-circuit means a non-scoped declared capability
+	// now reaches EvaluateCapabilityAccess. With a nil Engine it must fail closed
+	// (EVALUATE_NO_ENGINE), never forward to the handler. Production always wires a
+	// real engine (cfg.ABAC.Engine()), so this guards a misconfiguration — symmetric
+	// with the nil-DeclaredAccess and empty-PluginName guard tests.
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         nil, // misconfigured
+		PluginName:     "core-objects",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "read", true },
+	})
+	_, err := ic(ctxWithDispatch(t), &hostv1.GetRequest{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.KVService/Get",
+	}, okHandler)
+	errutil.AssertErrorCode(t, err, "EVALUATE_NO_ENGINE")
+}
+
 func TestInterceptorAccessReadDeniesWriteMethod(t *testing.T) {
 	ic := NewCapabilityInterceptor(InterceptorDeps{
 		Engine:         policytest.AllowAllEngine(),
@@ -153,6 +219,7 @@ func TestInterceptorAccessReadDeniesWriteMethod(t *testing.T) {
 func TestInterceptorAbsentDeclaredAccessPermitsWrite(t *testing.T) {
 	ic := NewCapabilityInterceptor(InterceptorDeps{
 		Engine:         policytest.AllowAllEngine(),
+		PluginName:     "core-objects",
 		DeclaredAccess: func(_, _ string) (string, bool) { return "", true }, // declared, no access narrowing
 	})
 	_, err := ic(ctxWithDispatch(t), &hostv1.SetRequest{}, &grpc.UnaryServerInfo{
@@ -188,6 +255,23 @@ func TestInterceptorPassesThroughSelfGatedCapabilityWhenUndeclared(t *testing.T)
 		FullMethod: "/holomush.plugin.host.v1.CommandRegistryService/ListCommands",
 	}, okHandler)
 	require.NoError(t, err)
+}
+
+func TestInterceptorUnmappedHostMethodFailsClosed(t *testing.T) {
+	// A host.v1 method whose service is not in the capability token map is
+	// unclassifiable and MUST fail closed rather than forward ungated (gum03.5).
+	// TestEveryServedCapabilityHasADescriptor structurally prevents the
+	// descriptor-missing case for *served* services; this exercises the
+	// interceptor denial itself for an unmapped host.v1 service.
+	ic := NewCapabilityInterceptor(InterceptorDeps{
+		Engine:         policytest.AllowAllEngine(),
+		PluginName:     "core-objects",
+		DeclaredAccess: func(_, _ string) (string, bool) { return "", true },
+	})
+	_, err := ic(context.Background(), struct{}{}, &grpc.UnaryServerInfo{
+		FullMethod: "/holomush.plugin.host.v1.UnmappedService/DoThing",
+	}, okHandler)
+	errutil.AssertErrorCode(t, err, "UNCLASSIFIED_CAPABILITY_METHOD")
 }
 
 func TestInterceptorNonHostMethodPassesThrough(t *testing.T) {

--- a/internal/plugin/lua/bufconn_endpoint_test.go
+++ b/internal/plugin/lua/bufconn_endpoint_test.go
@@ -57,11 +57,19 @@ func (f *fakeSessionAccessForEndpoint) UpdateLastWhispered(_ context.Context, _,
 }
 
 // newTestFunctions builds a *hostfunc.Functions with a session.Access wired in
-// so the SessionService server has a real backing for round-trip tests. All
-// other optional dependencies are left nil (fail-closed per the adapter).
+// so the SessionService server has a real backing for round-trip tests, plus an
+// AllowAll ABAC engine. The engine is required because the capability
+// interceptor now runs the default-deny ABAC decision for EVERY declared
+// non-exempt capability (holomush-kplrr, INV-PLUGIN-50), not just scope-eligible
+// ones — without it a non-scoped capability round-trip fails closed with
+// EVALUATE_NO_ENGINE. Production wires the real engine via
+// hostfunc.WithEngine(cfg.ABAC.Engine()) (setup/subsystem.go). Other optional
+// dependencies are left nil (fail-closed per the adapter).
 func newTestFunctions(t *testing.T) *hostfunc.Functions {
 	t.Helper()
-	return hostfunc.New(nil, hostfunc.WithSessionAccess(&fakeSessionAccessForEndpoint{}))
+	return hostfunc.New(nil,
+		hostfunc.WithSessionAccess(&fakeSessionAccessForEndpoint{}),
+		hostfunc.WithEngine(policytest.AllowAllEngine()))
 }
 
 // TestPluginEndpoint groups the per-plugin bufconn endpoint behaviors as
@@ -81,7 +89,9 @@ func TestPluginEndpoint(t *testing.T) {
 			// bufconn, asserting the endpoint serves the Lua capability set
 			// (INV-PLUGIN-49). ListActive is chosen because it has a real server
 			// impl (session.go:ListActive), fakeSessionAccessForEndpoint backs it,
-			// and it needs no dispatch token or ABAC engine.
+			// and it is non-scoped (no dispatch token needed). It IS subject to the
+			// default-deny ABAC decision (INV-PLUGIN-50); newTestFunctions wires an
+			// AllowAll engine so the declared session capability is permitted.
 			name: "serves host caps over the in-process bufconn",
 			run: func(t *testing.T) {
 				adapter := newLuaHostCapAdapter(newTestFunctions(t))


### PR DESCRIPTION
## Summary

Closes the INV-PLUGIN-50 gap surfaced by PR #4434 review (finding holomush-gum03.2). The host-capability interceptor previously ran the default-deny ABAC `Evaluate` **only** for scope-eligible methods (`world.mutation`). Non-scoped declared capabilities (`kv`, `settings`, `session`, `focus`, `property`, `world.query`, `audit`, `stream.*`) passed after the static declaration + access-class checks **without** an ABAC decision — so INV-PLUGIN-50's summary ("a plugin's consumption of a host capability MUST be authorized by a default-deny ABAC decision; declaration necessary but not sufficient") was honored only on the scoped path.

Resolved via **route (A)** — implement the enforcement so the invariant is fully true (not narrow the invariant).

- **Interceptor** (`internal/plugin/hostcap/interceptor.go`): removed the `len(md.Scopes)==0` short-circuit; `EvaluateCapabilityAccess` now runs for **every** declared non-exempt capability. Non-scoped methods evaluate at the capability **type level** (resource `"<type>:*"`); the scoped own-location path is unchanged. Non-scoped policy denial → `CAPABILITY_ACCESS_DENIED` (scoped keeps `SCOPE_DENIED`).
- **Seeds** (`internal/access/policy/seed.go`): 11 default-permit seeds (`seed:plugin-cap-*`), matched by **exact wildcard** `resource == "<type>:*"` — not `resource is <type>` — so they authorize only non-scoped type-level calls and can never match a scoped `location:<id>` write (which would defeat `seed:plugin-world-mutation-own-location`). An operator forbid policy overrides any of them (the lever INV-PLUGIN-50 promises).
- **Drift guard**: `TestEverySeededCapabilityResourceHasDefaultPermit` fails the build if any served non-exempt non-scoped capability lacks a permit seed (mirrors the INV-PLUGIN-52 extractor-completeness guard). Added exported `hostcap.IsDeclarationExempt`.
- **Fail-closed guard** for empty `PluginName` (`CAPABILITY_PLUGIN_NAME_MISSING`) — replaces a panic surface widened by removing the short-circuit.
- Folds **gum03.5**: interceptor-level `UNCLASSIFIED_CAPABILITY_METHOD` test.

INV-PLUGIN-50 is now fully honored for host capabilities; the registry summary already matched (binding meta-tests green).

### Pre-push review gates
- `abac-reviewer`: **READY** · `code-reviewer`: **READY** (both findings addressed — stream doc-comment corrected, empty-name guard added, seed renamed).

### Follow-ups filed
- `holomush-yvz2z` — recover scoped-capability dispatch ctx across the binary broker boundary (latent/unreachable today).
- `holomush-xakba` — plugin `stream.history` path lacks an instance-level system-stream ABAC check (pre-existing).

## Test Plan
- [x] `task pr-prep` (fast lane) green — bats, schema, license, lint, fmt, unit, build
- [x] Unit: hostcap + access/policy + pluginauthz suites (incl. interceptor deny/permit, seed permit + operator-forbid-override, completeness guard 32 subtests)
- [x] Integration: `test/integration/pluginparity/` (capability-gate surface) green locally
- [x] Invariant binding meta-tests green
- [ ] CI required checks: Integration Test + E2E Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)