### PR TITLE
test(plugin): cross-runtime parity for non-scoped capability ABAC denial (holomush-9krwa)

### DIFF
--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3838,6 +3838,10 @@ invariants:
       - "internal/plugin/pluginauthz/capability_test.go"
       - "internal/plugin/hostcap/interceptor_test.go"
       - "internal/access/policy/seed_smoke_test.go"
+      # Cross-runtime wire-tier witness: a DECLARED non-scoped capability forbidden
+      # by operator policy is denied IDENTICALLY through the shared interceptor on
+      # both the binary and Lua runtimes (the parity dimension of the M1 strategy).
+      - "test/integration/pluginparity/nonscoped_capability_deny_test.go"
   - id: INV-PLUGIN-51
     scope: INV-PLUGIN
     origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"

--- a/test/integration/pluginparity/gated_endpoints_test.go
+++ b/test/integration/pluginparity/gated_endpoints_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package pluginparity
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"google.golang.org/grpc"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/goplugin"
+	"github.com/holomush/holomush/internal/plugin/hostcap"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	"github.com/holomush/holomush/internal/plugin/lua"
+)
+
+// Shared gated-endpoint builders for the least-privilege parity specs. Both
+// runtimes stand up their host.v1 capability surface WITH the production
+// capability interceptor chained on, built from manifest via the SAME
+// hostcap.DeclaredAccessFromManifest constructor the production install sites
+// use (binary: goplugin/host_service.go:50; Lua: lua/bufconn_endpoint.go:44).
+// The non-gated parity endpoints in parity_test.go register servers WITHOUT the
+// interceptor and prove ROUTING only; these prove GATING.
+//
+// The interceptor's Engine is parameterized so a spec can drive either the
+// declaration gate (engine never reached — declaration fails first) or the
+// dynamic ABAC gate (a real engine that an operator policy forbids). The SAME
+// engine instance is wired into both runtimes' endpoints so a parity spec proves
+// one shared gate denies both identically (INV-PLUGIN-45/50), never two
+// per-runtime gates that happen to agree.
+
+// gatedBinaryEndpointWithEngine stands up the binary runtime's gated capability
+// surface with the given ABAC engine wired into BOTH the host and the
+// capability interceptor.
+func gatedBinaryEndpointWithEngine(manifest *plugins.Manifest, engine types.AccessPolicyEngine) runtimeEndpoint {
+	GinkgoHelper()
+
+	host := goplugin.NewHost(goplugin.WithEngine(engine))
+	DeferCleanup(func() { _ = host.Close(context.Background()) })
+
+	ic := hostcap.NewCapabilityInterceptor(hostcap.InterceptorDeps{
+		Engine:         engine,
+		PluginName:     manifest.Name,
+		DeclaredAccess: hostcap.DeclaredAccessFromManifest(manifest),
+	})
+	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(ic))
+	hostcap.RegisterCapabilities(srv, hostcap.NewBase(host, manifest.Name), hostcap.BinaryDefaultSet)
+
+	conn, err := plugins.NewInProcessConn(srv)
+	Expect(err).NotTo(HaveOccurred(), "binary gated in-process conn must stand up")
+	DeferCleanup(func() { _ = conn.Close() })
+
+	return runtimeEndpoint{srv: srv, conn: conn}
+}
+
+// gatedLuaEndpointWithEngine stands up the Lua runtime's gated capability
+// surface with the given ABAC engine wired into BOTH the host and the
+// capability interceptor.
+func gatedLuaEndpointWithEngine(manifest *plugins.Manifest, engine types.AccessPolicyEngine) runtimeEndpoint {
+	GinkgoHelper()
+
+	luaHost := lua.NewHostWithFunctions(hostfunc.New(nil, hostfunc.WithEngine(engine)))
+	DeferCleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	adapter := luaHost.HostCapabilitiesAdapter()
+	Expect(adapter).NotTo(BeNil(), "lua host must expose its real hostcap adapter")
+
+	ic := hostcap.NewCapabilityInterceptor(hostcap.InterceptorDeps{
+		Engine:         engine,
+		PluginName:     manifest.Name,
+		DeclaredAccess: hostcap.DeclaredAccessFromManifest(manifest),
+	})
+	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(ic))
+	hostcap.RegisterCapabilities(srv, hostcap.NewBase(adapter, manifest.Name), hostcap.LuaDefaultSet)
+
+	conn, err := plugins.NewInProcessConn(srv)
+	Expect(err).NotTo(HaveOccurred(), "lua gated in-process conn must stand up")
+	DeferCleanup(func() { _ = conn.Close() })
+
+	return runtimeEndpoint{srv: srv, conn: conn}
+}
+
+// gatedBinaryEndpoint is the AllowAll-engine convenience used by the
+// declaration-gate specs, which deny BEFORE the engine is consulted.
+func gatedBinaryEndpoint(manifest *plugins.Manifest) runtimeEndpoint {
+	GinkgoHelper()
+	return gatedBinaryEndpointWithEngine(manifest, policytest.AllowAllEngine())
+}
+
+// gatedLuaEndpoint is the AllowAll-engine convenience used by the
+// declaration-gate specs, which deny BEFORE the engine is consulted.
+func gatedLuaEndpoint(manifest *plugins.Manifest) runtimeEndpoint {
+	GinkgoHelper()
+	return gatedLuaEndpointWithEngine(manifest, policytest.AllowAllEngine())
+}

--- a/test/integration/pluginparity/least_privilege_gate_test.go
+++ b/test/integration/pluginparity/least_privilege_gate_test.go
@@ -10,16 +10,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/holomush/holomush/internal/access/policy/policytest"
 	plugins "github.com/holomush/holomush/internal/plugin"
-	"github.com/holomush/holomush/internal/plugin/goplugin"
-	"github.com/holomush/holomush/internal/plugin/hostcap"
-	"github.com/holomush/holomush/internal/plugin/hostfunc"
-	"github.com/holomush/holomush/internal/plugin/lua"
 	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
 )
 
@@ -65,63 +59,8 @@ func declaredKVManifest() *plugins.Manifest {
 	}
 }
 
-// gatedBinaryEndpoint stands up the binary runtime's KV-capability surface WITH
-// the production capability interceptor layered on, built from manifest via the
-// SAME hostcap.DeclaredAccessFromManifest constructor the binary install site
-// uses (internal/plugin/goplugin/host_service.go:45). Mirrors
-// newBinaryEndpointWithOpts but chains NewCapabilityInterceptor so the
-// declaration gate runs — the existing parity endpoints register servers WITHOUT
-// the interceptor and prove ROUTING only, not GATING.
-func gatedBinaryEndpoint(manifest *plugins.Manifest) runtimeEndpoint {
-	GinkgoHelper()
-
-	host := goplugin.NewHost(goplugin.WithEngine(policytest.AllowAllEngine()))
-	DeferCleanup(func() { _ = host.Close(context.Background()) })
-
-	ic := hostcap.NewCapabilityInterceptor(hostcap.InterceptorDeps{
-		Engine:         policytest.AllowAllEngine(),
-		PluginName:     manifest.Name,
-		DeclaredAccess: hostcap.DeclaredAccessFromManifest(manifest),
-	})
-	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(ic))
-	hostcap.RegisterCapabilities(srv, hostcap.NewBase(host, manifest.Name), hostcap.BinaryDefaultSet)
-
-	conn, err := plugins.NewInProcessConn(srv)
-	Expect(err).NotTo(HaveOccurred(), "binary gated in-process conn must stand up")
-	DeferCleanup(func() { _ = conn.Close() })
-
-	return runtimeEndpoint{srv: srv, conn: conn}
-}
-
-// gatedLuaEndpoint stands up the Lua runtime's KV-capability surface WITH the
-// production capability interceptor layered on, built from manifest via the SAME
-// hostcap.DeclaredAccessFromManifest constructor the Lua install site uses
-// (internal/plugin/lua/bufconn_endpoint.go:44). Mirrors
-// newLuaEndpointWithFunctions but chains NewCapabilityInterceptor so the
-// declaration gate runs.
-func gatedLuaEndpoint(manifest *plugins.Manifest) runtimeEndpoint {
-	GinkgoHelper()
-
-	luaHost := lua.NewHostWithFunctions(hostfunc.New(nil, hostfunc.WithEngine(policytest.AllowAllEngine())))
-	DeferCleanup(func() { _ = luaHost.Close(context.Background()) })
-
-	adapter := luaHost.HostCapabilitiesAdapter()
-	Expect(adapter).NotTo(BeNil(), "lua host must expose its real hostcap adapter")
-
-	ic := hostcap.NewCapabilityInterceptor(hostcap.InterceptorDeps{
-		Engine:         policytest.AllowAllEngine(),
-		PluginName:     manifest.Name,
-		DeclaredAccess: hostcap.DeclaredAccessFromManifest(manifest),
-	})
-	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(ic))
-	hostcap.RegisterCapabilities(srv, hostcap.NewBase(adapter, manifest.Name), hostcap.LuaDefaultSet)
-
-	conn, err := plugins.NewInProcessConn(srv)
-	Expect(err).NotTo(HaveOccurred(), "lua gated in-process conn must stand up")
-	DeferCleanup(func() { _ = conn.Close() })
-
-	return runtimeEndpoint{srv: srv, conn: conn}
-}
+// The gatedBinaryEndpoint / gatedLuaEndpoint builders these specs use live in
+// gated_endpoints_test.go (shared with the non-scoped ABAC-denial parity spec).
 
 var _ = Describe("Cross-runtime least-privilege declaration gate", func() {
 	// INV-PLUGIN-45: "The declaration gate that enforces least privilege MUST

--- a/test/integration/pluginparity/nonscoped_capability_deny_test.go
+++ b/test/integration/pluginparity/nonscoped_capability_deny_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package pluginparity
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
+// forbiddenKVResource is the type-level capability resource the interceptor
+// evaluates for a NON-scoped kv method: descriptor Resource "kv" + ":*" (the
+// non-scoped instance-less form, interceptor.go:199). The operator-forbid engine
+// below denies exactly this resource.
+const forbiddenKVResource = "kv:*"
+
+// policyDenialMessage is the interceptor's denial text when the dynamic ABAC gate
+// forbids a DECLARED non-scoped capability (interceptor.go: oops.Code(
+// "CAPABILITY_ACCESS_DENIED") ... Errorf("denied by policy")). A bare oops error
+// carries no GRPCStatus method, so grpc-go surfaces it as codes.Unknown with this
+// message preserved — the same wire shape the declaration gate uses, which is why
+// the denial reason (not just the code) is the discriminator that proves the ABAC
+// gate fired rather than the declaration gate.
+const policyDenialMessage = "denied by policy"
+
+// operatorForbidEngine models an operator policy that FORBIDS one specific
+// non-scoped capability resource type while permitting everything else — exactly
+// the M1 scenario "a default-permit seed overridden by an operator forbid"
+// (spec §M1; INV-PLUGIN-50). It is a purpose-built test engine in the sanctioned
+// ownLocationEngine idiom (hostcap/interceptor_test.go): it asserts the dynamic
+// half end-to-end across the wire without standing up a full DSL-backed engine,
+// whose seed DSL is verified separately by the policy package's seed smoke tests.
+//
+// EffectDeny (not EffectDefaultDeny) is deliberate: an operator forbid is an
+// EXPLICIT deny overriding the default-permit, which DenyAllEngine's blanket deny
+// would not distinguish from "nothing permits".
+type operatorForbidEngine struct {
+	forbidResource string
+}
+
+// Evaluate forbids the configured resource and default-permits all others.
+func (e operatorForbidEngine) Evaluate(_ context.Context, req types.AccessRequest) (types.Decision, error) {
+	if req.Resource == e.forbidResource {
+		return types.NewDecision(types.EffectDeny, "operator forbid", "test:operator-forbid"), nil
+	}
+	return types.NewDecision(types.EffectAllow, "default-permit seed", "test:default-permit"), nil
+}
+
+// CanPerformAction is not exercised by the capability interceptor (it uses
+// Evaluate); it satisfies the AccessPolicyEngine interface permissively.
+func (operatorForbidEngine) CanPerformAction(_ context.Context, _, _, _, _ string) (bool, error) {
+	return true, nil
+}
+
+var _ = Describe("Cross-runtime least-privilege ABAC denial (non-scoped capability)", func() {
+	// INV-PLUGIN-50: "A plugin's consumption of a host capability ... MUST be
+	// authorized by a default-deny ABAC decision keyed on the host-stamped
+	// plugin:<name> subject. Manifest declaration is necessary but not sufficient;
+	// an operator policy MAY deny a declared capability."
+	//
+	// The declaration-gate parity spec (least_privilege_gate_test.go) covers the
+	// STATIC half — a capability denied for being UNDECLARED. This spec covers the
+	// DYNAMIC half at the same cross-runtime tier: a capability that IS declared
+	// (the declaration gate passes) but is forbidden by operator policy. Both
+	// runtimes wire the SAME operatorForbidEngine into the SAME shared
+	// NewCapabilityInterceptor, so an identical denial is the structural witness
+	// that one shared ABAC gate — not two per-runtime gates that happen to agree —
+	// denies both (the parity dimension of the spec's M1 testing strategy).
+	//
+	// kv is the subject capability: its KVService is registered in BOTH runtime
+	// sets (register.go) so kv.Get ROUTES to a handler on both runtimes, and all
+	// its methods are NON-scoped (descriptor.go: empty Scopes), so the interceptor
+	// evaluates the type-level resource "kv:*" with no dispatch context required.
+	//
+	// Verifies: INV-PLUGIN-50
+	It("denies a declared but operator-forbidden non-scoped capability identically across runtimes", func() {
+		manifest := declaredKVManifest() // declares kv → declaration gate PASSES
+		engine := operatorForbidEngine{forbidResource: forbiddenKVResource}
+
+		binaryEP := gatedBinaryEndpointWithEngine(manifest, engine)
+		luaEP := gatedLuaEndpointWithEngine(manifest, engine)
+
+		binaryKV := hostv1.NewKVServiceClient(binaryEP.conn)
+		luaKV := hostv1.NewKVServiceClient(luaEP.conn)
+
+		_, binErr := binaryKV.Get(context.Background(), &hostv1.GetRequest{Key: "least-privilege"})
+		_, luaErr := luaKV.Get(context.Background(), &hostv1.GetRequest{Key: "least-privilege"})
+
+		Expect(binErr).To(HaveOccurred(),
+			"binary runtime MUST deny a declared kv capability forbidden by operator policy")
+		Expect(luaErr).To(HaveOccurred(),
+			"lua runtime MUST deny a declared kv capability forbidden by operator policy")
+
+		binCode := status.Code(binErr)
+		luaCode := status.Code(luaErr)
+
+		// IDENTICAL denial: same wire code on both runtimes.
+		Expect(binCode).To(Equal(luaCode),
+			"both runtimes MUST deny the forbidden capability with the IDENTICAL wire code — one shared ABAC gate, no per-runtime divergence (INV-PLUGIN-50)")
+		Expect(binCode).To(Equal(codes.Unknown),
+			"the shared ABAC gate's bare-oops CAPABILITY_ACCESS_DENIED denial surfaces as codes.Unknown on the wire")
+
+		// IDENTICAL denial reason: the dynamic gate's "denied by policy" text.
+		Expect(binErr.Error()).To(ContainSubstring(policyDenialMessage),
+			"binary denial MUST be the ABAC gate's CAPABILITY_ACCESS_DENIED reason")
+		Expect(luaErr.Error()).To(ContainSubstring(policyDenialMessage),
+			"lua denial MUST be the ABAC gate's CAPABILITY_ACCESS_DENIED reason")
+
+		// NOT the declaration gate: the manifest DECLARES kv, so a
+		// "plugin did not declare capability" denial would mean the wrong gate
+		// fired and this spec would not prove the ABAC (dynamic) half.
+		Expect(binErr.Error()).NotTo(ContainSubstring(declaredDenialMessage),
+			"the ABAC gate must deny, not the declaration gate — kv IS declared")
+		Expect(luaErr.Error()).NotTo(ContainSubstring(declaredDenialMessage),
+			"the ABAC gate must deny, not the declaration gate — kv IS declared")
+
+		// NOT the base: an Unimplemented here would mean the gate was bypassed and
+		// KVService's Unimplemented base answered instead of the ABAC gate.
+		Expect(binCode).NotTo(Equal(codes.Unimplemented),
+			"the GATE must deny, not the Unimplemented base — Unimplemented would mean the gate was bypassed")
+		Expect(luaCode).NotTo(Equal(codes.Unimplemented),
+			"the GATE must deny, not the Unimplemented base — Unimplemented would mean the gate was bypassed")
+	})
+
+	// Contrast / positive half: with the SAME declared-kv manifest but a policy
+	// that PERMITS the capability, the ABAC gate passes on both runtimes and the
+	// SAME kv.Get reaches the shared Unimplemented kvServer base, identically.
+	// AllowAllEngine stands in for the default-permit seed.
+	//
+	// This is what makes the denial assertion above non-vacuous: it proves the
+	// manifest's kv declaration is genuine (otherwise the permitted call would
+	// still be denied by the declaration gate, not reach the base), AND that the
+	// denial above was the OPERATOR POLICY firing — flip the policy to permit and
+	// the gate steps aside and the base answers.
+	//
+	// Verifies: INV-PLUGIN-50
+	It("admits the same declared non-scoped capability to the shared base when policy permits, identically across runtimes", func() {
+		manifest := declaredKVManifest()
+
+		binaryEP := gatedBinaryEndpointWithEngine(manifest, policytest.AllowAllEngine())
+		luaEP := gatedLuaEndpointWithEngine(manifest, policytest.AllowAllEngine())
+
+		binaryKV := hostv1.NewKVServiceClient(binaryEP.conn)
+		luaKV := hostv1.NewKVServiceClient(luaEP.conn)
+
+		_, binErr := binaryKV.Get(context.Background(), &hostv1.GetRequest{Key: "least-privilege"})
+		_, luaErr := luaKV.Get(context.Background(), &hostv1.GetRequest{Key: "least-privilege"})
+
+		Expect(binErr).To(HaveOccurred(), "permitted kv.Get reaches the Unimplemented base, which errors")
+		Expect(luaErr).To(HaveOccurred(), "permitted kv.Get reaches the Unimplemented base, which errors")
+
+		binCode := status.Code(binErr)
+		luaCode := status.Code(luaErr)
+
+		Expect(binCode).To(Equal(luaCode),
+			"both runtimes reach the IDENTICAL shared base when the capability is permitted")
+		Expect(binCode).To(Equal(codes.Unimplemented),
+			"a PERMITTED kv call passes the ABAC gate and reaches the Unimplemented base — proving the denial above was the operator policy, not the gate-bypass or declaration gate")
+
+		// Passing the ABAC gate means neither denial reason is present on either runtime.
+		Expect(binErr.Error()).NotTo(ContainSubstring(policyDenialMessage),
+			"a permitted capability MUST NOT be denied by the ABAC gate")
+		Expect(luaErr.Error()).NotTo(ContainSubstring(policyDenialMessage),
+			"a permitted capability MUST NOT be denied by the ABAC gate")
+	})
+})


### PR DESCRIPTION
## Summary

- Adds `test/integration/pluginparity/nonscoped_capability_deny_test.go` — a **cross-runtime parity** spec proving that a **declared** but operator-forbidden **non-scoped** host capability (`kv.Get`) is denied **identically** through the shared `NewCapabilityInterceptor` on both the binary and Lua `host.v1` runtimes: same wire code (`codes.Unknown`), same reason (`CAPABILITY_ACCESS_DENIED` / "denied by policy"), and provably **not** the declaration gate nor the `Unimplemented` base.
- Closes the M1 testing-strategy parity item for the *dynamic* ABAC half (the declaration-gate half was already covered by `least_privilege_gate_test.go`). Enforcement itself shipped in **holomush-kplrr** (#4462) — this is a completeness item, not a correctness gap.
- Relocates the gated-endpoint builders to a shared `gated_endpoints_test.go`, parameterized by engine; the `INV-PLUGIN-45` declaration-gate specs are behavior-unchanged.
- Registers the new spec as a cross-runtime wire-tier witness on `INV-PLUGIN-50.asserted_by` (regenerated via `inv-render`; registry meta-tests green).

### Design notes
- A purpose-built `operatorForbidEngine` returns `EffectDeny` (an explicit operator forbid, not blanket deny) on resource `kv:*` and `EffectAllow` otherwise — the sanctioned `ownLocationEngine` idiom. A **single instance** is wired into both runtimes, so identical denial is a structural shared-gate witness.
- A positive-control spec (same declared-kv manifest + permissive policy) reaches the `Unimplemented` base on both runtimes, proving the kv declaration is genuine and keeping the denial assertion non-vacuous.

## Test Plan
- [x] `task test:int -- -run TestPluginParity ./test/integration/pluginparity/` → 12 specs green (incl. 2 new)
- [x] Non-vacuousness: deliberate-break run → `Ran 2 of 12 Specs ... 1 Passed | 1 Failed` on the target assertion, then reverted
- [x] Invariant registry meta-tests green (`TestEveryRegistryInvariantHasBinding|TestProvenanceGuard|TestBoundInvariantsAreGenuinelyAsserted`)
- [x] `task pr-prep` (fast lane) → `status=pass, exit=0`
- [ ] CI required checks: Integration Test + E2E Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)