### PR TITLE
fix(compose): put dev otel-collector on the frontend network so the gateway can export OTLP (holomush-bpy6p)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -70,7 +70,8 @@ services:
       # default: the dev observability flow (`task dev` + `task dev:obs`) points
       # PUBLIC_OTEL_ENDPOINT straight at localhost:4318, so the relay isn't on
       # the dev path. Set to http://otel-collector:4318 to exercise the relay
-      # in compose (the gateway would also need the `backend` network).
+      # in compose — the collector is on both networks, so otel-collector:4318
+      # resolves from the gateway's frontend network.
       OTLP_RELAY_ENDPOINT: ${OTLP_RELAY_ENDPOINT-}
       SENTRY_DSN: ${SENTRY_DSN-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT-dev-local}
@@ -94,6 +95,10 @@ services:
       - ./docker/otel-collector/config.yaml:/etc/otelcol-contrib/config.yaml
     networks:
       - backend
+      # Gateway is frontend-only but exports OTLP to otel-collector:4317, so the
+      # collector must also be on frontend or the gateway's gRPC exporter fails
+      # DNS resolution ("produced zero addresses"). Mirrors compose.prod.yaml.
+      - frontend
     ports:
       - "4317:4317"
       - "4318:4318"


### PR DESCRIPTION
## Summary

Under `task dev:obs`, `gateway-1` spammed `telemetry SDK error … name resolver error: produced zero addresses` every ~10s and its spans never reached Jaeger/Grafana. Root cause is a dev-compose **network mismatch**: the `gateway` exports OTLP to `otel-collector:4317` but was attached to the `frontend` network only, while `otel-collector` was on `backend` only — they shared no network, so the gateway's gRPC exporter could not DNS-resolve the collector. `core` (on both networks) was unaffected, which is why only `gateway-1` errored.

This adds `frontend` to the `otel-collector` service's networks so it is on `[backend, frontend]` — **mirroring `compose.prod.yaml`**, which already puts the collector on both networks for exactly this reason (the gateway is `frontend`-only in prod too). Compose auto-registers the `otel-collector` service alias on every attached network, so the gateway resolves it on first boot.

Chosen over adding the gateway to `backend`, which would widen the gateway's reach to the DB/backend services and diverge from prod; collector-on-frontend keeps the gateway's network minimal and reduces dev↔prod drift.

## Root cause evidence

- `gateway` → `frontend` only (`compose.yaml:82`), exports to `http://otel-collector:4317` (`compose.yaml:68`).
- `otel-collector` → `backend` only (before this change).
- `core` → `[backend, frontend]` → unaffected.
- Live DNS test on the running stack: `core` resolved `otel-collector`; the gateway could not.
- Longstanding, not a regression — recent `compose.yaml` commits were image-digest bumps only.

## Validation

- A fresh container on the `frontend` network resolves `otel-collector` → `172.18.0.4`.
- Restarting the gateway with the collector reachable (reproduces the fixed startup order) → **0** `produced zero addresses` errors; clean `gateway process ready` startup.
- `task pr-prep` (fast lane): **pass**.
- `code-reviewer`: **READY**, no blocking findings.

## Test plan

- `task dev:obs` → `gateway-1` no longer logs telemetry export errors; gateway spans appear in Jaeger (http://localhost:16686).

Resolves `holomush-bpy6p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
