### PR TITLE
fix(plugin): instance-level ABAC for plugin stream.history reads, both runtimes (holomush-xakba)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -475,3 +475,33 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   check, the type-level `<type>:*` cap permit is the ONLY gate — a `when`-clause
   forbid on concrete attrs is dead weight there. Always trace whether the served
   handler re-checks the concrete resource before trusting a forbid to protect it.
+- **Two ReplayTail paths gated — RESOLVED READY (xakba, turn 2, 2026-06-19)**:
+  xakba closed both the kplrr Medium AND the turn-1 ambient-Lua gap. Single shared
+  gate `pluginauthz.AuthorizeStreamRead` (`pluginauthz/streamread.go`) QUALIFIES the
+  domain-relative stream (`eventbus.Qualify(GameID, Stream)`) BEFORE
+  `EvaluateCapabilityAccess(resource="stream:"+qualified, Declared:true)`. Reached by
+  BOTH production paths to plugin `HistoryReader.ReplayTail`: (1) host.v1
+  `hostcap/servers.go::QueryStreamHistory` (837-854, gate runs before ReplayTail:888);
+  (2) ambient Lua `query_stream_history` — reader WRAPPED in `authorizingHistoryReader`
+  (`hostfunc/streamauth.go`) at the SINGLE Register site (`functions.go:331-332`);
+  `getHistoryReader(ls)` returns the wrapped reader so `stdlib_focus.go:417` ReplayTail
+  is gated. Census confirmed only those two prod callers (`RegisterFocusFuncs` raw-reader
+  path is test-only: stdlib_focus_test.go:600, export_test.go:75; `RegisterStreamFuncs`
+  exposes only add/remove_session_stream, no read primitive). Engine math verified: glob
+  `like` compiles COLON-separated (evaluator.go:285) so `events.*.system.*` `*` crosses
+  DOTS and matches the qualified dotted subject; StreamProvider registered unconditionally
+  (setup.go:245) so `resource.stream.name` resolves (no g776 silent-deny); deny-overrides
+  (engine.go:591-598) returns the matching `principal is plugin` forbid before the new
+  `seed:plugin-stream-read` permit. Fail-closed total (qualify-err / nil-engine
+  capability.go:36 / deny — all stop before ReplayTail at both paths). Subject host-vouched
+  both paths (servers: manifest s.pluginName; Lua: r.pluginName closed over from host-routed
+  delivery name host.go:516 — plugin can't forge). GameID single-source s.cfg.GameID → host
+  WithCA:314 + hostfunc WithGameID:192. 3 Lows: (1) `Declared:true` comment inaccurate for
+  ambient Lua path (no interceptor proves declaration — but ambient hostfuncs are
+  universally available per ADR 05f3v and Declared:true is the LESS restrictive choice,
+  engine forbids are the real gate); (2) no wrapper test for nil-engine path (covered
+  transitively by capability.go guard); (3) plugin may read private scene `.ic` history
+  METADATA (ciphertext stays AuthGuard-gated; pre-existing, not introduced — host.v1 had
+  same exposure pre-xakba). DURABLE LESSON CONFIRMED: gate the SHARED read primitive (here:
+  wrap the HistoryReader once), not one handler — the capability service is never the only
+  path to a primitive when ambient hostfuncs exist.

--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -210,3 +210,24 @@
   nothing reads = harmless. Test mock engines model real interceptor: scope half surfaces
   dc.Attributes["location"] as action attr "dispatch_location" (interceptor.go:208). Non-blocking:
   no single host->ferry->server e2e test (legs proven separately; cross-process needs subprocess).
+- **Two-path stream-read gate, qualify-before-ABAC (xakba R2 READY, 2026-06-19) -- CLEAN dual-gate.**
+  R1 NOT READY: ABAC built resource from UN-qualified req.GetStream() so system forbid never fired;
+  tests used DenyAll+pre-qualified inputs (couldn't catch). R2 FIX: new pluginauthz.AuthorizeStreamRead
+  (streamread.go) eventbus.Qualify(GameID,Stream) BEFORE EvaluateCapabilityAccess on qualified
+  "stream:<qual>"; fail-closed on qualify err (Qualify "" gameID + relative ref -> error). SHARED gate
+  called by BOTH hostcap/servers.go QueryStreamHistory (brokered, both runtimes) AND hostfunc
+  authorizingHistoryReader decorator wrapping f.historyReader at functions.go:331 (ambient Lua path the
+  abac-reviewer flagged in R1) -> runtime-symmetry closed. ReplayTail DIVERGENCE harmless: handler passes
+  RELATIVE req.GetStream() to ReplayTail (servers.go:888) but busHistoryReaderAdapter.ReplayTail
+  (sub_grpc.go:811) re-Qualifies idempotently (Qualify returns events.* unchanged). Declared:true SOUND:
+  stream.history NOT in declarationExemptCapabilities, interceptor proves declaration before handler.
+  Tests have TEETH: recordingEngine asserts EXACT qualified resource "stream:events.main.system.rekey..."
+  (removing qualify flips it -> assert fails) + reader.called==false on deny + fail-closed-on-qualify-err
+  asserts engine NEVER consulted. Fixture channel:abc->channel.abc CORRECT (subjectTokenRe=^[A-Za-z0-9_-]+$
+  rejects colon; channel.abc splits to 2 valid tokens). NON-BLOCKING latent: binary Host.gameID set ONLY
+  via WithCA(ca,gameID) (host.go:136) gated on cfg.CertsDir!=""+CA-load-ok (subsystem.go:309-316); no-mTLS
+  binary plugins DO run (host.go:361 fallback) -> Host.gameID="" -> every binary stream.history fails
+  closed Internal. Lua path UNAFFECTED (WithGameID(cfg.GameID) direct, subsystem.go:195). Fail-closed safe
+  + no-mTLS flagged non-prod, but binary gameID should be independent of CA option. LESSON: gating a
+  capability handler -> rg the underlying read primitive (ReplayTail) across internal/plugin; ambient
+  hostfuncs bypass the interceptor (decorator-wrap the reader, don't just gate the broker handler).

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3842,6 +3842,13 @@ invariants:
       # by operator policy is denied IDENTICALLY through the shared interceptor on
       # both the binary and Lua runtimes (the parity dimension of the M1 strategy).
       - "test/integration/pluginparity/nonscoped_capability_deny_test.go"
+      # Instance-level stream.history gate (holomush-xakba): the shared
+      # AuthorizeStreamRead qualifies + runs the default-deny decision on the
+      # concrete stream, enforced identically on the host.v1 handler and the
+      # ambient Lua hostfunc decorator.
+      - "internal/plugin/pluginauthz/streamread_test.go"
+      - "internal/plugin/hostcap/streamhistory_test.go"
+      - "internal/plugin/hostfunc/streamauth_test.go"
   - id: INV-PLUGIN-51
     scope: INV-PLUGIN
     origin_spec: "docs/superpowers/specs/2026-06-12-plugin-least-privilege-trust-design.md"

--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -406,16 +406,18 @@ func SeedPolicies() []SeedPolicy {
 			DSLText:     `permit(principal is plugin, action in ["read", "write"], resource == "focus:*");`,
 			SeedVersion: 1,
 		},
-		// seed:plugin-cap-stream interaction with the system-namespace forbid
-		// (seed:deny-events-system-read-plugin, action read, when resource.stream.name
-		// like "events.*.system.*"): the forbid's TARGET (resource is stream) does match
-		// the stream:* sentinel, but its WHEN clause evaluates resource.stream.name to the
-		// literal "*" (StreamProvider on a wildcard id), and "*" like "events.*.system.*"
-		// is false — so the forbid does not fire at this type-level gate. Instance-level
-		// system-stream protection therefore lives on paths that re-check a concrete
-		// stream name (the CoreServer player QueryStreamHistory path); the plugin
-		// stream.history handler does not currently do so (pre-existing; tracked in
-		// holomush-xakba).
+		// Stream authorization is two-layer (holomush-kplrr + holomush-xakba):
+		//   1. seed:plugin-cap-stream below is the TYPE-level capability gate the
+		//      interceptor evaluates (resource "stream:*"). The system-namespace
+		//      forbid (seed:deny-events-system-read-plugin, when resource.stream.name
+		//      like "events.*.system.*") cannot fire here: its WHEN clause evaluates
+		//      resource.stream.name to the literal "*" (StreamProvider on a wildcard
+		//      id), and "*" like "events.*.system.*" is false.
+		//   2. seed:plugin-stream-read (further below) is the INSTANCE-level read
+		//      permit the plugin stream.history handler evaluates against the CONCRETE
+		//      stream name (resource "stream:<name>"); there the audit/crypto/system
+		//      forbids match real names and override, so a plugin can read non-system
+		//      streams but not forbidden namespaces.
 		{
 			Name:        "seed:plugin-cap-stream",
 			Description: "Default-permit a declared plugin's stream capability at the type level (INV-PLUGIN-50; operator MAY forbid)",
@@ -426,6 +428,22 @@ func SeedPolicies() []SeedPolicy {
 			Name:        "seed:plugin-cap-audit",
 			Description: "Default-permit a declared plugin's audit capability (DecryptOwnAuditRows) at the type level (INV-PLUGIN-50; operator MAY forbid)",
 			DSLText:     `permit(principal is plugin, action in ["read"], resource == "audit:*");`,
+			SeedVersion: 1,
+		},
+
+		// Instance-level plugin stream read (holomush-xakba). Type-match (resource
+		// is stream) so it matches a CONCRETE stream:<name>, unlike the exact-wildcard
+		// capability gate above. The plugin stream.history handler
+		// (internal/plugin/hostcap/servers.go::QueryStreamHistory) evaluates the
+		// concrete stream against this permit; the audit/crypto_totp/crypto_policy/
+		// system forbids (deny-overrides) carve out the forbidden namespaces. This is
+		// the plugin analogue of seed:player-location-stream-read, minus the
+		// co-location condition (plugins have no location). Read-only: stream writes
+		// (stream.subscription) remain gated solely by the type-level capability.
+		{
+			Name:        "seed:plugin-stream-read",
+			Description: "Permit a declared plugin to read a concrete stream's history; audit/crypto/system forbids override forbidden namespaces (INV-PLUGIN-50; holomush-xakba)",
+			DSLText:     `permit(principal is plugin, action in ["read"], resource is stream);`,
 			SeedVersion: 1,
 		},
 	}

--- a/internal/access/policy/seed_smoke_test.go
+++ b/internal/access/policy/seed_smoke_test.go
@@ -1001,6 +1001,36 @@ func TestSeedSmokePluginDeniedEventsSystemRekeyStream(t *testing.T) {
 }
 
 // Verifies: INV-PLUGIN-50
+func TestSeedSmokePluginDeniedForbiddenStreamNamespaces(t *testing.T) {
+	// End-to-end (real seed engine) proof that the instance-level plugin stream
+	// read (seed:plugin-stream-read, holomush-xakba) is overridden by each
+	// forbidden-namespace forbid at a CONCRETE stream name — not just the rekey
+	// case. Every entry below must be DENIED (deny-overrides beats the permit).
+	for _, streamName := range []string{
+		"events.01GAME01.system.crypto_totp.01CT000.01CID00",
+		"events.01GAME01.system.crypto_policy.01CT000.01CID00",
+		"events.01GAME01.system.somethingelse.01X",
+		"audit.access.01X",
+	} {
+		t.Run(streamName, func(t *testing.T) {
+			engine := createSeedEngine(t, []attribute.AttributeProvider{
+				pluginProvider(map[string]any{"name": "echo-bot"}),
+				streamProvider(map[string]any{"name": streamName}),
+			})
+			decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+				Subject:  access.PluginSubject("echo-bot"),
+				Action:   "read",
+				Resource: "stream:" + streamName,
+			})
+			require.NoError(t, err)
+			assert.False(t, decision.IsAllowed(),
+				"plugin must NOT read forbidden-namespace stream %q; got: %s — %s",
+				streamName, decision.Effect(), decision.Reason())
+		})
+	}
+}
+
+// Verifies: INV-PLUGIN-50
 func TestSeedSmokePluginNonScopedCapabilityPermittedByDefaultSeed(t *testing.T) {
 	// A non-scoped host capability (kv read) is evaluated at the capability type
 	// level (resource "kv:*", as the interceptor supplies it). The per-capability
@@ -1046,6 +1076,31 @@ func TestSeedSmokePluginNonScopedCapabilityDeniedByOperatorForbid(t *testing.T) 
 	require.NoError(t, err)
 	assert.False(t, decision.IsAllowed(),
 		"operator forbid must override the default-permit seed for a declared capability; got: %s — %s",
+		decision.Effect(), decision.Reason())
+}
+
+// Verifies: INV-PLUGIN-50
+func TestSeedSmokePluginStreamReadConcreteNonSystemPermitted(t *testing.T) {
+	// The plugin stream.history handler evaluates the CONCRETE stream name
+	// (stream:<name>, holomush-xakba), not the type-level stream:* sentinel the
+	// interceptor uses. A non-system stream must be permitted by the instance-level
+	// seed (seed:plugin-stream-read) so the handler does not over-deny legitimate
+	// reads; the system/audit/crypto forbids override only the forbidden namespaces
+	// (proven by TestSeedSmokePluginDeniedEventsSystemRekeyStream et al.).
+	const streamName = "events.main.location.01LOCAAAAAAAAAAAAAAAAAA"
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		pluginProvider(map[string]any{"name": "stream-reader"}),
+		streamProvider(map[string]any{"name": streamName}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  access.PluginSubject("stream-reader"),
+		Action:   "read",
+		Resource: "stream:" + streamName,
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(),
+		"plugin should read a concrete non-system stream (seed:plugin-stream-read); got: %s — %s",
 		decision.Effect(), decision.Reason())
 }
 

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSeedPoliciesCount(t *testing.T) {
 	seeds := SeedPolicies()
-	// 39 permit + 9 forbid = 48 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history + 1 presence list_presence_same_location + 1 eykuh.3 plugin world.mutation own-location + 11 holomush-kplrr plugin host-capability default-permit seeds)
-	assert.Len(t, seeds, 48, "expected 48 seed policies (39 permit, 9 forbid)")
+	// 40 permit + 9 forbid = 49 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history + 1 presence list_presence_same_location + 1 eykuh.3 plugin world.mutation own-location + 11 holomush-kplrr plugin host-capability default-permit seeds + 1 holomush-xakba plugin instance-level stream read)
+	assert.Len(t, seeds, 49, "expected 49 seed policies (40 permit, 9 forbid)")
 }
 
 func TestSeedPoliciesAllNamesHaveSeedPrefix(t *testing.T) {
@@ -71,7 +71,7 @@ func TestSeedPoliciesEffectDistribution(t *testing.T) {
 			forbidCount++
 		}
 	}
-	assert.Equal(t, 39, permitCount, "expected 39 permit policies (+11 holomush-kplrr plugin host-capability default-permit seeds)")
+	assert.Equal(t, 40, permitCount, "expected 40 permit policies (+11 holomush-kplrr plugin host-capability default-permit seeds, +1 holomush-xakba plugin instance-level stream read)")
 	assert.Equal(t, 9, forbidCount, "expected 9 forbid policies (+2 phase-5 sub-epic A events.*.system.crypto_totp.* denies + 2 phase-5 sub-epic D events.*.system.crypto_policy.* denies + 2 phase-5 sub-epic E events.*.system.* broad denies)")
 }
 
@@ -136,6 +136,7 @@ func TestSeedPoliciesExpectedNames(t *testing.T) {
 		"seed:plugin-cap-focus",
 		"seed:plugin-cap-stream",
 		"seed:plugin-cap-audit",
+		"seed:plugin-stream-read",
 	}
 
 	seeds := SeedPolicies()

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -137,6 +137,16 @@ func WithCA(ca *tlscerts.CA, gameID string) HostOption {
 	}
 }
 
+// WithGameID sets the host's game ID independently of WithCA (mTLS). The game ID
+// is needed to qualify domain-relative stream references for the QueryStreamHistory
+// instance-level ABAC check (holomush-xakba); wiring it only through WithCA would
+// fail-close stream.history for binary plugins running without mTLS.
+func WithGameID(gameID string) HostOption {
+	return func(h *Host) {
+		h.gameID = gameID
+	}
+}
+
 // WithServiceRegistry configures the host to register plugin-provided services.
 func WithServiceRegistry(r *plugins.ServiceRegistry) HostOption {
 	return func(h *Host) { h.registry = r }
@@ -540,6 +550,15 @@ func (h *Host) GameSettings() settings.GameSettings {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.gameSettings
+}
+
+// GameID returns the host's game ID, used to qualify a domain-relative stream
+// reference before the QueryStreamHistory instance-level ABAC check
+// (holomush-xakba). Satisfies hostcap.HostCapabilities.
+func (h *Host) GameID() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.gameID
 }
 
 // SetIdentityRegistry implements plugins.IdentityRegistryConfigurer.

--- a/internal/plugin/goplugin/host_service_test.go
+++ b/internal/plugin/goplugin/host_service_test.go
@@ -130,6 +130,14 @@ func newTestServer(fc focus.Coordinator, hr plugins.HistoryReader) *pluginHostSe
 		plugins:          make(map[string]*loadedPlugin),
 		focusCoordinator: fc,
 		historyReader:    hr,
+		// QueryStreamHistory now runs an instance-level ABAC check on the concrete
+		// stream (holomush-xakba) which first QUALIFIES the relative ref — so the
+		// test Host needs both an engine and a gameID, or the gate fails closed.
+		// Production always wires both; AllowAll + "main" let the cursor / count /
+		// delegation assertions exercise the happy path. ABAC behavior is covered by
+		// hostcap's streamHistory tests + the seed smoke tests.
+		engine: policytest.AllowAllEngine(),
+		gameID: "main",
 	}
 	return &pluginHostServiceServer{
 		host:       h,
@@ -353,21 +361,21 @@ func TestPresentFocusReturnsErrorWhenCoordinatorFails(t *testing.T) {
 func TestQueryStreamHistoryDelegatesToEventStore(t *testing.T) {
 	es := &stubHistoryReader{
 		replayTailResult: []core.Event{
-			{Stream: "channel:abc", Type: "say", Payload: []byte(`{"text":"hi"}`)},
+			{Stream: "channel.abc", Type: "say", Payload: []byte(`{"text":"hi"}`)},
 		},
 	}
 	srv := newTestServer(nil, es)
 
 	resp, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  10,
 	})
 	require.NoError(t, err)
 	require.Len(t, resp.GetEvents(), 1)
-	assert.Equal(t, "channel:abc", resp.GetEvents()[0].GetStream())
+	assert.Equal(t, "channel.abc", resp.GetEvents()[0].GetStream())
 
 	require.Len(t, es.replayTailCalls, 1)
-	assert.Equal(t, "channel:abc", es.replayTailCalls[0].stream)
+	assert.Equal(t, "channel.abc", es.replayTailCalls[0].stream)
 	assert.Equal(t, 10, es.replayTailCalls[0].count)
 }
 
@@ -376,7 +384,7 @@ func TestQueryStreamHistoryCapsCountAt500(t *testing.T) {
 	srv := newTestServer(nil, es)
 
 	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  1000,
 	})
 	require.NoError(t, err)
@@ -390,7 +398,7 @@ func TestQueryStreamHistoryConvertsNotBeforeMs(t *testing.T) {
 	srv := newTestServer(nil, es)
 
 	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream:      "channel:abc",
+		Stream:      "channel.abc",
 		Count:       10,
 		NotBeforeMs: 1700000000000,
 	})
@@ -404,7 +412,7 @@ func TestQueryStreamHistoryReturnsErrorWhenEventStoreIsNil(t *testing.T) {
 	srv := newTestServer(nil, nil)
 
 	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  10,
 	})
 	require.Error(t, err)
@@ -452,7 +460,7 @@ func TestPresentFocusReturnsErrorWhenHostIsNil(t *testing.T) {
 func TestQueryStreamHistoryReturnsErrorWhenHostIsNil(t *testing.T) {
 	srv := &pluginHostServiceServer{pluginName: "test-plugin"}
 	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  10,
 	})
 	require.Error(t, err)
@@ -464,7 +472,7 @@ func TestQueryStreamHistoryRejectsNegativeCount(t *testing.T) {
 	srv := newTestServer(nil, es)
 
 	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  -5,
 	})
 	require.Error(t, err)
@@ -475,13 +483,13 @@ func TestQueryStreamHistoryPopulatesPerEventCursors(t *testing.T) {
 	evID := ulid.Make()
 	es := &stubHistoryReader{
 		replayTailResult: []core.Event{
-			{ID: evID, Stream: "channel:abc", Type: "say", Payload: []byte(`{}`)},
+			{ID: evID, Stream: "channel.abc", Type: "say", Payload: []byte(`{}`)},
 		},
 	}
 	srv := newTestServer(nil, es)
 
 	resp, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  10,
 	})
 	require.NoError(t, err)
@@ -509,7 +517,7 @@ func TestQueryStreamHistoryDecodesOpaqueBeforeIDCursor(t *testing.T) {
 	require.NotEmpty(t, cursorBytes)
 
 	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  5,
 		Cursor: cursorBytes,
 	})
@@ -524,7 +532,7 @@ func TestQueryStreamHistoryRejectsInvalidCursorBytes(t *testing.T) {
 	srv := newTestServer(nil, es)
 
 	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  5,
 		Cursor: []byte("not-a-valid-cursor"),
 	})
@@ -540,13 +548,13 @@ func TestQueryStreamHistorySetsNextCursorWhenPageFull(t *testing.T) {
 	// When len(events) == count, next_cursor should be populated.
 	evts := make([]core.Event, 0, 3)
 	for range 3 {
-		evts = append(evts, core.Event{ID: ulid.Make(), Stream: "channel:abc", Type: "say", Payload: []byte(`{}`)})
+		evts = append(evts, core.Event{ID: ulid.Make(), Stream: "channel.abc", Type: "say", Payload: []byte(`{}`)})
 	}
 	es := &stubHistoryReader{replayTailResult: evts}
 	srv := newTestServer(nil, es)
 
 	resp, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  3, // exactly count events returned → next_cursor populated
 	})
 	require.NoError(t, err)
@@ -555,13 +563,13 @@ func TestQueryStreamHistorySetsNextCursorWhenPageFull(t *testing.T) {
 
 func TestQueryStreamHistoryNextCursorEmptyWhenFewerEventsThanCount(t *testing.T) {
 	evts := []core.Event{
-		{ID: ulid.Make(), Stream: "channel:abc", Type: "say", Payload: []byte(`{}`)},
+		{ID: ulid.Make(), Stream: "channel.abc", Type: "say", Payload: []byte(`{}`)},
 	}
 	es := &stubHistoryReader{replayTailResult: evts}
 	srv := newTestServer(nil, es)
 
 	resp, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
-		Stream: "channel:abc",
+		Stream: "channel.abc",
 		Count:  10, // more than returned → no more pages
 	})
 	require.NoError(t, err)

--- a/internal/plugin/hostcap/capabilities.go
+++ b/internal/plugin/hostcap/capabilities.go
@@ -112,6 +112,10 @@ type HostCapabilities interface {
 
 	// FocusCoordinator backs the FocusService RPCs (nil ⇒ not configured).
 	FocusCoordinator() focus.Coordinator
+	// GameID returns the game ID used to qualify a domain-relative stream
+	// reference before the QueryStreamHistory instance-level ABAC check
+	// ("" ⇒ unqualifiable ⇒ the gate fails closed; holomush-xakba).
+	GameID() string
 	// HistoryReader backs QueryStreamHistory (nil ⇒ not configured).
 	HistoryReader() plugins.HistoryReader
 	// ReadbackDecryptor backs DecryptOwnAuditRows (nil ⇒ not configured).

--- a/internal/plugin/hostcap/register_test.go
+++ b/internal/plugin/hostcap/register_test.go
@@ -50,6 +50,7 @@ func (stubHostCaps) GameSettings() settings.GameSettings                { return
 func (stubHostCaps) PlayerSettings() settings.PlayerSettingsStore       { return nil }
 func (stubHostCaps) CharacterSettings() settings.CharacterSettingsStore { return nil }
 func (stubHostCaps) FocusCoordinator() focus.Coordinator                { return nil }
+func (stubHostCaps) GameID() string                                     { return "" }
 func (stubHostCaps) HistoryReader() plugins.HistoryReader               { return nil }
 func (stubHostCaps) ReadbackDecryptor() plugins.ReadbackDecryptor       { return nil }
 

--- a/internal/plugin/hostcap/servers.go
+++ b/internal/plugin/hostcap/servers.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus/cursor"
@@ -21,6 +22,7 @@ import (
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/settings"
+	"github.com/holomush/holomush/pkg/errutil"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
 )
@@ -822,6 +824,33 @@ func (s *streamHistoryServer) QueryStreamHistory(ctx context.Context, req *hostv
 	hr := s.host.HistoryReader()
 	if hr == nil {
 		return nil, oops.With("plugin", s.pluginName).New("history reader not configured")
+	}
+
+	// Instance-level ABAC on the concrete stream. The capability interceptor
+	// authorizes stream.history only at the type level (resource "stream:*"), where
+	// the system-namespace / audit / crypto forbids (keyed on the QUALIFIED
+	// resource.stream.name) cannot match. AuthorizeStreamRead qualifies the
+	// domain-relative stream and runs the default-deny capability decision on the
+	// qualified resource — the single shared gate also used by the ambient Lua
+	// holomush.query_stream_history hostfunc, so both runtimes enforce identically
+	// (plugin-runtime-symmetry; holomush-xakba, INV-PLUGIN-50).
+	dec, decErr := pluginauthz.AuthorizeStreamRead(ctx, pluginauthz.StreamReadInput{
+		Engine:     s.host.AccessEngine(),
+		Auditor:    s.host.Auditor(),
+		PluginName: s.pluginName,
+		Subject:    access.PluginSubject(s.pluginName),
+		GameID:     s.host.GameID(),
+		Stream:     req.GetStream(),
+	})
+	if decErr != nil {
+		// Fail closed: log internally, return a generic error (do not leak inner
+		// detail past the gRPC trust boundary — grpc-errors rule).
+		errutil.LogErrorContext(ctx, "plugin stream.history capability check failed", decErr,
+			"plugin", s.pluginName, "stream", req.GetStream())
+		return nil, status.Errorf(codes.Internal, "internal error")
+	}
+	if !dec.Allowed {
+		return nil, status.Errorf(codes.PermissionDenied, "not authorized to read stream")
 	}
 
 	count := int(req.GetCount())

--- a/internal/plugin/hostcap/streamhistory_test.go
+++ b/internal/plugin/hostcap/streamhistory_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostcap_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/hostcap"
+	hostv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/host/v1"
+)
+
+// recordingHistoryReader records whether ReplayTail was reached and with which
+// stream, so a test can assert a denied read never hits the bus.
+type recordingHistoryReader struct {
+	called    bool
+	gotStream string
+}
+
+func (r *recordingHistoryReader) ReplayTail(_ context.Context, stream string, _ int, _ time.Time, _ ulid.ULID) ([]core.Event, error) {
+	r.called = true
+	r.gotStream = stream
+	return nil, nil
+}
+
+// streamHostCaps is a focused HostCapabilities stub for streamHistoryServer
+// tests: a configurable ABAC engine, game ID, and a recording history reader.
+// Everything else inherits stubHostCaps' nil accessors.
+type streamHostCaps struct {
+	stubHostCaps
+	engine types.AccessPolicyEngine
+	gameID string
+	reader plugins.HistoryReader
+}
+
+func (c streamHostCaps) AccessEngine() types.AccessPolicyEngine { return c.engine }
+func (c streamHostCaps) GameID() string                         { return c.gameID }
+func (c streamHostCaps) HistoryReader() plugins.HistoryReader   { return c.reader }
+
+func newStreamServer(engine types.AccessPolicyEngine, reader plugins.HistoryReader) hostv1.StreamHistoryServiceServer {
+	return hostcap.NewStreamHistoryServer(hostcap.NewBase(streamHostCaps{engine: engine, gameID: "main", reader: reader}, "test-plugin"))
+}
+
+// recordingStreamEngine records the resource it is asked to evaluate and denies,
+// so a test can prove the handler QUALIFIES a relative stream before the ABAC
+// check (the bug holomush-xakba fixes: evaluating the un-qualified form).
+type recordingStreamEngine struct{ gotResource string }
+
+func (e *recordingStreamEngine) Evaluate(_ context.Context, req types.AccessRequest) (types.Decision, error) {
+	e.gotResource = req.Resource
+	return types.NewDecision(types.EffectDefaultDeny, "test", ""), nil
+}
+
+func (e *recordingStreamEngine) CanPerformAction(_ context.Context, _, _, _, _ string) (bool, error) {
+	return true, nil
+}
+
+// Verifies: INV-PLUGIN-50
+func TestStreamHistoryQueryStreamHistoryGate(t *testing.T) {
+	// The capability interceptor authorizes stream.history only at the type level
+	// (stream:*); the handler MUST evaluate the concrete stream and reach ReplayTail
+	// ONLY when the gate permits. A denied / wildcard / nil-engine read must fail
+	// closed and never reach ReplayTail; a permitted read is delegated with the
+	// relative ref intact (holomush-xakba).
+	tests := []struct {
+		name         string
+		engine       types.AccessPolicyEngine
+		stream       string
+		wantCode     codes.Code // codes.OK ⇒ expect success
+		wantReplayed bool
+	}{
+		{"policy-denied stream not replayed", policytest.DenyAllEngine(), "system.rekey.01CT000.01CID00", codes.PermissionDenied, false},
+		{"permitted stream replayed", policytest.AllowAllEngine(), "location.01LOCAAAAAAAAAAAAAAAAAA", codes.OK, true},
+		{"wildcard stream rejected", policytest.AllowAllEngine(), "location.>", codes.Internal, false},
+		{"nil engine fails closed", nil, "location.01LOCAAAAAAAAAAAAAAAAAA", codes.Internal, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := &recordingHistoryReader{}
+			srv := newStreamServer(tc.engine, reader)
+
+			_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{Stream: tc.stream})
+			if tc.wantCode == codes.OK {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantCode, status.Code(err))
+			}
+			assert.Equal(t, tc.wantReplayed, reader.called)
+			if tc.wantReplayed {
+				assert.Equal(t, tc.stream, reader.gotStream,
+					"ReplayTail receives the relative ref (the bus adapter re-qualifies)")
+			}
+		})
+	}
+}
+
+// Verifies: INV-PLUGIN-50
+func TestStreamHistoryQualifiesRelativeStreamBeforeABAC(t *testing.T) {
+	// A plugin sends a DOMAIN-RELATIVE stream ref ("system.rekey..."); the handler
+	// MUST qualify it (events.<gameID>.<rel>) before the ABAC check so the
+	// system/audit/crypto forbids (keyed on the qualified resource.stream.name) can
+	// match. Without qualification the resource was "stream:system.rekey..." and no
+	// forbid fired — the holomush-xakba bug.
+	eng := &recordingStreamEngine{}
+	reader := &recordingHistoryReader{}
+	srv := hostcap.NewStreamHistoryServer(hostcap.NewBase(
+		streamHostCaps{engine: eng, gameID: "main", reader: reader}, "test-plugin",
+	))
+
+	_, err := srv.QueryStreamHistory(context.Background(), &hostv1.QueryStreamHistoryRequest{
+		Stream: "system.rekey.01CT000.01CID00", // relative, as a plugin sends it
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, "stream:events.main.system.rekey.01CT000.01CID00", eng.gotResource,
+		"handler must evaluate the QUALIFIED stream so the system forbid can match")
+	assert.False(t, reader.called)
+}

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -54,6 +54,7 @@ type Functions struct {
 	settingsOps      SettingsOps
 	historyReader    HistoryReader
 	auditDecryptor   AuditDecryptor
+	gameID           string
 	// pluginConfigs holds the merged (opaque) config per plugin, set by the
 	// Lua host before Register. nil/absent → empty holomush.config. Guarded by
 	// pluginConfigsMu because SetPluginConfigs/pluginConfigFor run per delivery
@@ -74,6 +75,15 @@ type Option func(*Functions)
 func WithEngine(engine types.AccessPolicyEngine) Option {
 	return func(f *Functions) {
 		f.engine = engine
+	}
+}
+
+// WithGameID sets the game ID used to qualify domain-relative stream references
+// before the stream.history ABAC check (holomush.query_stream_history). Without
+// it the gate cannot qualify and fails closed (holomush-xakba).
+func WithGameID(gameID string) Option {
+	return func(f *Functions) {
+		f.gameID = gameID
 	}
 }
 
@@ -156,6 +166,10 @@ func (f *Functions) SetAuditDecryptor(d AuditDecryptor) {
 // Engine returns the ABAC access policy engine, or nil when unconfigured.
 // Used by the hostcap_adapter to satisfy hostcap.HostCapabilities.AccessEngine.
 func (f *Functions) Engine() types.AccessPolicyEngine { return f.engine }
+
+// GameID returns the game ID used to qualify stream references (may be "" in
+// tests / before wiring; the stream.history gate fails closed if so).
+func (f *Functions) GameID() string { return f.gameID }
 
 // Auditor returns the plugin-authz auditor, or nil when unconfigured.
 // Used by the hostcap_adapter to satisfy hostcap.HostCapabilities.Auditor.
@@ -310,8 +324,12 @@ func (f *Functions) Register(ls *lua.LState, pluginName string, requires ...stri
 	// Register the stream.history read-back (query_stream_history). The `focus`
 	// capability functions that used to ship alongside it (RegisterFocusFuncs)
 	// are retired to the host-brokered path (spec R1); stream.history is not one
-	// of the ten retired capabilities and stays ambient.
-	RegisterStreamHistoryFunc(ls, mod, f.historyReader)
+	// of the ten retired capabilities and stays ambient. The reader is wrapped
+	// with the instance-level stream-read ABAC gate so the ambient path enforces
+	// identically to the host.v1 StreamHistoryService handler (holomush-xakba,
+	// plugin-runtime-symmetry).
+	RegisterStreamHistoryFunc(ls, mod,
+		newAuthorizingHistoryReader(f.historyReader, f.engine, f.auditor, f.gameID, pluginName))
 
 	// Register audit read-back decrypt functions.
 	RegisterAuditFuncs(ls, mod, pluginName, f.auditDecryptor)

--- a/internal/plugin/hostfunc/streamauth.go
+++ b/internal/plugin/hostfunc/streamauth.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// authorizingHistoryReader wraps a HistoryReader with the same instance-level
+// ABAC gate the host.v1 StreamHistoryService handler runs
+// (pluginauthz.AuthorizeStreamRead), so the ambient Lua
+// holomush.query_stream_history path enforces identically to the brokered path
+// (plugin-runtime-symmetry). Without this the ambient hostfunc reached
+// ReplayTail with zero ABAC, letting a Lua plugin read events.<gid>.system.* /
+// audit.* / crypto streams (holomush-xakba).
+type authorizingHistoryReader struct {
+	inner      HistoryReader
+	engine     types.AccessPolicyEngine
+	auditor    pluginauthz.Auditor
+	gameID     string
+	pluginName string
+}
+
+// newAuthorizingHistoryReader wraps inner with the stream-read gate. Returns nil
+// when inner is nil so the caller's nil-reader no-op path is preserved.
+func newAuthorizingHistoryReader(inner HistoryReader, engine types.AccessPolicyEngine, auditor pluginauthz.Auditor, gameID, pluginName string) HistoryReader {
+	if inner == nil {
+		return nil
+	}
+	return &authorizingHistoryReader{
+		inner:      inner,
+		engine:     engine,
+		auditor:    auditor,
+		gameID:     gameID,
+		pluginName: pluginName,
+	}
+}
+
+func (r *authorizingHistoryReader) ReplayTail(ctx context.Context, stream string, count int, notBefore time.Time, beforeID ulid.ULID) ([]core.Event, error) {
+	dec, err := pluginauthz.AuthorizeStreamRead(ctx, pluginauthz.StreamReadInput{
+		Engine:     r.engine,
+		Auditor:    r.auditor,
+		PluginName: r.pluginName,
+		Subject:    access.PluginSubject(r.pluginName),
+		GameID:     r.gameID,
+		Stream:     stream,
+	})
+	if err != nil {
+		return nil, err //nolint:wrapcheck // pluginauthz already wraps with oops context
+	}
+	if !dec.Allowed {
+		return nil, oops.Code("STREAM_ACCESS_DENIED").
+			With("plugin", r.pluginName).With("stream", stream).
+			Errorf("not authorized to read stream")
+	}
+	events, err := r.inner.ReplayTail(ctx, stream, count, notBefore, beforeID)
+	if err != nil {
+		return nil, oops.With("plugin", r.pluginName).With("stream", stream).Wrap(err)
+	}
+	return events, nil
+}

--- a/internal/plugin/hostfunc/streamauth_test.go
+++ b/internal/plugin/hostfunc/streamauth_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/core"
+)
+
+type recordingInnerReader struct{ called bool }
+
+func (r *recordingInnerReader) ReplayTail(_ context.Context, _ string, _ int, _ time.Time, _ ulid.ULID) ([]core.Event, error) {
+	r.called = true
+	return nil, nil
+}
+
+// Verifies: INV-PLUGIN-50
+func TestAuthorizingHistoryReaderReplayTail(t *testing.T) {
+	// The ambient Lua query_stream_history path is gated by wrapping the reader.
+	// Each case asserts that the wrapped ReplayTail delegates to the inner reader
+	// ONLY when the gate permits — a denied/misconfigured/wildcard read must never
+	// reach the inner ReplayTail (holomush-xakba, plugin-runtime-symmetry with the
+	// host.v1 handler).
+	tests := []struct {
+		name          string
+		engine        types.AccessPolicyEngine
+		stream        string
+		wantDelegated bool
+	}{
+		{"policy-denied stream is not delegated", policytest.DenyAllEngine(), "system.rekey.01CT000.01CID00", false},
+		{"permitted stream is delegated", policytest.AllowAllEngine(), "location.01LOCAAAAAAAAAAAAAAAAAA", true},
+		{"nil engine fails closed", nil, "location.01LOCAAAAAAAAAAAAAAAAAA", false},
+		{"wildcard is rejected even under allow-all", policytest.AllowAllEngine(), "location.>", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inner := &recordingInnerReader{}
+			hr := newAuthorizingHistoryReader(inner, tc.engine, nil, "main", "echo-bot")
+
+			_, err := hr.ReplayTail(context.Background(), tc.stream, 10, time.Time{}, ulid.ULID{})
+			if tc.wantDelegated {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			assert.Equal(t, tc.wantDelegated, inner.called)
+		})
+	}
+}
+
+// Verifies: INV-PLUGIN-50
+func TestQueryStreamHistoryLuaPathEnforcesGate(t *testing.T) {
+	// End-to-end Lua call chain: holomush.query_stream_history → Register-wrapped
+	// reader → AuthorizeStreamRead. A denied system stream must return nil + an
+	// error to Lua and never reach the inner reader (closes the fw118.6 gap where
+	// the ambient hostfunc tests wired the raw reader, bypassing the gate).
+	inner := &recordingInnerReader{}
+	f := New(nil,
+		WithEngine(policytest.DenyAllEngine()),
+		WithGameID("main"),
+		WithHistoryReader(inner))
+	L := lua.NewState()
+	defer L.Close()
+	f.Register(L, "echo-bot")
+
+	require.NoError(t, L.DoString(`result, errmsg = holomush.query_stream_history({stream="system.rekey.01CT000.01CID00", count=5})`))
+	assert.Equal(t, lua.LNil, L.GetGlobal("result"), "a denied stream read must return nil")
+	assert.NotEqual(t, lua.LNil, L.GetGlobal("errmsg"), "a denied stream read must return an error message")
+	assert.False(t, inner.called, "the ABAC gate must deny before the inner reader is reached")
+}
+
+func TestNewAuthorizingHistoryReaderNilInnerStaysNil(t *testing.T) {
+	// Preserves the caller's nil-reader no-op path (RegisterStreamHistoryFunc skips
+	// stashing a nil reader).
+	require.Nil(t, newAuthorizingHistoryReader(nil, policytest.AllowAllEngine(), nil, "main", "echo-bot"))
+}

--- a/internal/plugin/lua/hostcap_adapter.go
+++ b/internal/plugin/lua/hostcap_adapter.go
@@ -97,6 +97,13 @@ func (a *luaHostCapAdapter) Auditor() pluginauthz.Auditor {
 	return a.f.Auditor()
 }
 
+// GameID returns the game ID from the Functions backing, used to qualify a
+// domain-relative stream reference before the QueryStreamHistory ABAC check
+// (holomush-xakba). Satisfies hostcap.HostCapabilities.
+func (a *luaHostCapAdapter) GameID() string {
+	return a.f.GameID()
+}
+
 // EventEmitter returns nil: Lua event emissions flow through hostfuncs (holomush.emit),
 // not through the gRPC EmitEvent RPC. The emitServer's nil-guard covers this.
 func (a *luaHostCapAdapter) EventEmitter() plugins.PluginIntentEmitter {

--- a/internal/plugin/pluginauthz/streamread.go
+++ b/internal/plugin/pluginauthz/streamread.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginauthz
+
+import (
+	"context"
+	"strings"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/eventbus"
+)
+
+// StreamReadInput is the input to AuthorizeStreamRead. Subject is host-derived
+// (access.PluginSubject(PluginName), built by the caller — pluginauthz does not
+// depend on internal/access); Stream is the domain-relative reference the plugin
+// supplied; GameID qualifies it.
+type StreamReadInput struct {
+	Engine     types.AccessPolicyEngine
+	Auditor    Auditor
+	PluginName string
+	Subject    string
+	GameID     string
+	Stream     string // domain-relative (e.g. "location.<id>", "system.rekey.<ct>.<cid>")
+}
+
+// AuthorizeStreamRead is the single shared gate for a plugin reading stream
+// history. It is reached by BOTH the host.v1 StreamHistoryService handler and the
+// ambient Lua holomush.query_stream_history hostfunc so the two runtimes enforce
+// identically (plugin-runtime-symmetry).
+//
+// It QUALIFIES the domain-relative stream (events.<gameID>.<rel>) before
+// evaluating, because the system/audit/crypto stream forbids
+// (seed:deny-events-system-read-plugin et al.) key on the qualified
+// resource.stream.name — evaluating the un-qualified form lets system reads slip
+// past every forbid (holomush-xakba). It then runs the default-deny capability
+// decision (EvaluateCapabilityAccess; stream is not a plugin-owned type, so the
+// capability-entitlement path is required) on the qualified resource. Fails
+// closed: a qualify error yields a non-allowing Decision and a non-nil error.
+func AuthorizeStreamRead(ctx context.Context, in StreamReadInput) (Decision, error) {
+	// Require a domain-relative reference, fail closed. eventbus.Qualify passes an
+	// already-"events."-prefixed subject through UNCHANGED, so a pre-qualified ref
+	// would (a) skip host-gameID scoping — letting a plugin in one game read another
+	// game's concrete streams under a shared backing store — and (b) bypass the
+	// gameID the host controls. Producers emit domain-relative refs by convention
+	// (.claude/rules/event-conventions.md); forcing relative here guarantees Qualify
+	// scopes every plugin read to the host's own game (holomush-xakba / fw118.4).
+	if strings.HasPrefix(in.Stream, "events.") {
+		return Decision{}, oops.Code("STREAM_NOT_RELATIVE").
+			With("plugin", in.PluginName).With("stream", in.Stream).
+			Errorf("plugin stream reads must use a domain-relative reference, not a pre-qualified subject")
+	}
+	qualified, qErr := eventbus.Qualify(in.GameID, in.Stream)
+	if qErr != nil {
+		return Decision{}, oops.Code("STREAM_QUALIFY_FAILED").
+			With("plugin", in.PluginName).With("stream", in.Stream).Wrap(qErr)
+	}
+	// Reject wildcard subjects, fail closed. NewSubject permits the NATS wildcard
+	// tokens '*' and '>', but a stream.history read MUST target a CONCRETE stream:
+	// a wildcard (e.g. ">" → "events.<gid>.>") is a read-across-all-streams that the
+	// system/audit/crypto forbids — keyed on a concrete .system./audit/crypto
+	// segment — cannot match, so the unconditional seed:plugin-stream-read permit
+	// would grant it and ReplayTail would read every stream including the forbidden
+	// namespaces. Concrete subject tokens are [A-Za-z0-9_-]+ (never '*'/'>'), so a
+	// surviving wildcard token is unambiguous (holomush-xakba).
+	if strings.ContainsAny(string(qualified), "*>") {
+		return Decision{}, oops.Code("STREAM_WILDCARD_FORBIDDEN").
+			With("plugin", in.PluginName).With("stream", in.Stream).
+			Errorf("wildcard stream subjects are not permitted for plugin history reads")
+	}
+	return EvaluateCapabilityAccess(ctx, CapabilityInput{
+		Engine:     in.Engine,
+		Auditor:    in.Auditor,
+		PluginName: in.PluginName,
+		Subject:    in.Subject,
+		Action:     types.ActionRead,
+		Resource:   "stream:" + string(qualified),
+		// host.v1 path: the capability interceptor proved declaration before the
+		// handler is reachable. Ambient Lua path: stream.history is universally
+		// available (ADR holomush-05f3v), so there is no per-plugin declaration to
+		// prove — Declared:true is intentional, and the engine decision (permit
+		// minus the system/audit/crypto forbids) is the operative gate either way.
+		Declared: true,
+	})
+}

--- a/internal/plugin/pluginauthz/streamread_test.go
+++ b/internal/plugin/pluginauthz/streamread_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginauthz_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// recordingEngine captures the AccessRequest it is handed and returns a fixed
+// decision, so a test can assert what resource AuthorizeStreamRead evaluates.
+type recordingEngine struct {
+	gotResource string
+	allow       bool
+}
+
+func (e *recordingEngine) Evaluate(_ context.Context, req types.AccessRequest) (types.Decision, error) {
+	e.gotResource = req.Resource
+	if e.allow {
+		return types.NewDecision(types.EffectAllow, "test", "test:permit"), nil
+	}
+	return types.NewDecision(types.EffectDefaultDeny, "test", ""), nil
+}
+
+func (e *recordingEngine) CanPerformAction(_ context.Context, _, _, _, _ string) (bool, error) {
+	return true, nil
+}
+
+// Verifies: INV-PLUGIN-50
+func TestAuthorizeStreamReadQualifiesRelativeStreamBeforeEvaluating(t *testing.T) {
+	// The plugin sends a DOMAIN-RELATIVE stream reference; the gate MUST qualify it
+	// (events.<gameID>.<rel>) before evaluating, so the system/audit/crypto forbids
+	// (keyed on the qualified resource.stream.name) can match. This is the bug
+	// holomush-xakba fixes: evaluating the un-qualified form let system reads slip
+	// past the forbid.
+	eng := &recordingEngine{allow: true}
+	dec, err := pluginauthz.AuthorizeStreamRead(context.Background(), pluginauthz.StreamReadInput{
+		Engine:     eng,
+		PluginName: "p",
+		Subject:    access.PluginSubject("p"),
+		GameID:     "main",
+		Stream:     "system.rekey.01CT000.01CID00", // domain-relative
+	})
+	require.NoError(t, err)
+	assert.True(t, dec.Allowed)
+	assert.Equal(t, "stream:events.main.system.rekey.01CT000.01CID00", eng.gotResource,
+		"the ABAC resource must be the QUALIFIED stream so forbids can match")
+}
+
+// Verifies: INV-PLUGIN-50
+func TestAuthorizeStreamReadRejectsBeforeEngine(t *testing.T) {
+	// Inputs that must fail closed BEFORE the engine is consulted (the engine's
+	// gotResource must stay empty):
+	//   - unqualifiable refs (no gameID) → STREAM_QUALIFY_FAILED;
+	//   - wildcard subjects ('>' / '*') → a read-across-all-streams the
+	//     concrete-name system/audit/crypto forbids cannot match (fw118.4);
+	//   - pre-qualified ("events."-prefixed) refs → would skip host-gameID scoping
+	//     and allow cross-game reads (fw118.4 residual).
+	tests := []struct {
+		name, gameID, stream string
+	}{
+		{"unqualifiable: no game id", "", "system.rekey.x"},
+		{"wildcard: bare >", "main", ">"},
+		{"wildcard: trailing .>", "main", "location.>"},
+		{"wildcard: * token", "main", "scene.*.ic"},
+		{"wildcard: pre-qualified .>", "main", "events.main.>"},
+		{"wildcard: cross-game .>", "main", "events.other.>"},
+		{"pre-qualified: own game concrete", "main", "events.main.location.01LOCAAAAAAAAAAAAAAAAAA"},
+		{"pre-qualified: cross-game concrete", "main", "events.other.location.01LOCAAAAAAAAAAAAAAAAAA"},
+		{"pre-qualified: system", "main", "events.main.system.rekey.01CT000.01CID00"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			eng := &recordingEngine{allow: true}
+			_, err := pluginauthz.AuthorizeStreamRead(context.Background(), pluginauthz.StreamReadInput{
+				Engine:     eng,
+				PluginName: "p",
+				Subject:    access.PluginSubject("p"),
+				GameID:     tc.gameID,
+				Stream:     tc.stream,
+			})
+			require.Error(t, err, "%q must be rejected", tc.stream)
+			assert.Empty(t, eng.gotResource, "must be rejected before the engine is consulted")
+		})
+	}
+}
+
+// Verifies: INV-PLUGIN-50
+func TestAuthorizeStreamReadDeniesWhenPolicyDenies(t *testing.T) {
+	eng := &recordingEngine{allow: false}
+	dec, err := pluginauthz.AuthorizeStreamRead(context.Background(), pluginauthz.StreamReadInput{
+		Engine:     eng,
+		PluginName: "p",
+		Subject:    access.PluginSubject("p"),
+		GameID:     "main",
+		Stream:     "system.rekey.x", // domain-relative
+	})
+	require.NoError(t, err)
+	assert.False(t, dec.Allowed)
+}

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -190,6 +190,9 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		hostfunc.WithWorldService(s.cfg.World.Service()),
 		hostfunc.WithSessionAccess(sessionStore),
 		hostfunc.WithCapabilities(capRegistry),
+		// Qualifies domain-relative stream refs before the ambient
+		// query_stream_history ABAC gate (holomush-xakba).
+		hostfunc.WithGameID(s.cfg.GameID),
 	}
 	if s.cfg.StreamRegistry != nil {
 		hostFuncOpts = append(hostFuncOpts, hostfunc.WithStreamRegistry(s.cfg.StreamRegistry))
@@ -283,6 +286,9 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		hostOpts,
 		goplugin.WithSchemaProvisioner(schemaProvisioner),
 		goplugin.WithServiceRegistry(s.registry),
+		// Game ID for stream qualification, wired unconditionally (independent of
+		// WithCA/mTLS) so stream.history works for no-mTLS binary plugins (holomush-xakba).
+		goplugin.WithGameID(s.cfg.GameID),
 		// Wire the ABAC engine so host.v1 EvalService.Evaluate resolves (holomush-8kkv5.18).
 		// This MUST use the same engine instance as s.cfg.ABAC.Engine() above — the Lua
 		// hostfunc bridge (hostfunc.WithEngine) is wired from the same call, and the


### PR DESCRIPTION
## Summary

Closes a pre-existing access-control gap: a declared read-access plugin could read `events.<gid>.system.*` / `audit.*` / crypto stream history. The plugin `stream.history` capability was authorized only at the **type** level (interceptor, resource `stream:*`), where the system/audit/crypto stream forbids — keyed on the **qualified** `resource.stream.name` — cannot match; the handler then `ReplayTail`'d the requested stream with no per-stream ABAC. **Two** production paths were affected: the host.v1 `StreamHistoryService` handler (binary + Lua-via-bufconn) and the ambient Lua `holomush.query_stream_history` hostfunc (which reached `ReplayTail` with zero ABAC).

Resolved with a single **shared cross-runtime gate** (plugin-runtime-symmetry):

- **`pluginauthz.AuthorizeStreamRead`** qualifies the domain-relative stream via `eventbus.Qualify(gameID, stream)` **before** the default-deny capability decision on the **qualified** resource; fails closed on a qualify error.
- **host.v1 handler** (`hostcap/servers.go::QueryStreamHistory`) calls it with `s.host.GameID()`.
- **ambient Lua hostfunc**: the reader is wrapped in an `authorizingHistoryReader` decorator (`hostfunc/streamauth.go`) that calls the same gate before delegating; `queryStreamHistoryFn` is untouched.
- **gameID** plumbed via `GameID()` on `HostCapabilities` (`goplugin.Host`, `luaHostCapAdapter`) + `Functions.gameID`; `goplugin.WithGameID` wired **unconditionally** (independent of mTLS) so no-mTLS binary plugins are covered.
- **`seed:plugin-stream-read`** (`permit(plugin, read, resource is stream)`) is the instance-level permit; the audit/crypto/system forbids override at concrete names. `cap-stream` (exact `stream:*`) stays the type-level capability gate.

INV-PLUGIN-50 is now enforced at the instance level for plugin stream reads, symmetrically across runtimes.

### Pre-push review gates
`abac-reviewer`: **READY** · `code-reviewer`: **READY** (turn 2; both turn-1 blocking findings — un-qualified resource, ungated ambient Lua path — resolved; post-review fixes: unconditional `WithGameID`, comment accuracy, nil-engine wrapper test).

### Follow-up filed
- Decide whether plugins with `stream.history` may read private scene `.ic` stream **metadata** (pre-existing; plaintext is DEK-protected).

## Test Plan
- [x] `task pr-prep` (fast lane) green
- [x] Unit: shared-helper qualify-proof, handler relative-input qualify-proof (`TestStreamHistoryQualifiesRelativeStreamBeforeABAC`), decorator deny/permit/nil-engine, seed_smoke permit + system/audit forbid guards; full unit sweep (7863)
- [x] Integration: `pluginparity` + `wholesystem`
- [x] lint 0 · fmt/license clean
- [ ] CI required: Integration Test + E2E Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)