### PR TITLE
fix(observability): detach keepalive into its own trace + migrate dev Jaeger v1→v2 (holomush-m7djf, holomush-lz92t)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -101,10 +101,13 @@ services:
       - jaeger
 
   jaeger:
-    image: jaegertracing/all-in-one:latest@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    # Jaeger v2 all-in-one (jaegertracing/jaeger). The v1 jaegertracing/all-in-one
+    # image is end-of-life (Dec 31 2025). v2 runs with a built-in all-in-one default
+    # config — memory storage, OTLP receivers on 4317/4318, UI on 16686 — so the
+    # v1-only COLLECTOR_OTLP_ENABLED env var is dropped (OTLP is on by default). The
+    # otel-collector still forwards traces to jaeger:4317 via OTLP (docker/otel-collector/config.yaml).
+    image: jaegertracing/jaeger:latest@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     profiles: [observability]
-    environment:
-      COLLECTOR_OTLP_ENABLED: "true"
     networks:
       - backend
     ports:

--- a/internal/telemetry/detach.go
+++ b/internal/telemetry/detach.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// DetachTrace starts a NEW-ROOT span for periodic or background work that must
+// not be parented under a long-lived operation's span.
+//
+// Parenting periodic work (e.g. a 15s connection-lease keepalive) under a
+// connection-lifetime span orphans the trace: the long-lived parent is not
+// exported until the operation finally ends, so every child renders as a
+// rootless span carrying an "invalid parent span IDs" warning, and the trace
+// grows unbounded for the connection's whole life. Starting a new root per call
+// keeps each unit of work in its own complete, bounded trace.
+//
+// When ctx carries a span, a Link back to it is added so the detached trace can
+// still be correlated to the originating operation. The caller MUST End the
+// returned span.
+func DetachTrace(ctx context.Context, tracer trace.Tracer, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	startOpts := []trace.SpanStartOption{trace.WithNewRoot()}
+	if parent := trace.SpanContextFromContext(ctx); parent.IsValid() {
+		startOpts = append(startOpts, trace.WithLinks(trace.Link{SpanContext: parent}))
+	}
+	startOpts = append(startOpts, opts...)
+	return tracer.Start(ctx, spanName, startOpts...)
+}

--- a/internal/telemetry/detach_test.go
+++ b/internal/telemetry/detach_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/holomush/holomush/internal/telemetry"
+)
+
+func TestDetachTraceStartsNewRootLinkedToParentSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	tracer := tp.Tracer("test")
+
+	parentCtx, parent := tracer.Start(context.Background(), "connection")
+	parentSC := parent.SpanContext()
+
+	_, detached := telemetry.DetachTrace(parentCtx, tracer, "gateway.lease_refresh")
+	detached.End()
+	parent.End()
+
+	var refresh sdktrace.ReadOnlySpan
+	for _, s := range sr.Ended() {
+		if s.Name() == "gateway.lease_refresh" {
+			refresh = s
+		}
+	}
+	require.NotNil(t, refresh, "detached span was not recorded")
+
+	assert.NotEqual(t, parentSC.TraceID(), refresh.SpanContext().TraceID(),
+		"detached span must start a new trace, not inherit the connection trace")
+	assert.False(t, refresh.Parent().IsValid(),
+		"detached span must be a root (no parent span)")
+
+	links := refresh.Links()
+	require.Len(t, links, 1, "detached span must carry exactly one link to the originating span")
+	assert.Equal(t, parentSC.TraceID(), links[0].SpanContext.TraceID())
+	assert.Equal(t, parentSC.SpanID(), links[0].SpanContext.SpanID())
+}
+
+func TestDetachTraceWithoutParentSpanIsRootWithNoLink(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	tracer := tp.Tracer("test")
+
+	_, detached := telemetry.DetachTrace(context.Background(), tracer, "gateway.lease_refresh")
+	detached.End()
+
+	ended := sr.Ended()
+	require.Len(t, ended, 1)
+	assert.False(t, ended[0].Parent().IsValid())
+	assert.Empty(t, ended[0].Links(), "no parent span ⇒ no link recorded")
+}

--- a/internal/telnet/gateway_handler.go
+++ b/internal/telnet/gateway_handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/gatewaymetrics"
 	grpcclient "github.com/holomush/holomush/internal/grpc"
+	"github.com/holomush/holomush/internal/telemetry"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 )
 
@@ -934,14 +935,18 @@ func (h *GatewayHandler) refreshOnce(ctx context.Context) {
 	if !h.authed || h.sessionID == "" {
 		return
 	}
-	rCtx, rCancel := context.WithTimeout(ctx, rpcTimeout)
+	// Detach into its own trace root so the periodic refresh does not orphan
+	// the long-lived connection trace (holomush-m7djf).
+	rCtx, rSpan := telemetry.DetachTrace(ctx, tracer, "gateway.lease_refresh")
+	defer rSpan.End()
+	rCtx, rCancel := context.WithTimeout(rCtx, rpcTimeout)
 	defer rCancel()
 	if _, err := h.client.RefreshConnection(rCtx, &corev1.RefreshConnectionRequest{
 		SessionId:          h.sessionID,
 		ConnectionId:       h.connectionID,
 		PlayerSessionToken: h.playerSessionToken,
 	}); err != nil {
-		slog.DebugContext(ctx, "gateway: lease refresh failed (transient)", "session_id", h.sessionID, "error", err)
+		slog.DebugContext(rCtx, "gateway: lease refresh failed (transient)", "session_id", h.sessionID, "error", err)
 	}
 }
 

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -14,11 +14,13 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/samber/oops"
+	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/telemetry"
 	contentv1 "github.com/holomush/holomush/pkg/proto/holomush/content/v1"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 	sceneaccessv1 "github.com/holomush/holomush/pkg/proto/holomush/sceneaccess/v1"
@@ -35,6 +37,9 @@ const (
 	// configured an explicit ceiling. Well under the 30m session reattach TTL.
 	defaultReconnectCeiling = 2 * time.Minute
 )
+
+// tracer emits gateway web-side spans (e.g. the detached lease-refresh trace).
+var tracer = otel.Tracer("holomush.web")
 
 // errStreamClosed is a sentinel to signal that the stream was closed by the server.
 var errStreamClosed = errors.New("stream closed")
@@ -458,16 +463,20 @@ func (h *Handler) runSubscribeOnce(
 				return breakClientGone, opened
 			}
 			// Refresh the server-side liveness lease for this connection (I-LIVE-1).
-			// Failure is transient — log at Debug and keep the stream open.
-			refreshCtx, refreshCancel := context.WithTimeout(ctx, rpcTimeout)
+			// Detach into its own trace root so the periodic refresh does not orphan
+			// the long-lived StreamEvents trace (holomush-m7djf). Failure is
+			// transient — log at Debug and keep the stream open.
+			refreshCtx, refreshSpan := telemetry.DetachTrace(ctx, tracer, "gateway.lease_refresh")
+			refreshCtx, refreshCancel := context.WithTimeout(refreshCtx, rpcTimeout)
 			if _, refreshErr := h.client.RefreshConnection(refreshCtx, &corev1.RefreshConnectionRequest{
 				SessionId:          sessionID,
 				ConnectionId:       connID,
 				PlayerSessionToken: token,
 			}); refreshErr != nil {
-				slog.DebugContext(ctx, "web: lease refresh failed (transient)", "session_id", sessionID, "error", refreshErr)
+				slog.DebugContext(refreshCtx, "web: lease refresh failed (transient)", "session_id", sessionID, "error", refreshErr)
 			}
 			refreshCancel()
+			refreshSpan.End()
 
 		case result, ok := <-recvCh:
 			if !ok {


### PR DESCRIPTION
Two related fixes for the dev observability stack, surfaced while investigating a broken-looking Jaeger trace under `task dev:obs`.

## 1. Detach the keepalive into its own trace (`holomush-m7djf`)

The 15s connection-lease keepalive (`CoreService.RefreshConnection`) inherited the connection's long-lived `ctx`, so its otelgrpc **client** span was parented under the still-open `StreamEvents` (web) / telnet server span. A long-lived connection is **by design** — but that means the parent span never exports while the connection lives, so Jaeger renders a **rootless trace**: every keepalive span warns `invalid parent span IDs`, the span-detail panel renders blank, and the trace grows unbounded (a held-open root span per live connection).

> Confirmed via the Jaeger API: one trace = **142 spans, 0 roots**, all referencing an absent parent (`e3c4016f…` = the open stream span).

**Fix:** new `internal/telemetry/DetachTrace` starts a **new-root** span (`trace.WithNewRoot()`) with a **Link** back to the connection span for correlation. Applied at both keepalive sites — web (`internal/web/handler.go`) and telnet (`refreshOnce`, `internal/telnet/gateway_handler.go`) — so each keepalive is its own complete, bounded trace. Unit tests (`detach_test.go`) prove the new-root + link behavior and the no-parent path.

## 2. Migrate dev Jaeger v1 → v2 (`holomush-lz92t`)

The dev stack ran `jaegertracing/all-in-one` = **Jaeger v1.76.0, EOL since 2025-12-31** (the container prints the 🛑 notice; `:latest` is frozen on dead v1 because v2 ships as `jaegertracing/jaeger`).

**Fix:** migrate to `jaegertracing/jaeger` v2 and drop the v1-only `COLLECTOR_OTLP_ENABLED` env (v2 runs an all-in-one default config: memory storage + OTLP receivers 4317/4318 + UI 16686). The otel-collector still forwards to `jaeger:4317` via **OTLP**, which v2 accepts natively — **no collector-config change**.

## Validation

- `task build` ✓; `task test ./internal/telemetry/ ./internal/web/ ./internal/telnet/` ✓ (422 tests, incl. 2 new DetachTrace tests).
- `task pr-prep` (fast lane): **pass**.
- Jaeger v2 standalone: `v2.19.0`, `No '--config' flags … default All-in-One configuration with memory storage`, UI HTTP 200, OTLP `:4317`/`:4318` up.
- `code-reviewer`: fix reviewed **READY** on the merits (DetachTrace semantics, both call sites symmetric, ctx values preserved, tests genuine, v2 migration correct).

## Test plan

- `task dev:obs` → Jaeger v2 UI at http://localhost:16686 (no EOL warning); keepalive traces are separate, rooted, and free of `invalid parent span IDs` warnings; the long-lived connection trace is no longer orphaned by periodic refreshes.

Resolves `holomush-m7djf` and `holomush-lz92t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
