### PR TITLE
fix(plugin): thread derived ctx into Lua hostfunc guard logs for trace correlation (holomush-135sn)

### DIFF
--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -449,7 +449,7 @@ func (f *Functions) logFn(pluginName string) lua.LGFunction {
 			//nolint:sloglint // plugin-supplied log message, dynamic by design
 			logger.Error(message)
 		default:
-			slog.Warn("invalid log level from plugin",
+			slog.WarnContext(luaContext(L), "invalid log level from plugin",
 				"plugin", pluginName,
 				"requested_level", level)
 			L.RaiseError("invalid log level %q: must be debug, info, warn, or error", level)
@@ -472,7 +472,7 @@ func (f *Functions) newRequestIDFn() lua.LGFunction {
 // for Lua if denied, or empty string if allowed.
 func (f *Functions) checkKVAccess(L *lua.LState, pluginName, action, key string) string { //nolint:gocritic // L is standard gopher-lua convention
 	if f.engine == nil {
-		slog.Warn("KV access denied: no ABAC engine configured",
+		slog.WarnContext(luaContext(L), "KV access denied: no ABAC engine configured",
 			"plugin", pluginName, "action", action, "key", key)
 		return "access engine not available"
 	}
@@ -522,7 +522,7 @@ func (f *Functions) kvGetFn(pluginName string) lua.LGFunction {
 		}
 
 		if f.kvStore == nil {
-			slog.Error("kv_get called but store unavailable",
+			slog.ErrorContext(luaContext(L), "kv_get called but store unavailable",
 				"plugin", pluginName,
 				"key", key)
 			L.Push(lua.LNil)
@@ -572,7 +572,7 @@ func (f *Functions) kvSetFn(pluginName string) lua.LGFunction {
 		}
 
 		if f.kvStore == nil {
-			slog.Error("kv_set called but store unavailable",
+			slog.ErrorContext(luaContext(L), "kv_set called but store unavailable",
 				"plugin", pluginName,
 				"key", key)
 			L.Push(lua.LNil)
@@ -614,7 +614,7 @@ func (f *Functions) kvDeleteFn(pluginName string) lua.LGFunction {
 		}
 
 		if f.kvStore == nil {
-			slog.Error("kv_delete called but store unavailable",
+			slog.ErrorContext(luaContext(L), "kv_delete called but store unavailable",
 				"plugin", pluginName,
 				"key", key)
 			L.Push(lua.LNil)

--- a/internal/plugin/hostfunc/slog_trace_propagation_test.go
+++ b/internal/plugin/hostfunc/slog_trace_propagation_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+)
+
+// ctxCapturingHandler is a slog.Handler that records the context.Context passed
+// to the most recent Handle call. It lets a test prove that a log call used a
+// *Context slog variant (which forwards the caller's ctx) rather than a bare
+// variant (which logs with context.Background(), silently dropping whatever ctx
+// the caller holds) — the distinction that decides whether a log line carries
+// trace_id/span_id (.claude/rules/logging.md).
+type ctxCapturingHandler struct {
+	mu      sync.Mutex
+	lastCtx context.Context
+}
+
+func (h *ctxCapturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *ctxCapturingHandler) Handle(ctx context.Context, _ slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastCtx = ctx
+	return nil
+}
+
+func (h *ctxCapturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *ctxCapturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *ctxCapturingHandler) capturedSpanContext() trace.SpanContext {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.lastCtx == nil {
+		// Handle was never called (guard path not reached). Return a zero
+		// SpanContext so the assertion fails readably rather than relying on a
+		// nil ctx flowing into trace.SpanContextFromContext.
+		return trace.SpanContext{}
+	}
+	return trace.SpanContextFromContext(h.lastCtx)
+}
+
+// installCapturingDefaultLogger swaps slog's default logger for one backed by a
+// ctxCapturingHandler and restores the original on cleanup. The guard log calls
+// under test use the package-level slog.* functions, which route through
+// slog.Default().
+func installCapturingDefaultLogger(t *testing.T) *ctxCapturingHandler {
+	t.Helper()
+	h := &ctxCapturingHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return h
+}
+
+// tracedTestContext returns a context carrying a valid, sampled SpanContext so a
+// test can assert that the span survives the log call (i.e. the ctx was
+// threaded through rather than dropped).
+func tracedTestContext() (context.Context, trace.TraceID) {
+	traceID := trace.TraceID{0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), sc), traceID
+}
+
+func TestJoinFocusNotInitializedGuardLogCarriesTraceContext(t *testing.T) {
+	h := installCapturingDefaultLogger(t)
+
+	// focus ops nil → getFocusOps returns nil → the "focus ops not initialized"
+	// guard fires before the function derives its own ctx.
+	L := newFocusTestState(t, nil, nil)
+	ctx, wantTraceID := tracedTestContext()
+	L.SetContext(ctx)
+
+	require.NoError(t, L.DoString(`holomush.join_focus("sess-1", "scene", "ignored")`))
+
+	sc := h.capturedSpanContext()
+	require.True(t, sc.IsValid(),
+		"guard log must carry the Lua state's trace context (use slog.WarnContext with a derived ctx)")
+	assert.Equal(t, wantTraceID, sc.TraceID(), "log ctx must carry the same trace as the Lua state")
+}
+
+func TestJoinFocusGuardLogUsesBackgroundWhenLuaStateHasNoTraceContext(t *testing.T) {
+	h := installCapturingDefaultLogger(t)
+
+	// No L.SetContext → luaContext falls back to context.Background(), which
+	// carries no span. This pins the negative half of the contract: the guard
+	// log degrades to an un-correlated line rather than fabricating a span.
+	L := newFocusTestState(t, nil, nil)
+
+	require.NoError(t, L.DoString(`holomush.join_focus("sess-1", "scene", "ignored")`))
+
+	sc := h.capturedSpanContext()
+	assert.False(t, sc.IsValid(),
+		"with no ctx on the Lua state, the guard log must carry no trace context (Background fallback)")
+}
+
+func TestKVGetStoreUnavailableGuardLogCarriesTraceContext(t *testing.T) {
+	h := installCapturingDefaultLogger(t)
+
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+
+	// nil kv store, engine allows → ABAC passes and execution reaches the
+	// nil-store guard, which fires before the function derives its own ctx.
+	hf := hostfunc.New(nil, hostfunc.WithEngine(policytest.AllowAllEngine()))
+	hf.Register(L, "test-plugin")
+	hf.RegisterCapabilityFuncsForTest(L, "test-plugin")
+
+	ctx, wantTraceID := tracedTestContext()
+	L.SetContext(ctx)
+
+	require.NoError(t, L.DoString(`val, err = holomush.kv_get("key")`))
+
+	sc := h.capturedSpanContext()
+	require.True(t, sc.IsValid(),
+		"guard log must carry the Lua state's trace context (use slog.ErrorContext with a derived ctx)")
+	assert.Equal(t, wantTraceID, sc.TraceID(), "log ctx must carry the same trace as the Lua state")
+}

--- a/internal/plugin/hostfunc/stdlib_focus.go
+++ b/internal/plugin/hostfunc/stdlib_focus.go
@@ -141,7 +141,7 @@ func joinFocusFn(ls *lua.LState) int {
 
 	fo := getFocusOps(ls)
 	if fo == nil {
-		slog.Warn("holomush.join_focus: focus ops not initialized")
+		slog.WarnContext(luaContext(ls), "holomush.join_focus: focus ops not initialized")
 		return 0
 	}
 
@@ -179,7 +179,7 @@ func leaveFocusFn(ls *lua.LState) int {
 
 	fo := getFocusOps(ls)
 	if fo == nil {
-		slog.Warn("holomush.leave_focus: focus ops not initialized")
+		slog.WarnContext(luaContext(ls), "holomush.leave_focus: focus ops not initialized")
 		return 0
 	}
 
@@ -228,7 +228,7 @@ func leaveFocusByTargetFn(ls *lua.LState) int {
 
 	fo := getFocusOps(ls)
 	if fo == nil {
-		slog.Warn("holomush.leave_focus_by_target: focus ops not initialized")
+		slog.WarnContext(luaContext(ls), "holomush.leave_focus_by_target: focus ops not initialized")
 		ls.Push(lua.LNil)
 		ls.Push(lua.LString("focus ops not initialized"))
 		return 2
@@ -288,7 +288,7 @@ func presentFocusFn(ls *lua.LState) int {
 
 	fo := getFocusOps(ls)
 	if fo == nil {
-		slog.Warn("holomush.present_focus: focus ops not initialized")
+		slog.WarnContext(luaContext(ls), "holomush.present_focus: focus ops not initialized")
 		return 0
 	}
 
@@ -398,7 +398,7 @@ func queryStreamHistoryFn(ls *lua.LState) int {
 
 	hr := getHistoryReader(ls)
 	if hr == nil {
-		slog.Warn("holomush.query_stream_history: history reader not initialized")
+		slog.WarnContext(luaContext(ls), "holomush.query_stream_history: history reader not initialized")
 		return 0
 	}
 


### PR DESCRIPTION
## Summary
- 10 early-guard log calls in `internal/plugin/hostfunc/{functions.go,stdlib_focus.go}` used bare `slog.Warn/Error`, dropping trace context (no `trace_id`/`span_id`) on plugin misconfig / not-initialized paths.
- These are `sloglint context:scope` **blind spots**: a `ctx` is derivable via `L.Context()`/`ls.Context()` but not bound as a variable at the guard site, so the linter stays green — yet `.claude/rules/logging.md`'s spirit ("derivable value MUST be threaded") applies. Orphaned log lines can't be correlated in Loki/Grafana/Sentry.
- Switched all 10 to `slog.WarnContext`/`ErrorContext` via the canonical `luaContext(L)` helper (`cap_session.go:193`). Added `slog_trace_propagation_test.go` proving guard logs now carry the Lua state's trace context.

**Scope note:** investigation found the bead's broader file list stale — `task lint:go` (sloglint `context:scope`, active) is green, so there are zero bare calls with a `ctx` variable in lexical scope. `gateway_handler.go` bare calls are pure no-ctx `send`/`format*` helpers (already compliant); `internal/grpc/focus` had zero bare calls. `manager.go` (4) left out per the agreed focused scope (would need API-signature changes).

## Test Plan
- [x] `task test -- ./internal/plugin/hostfunc/` — 439 pass (incl. 2 new trace-propagation tests; verified red→green)
- [x] `task lint:go` — 0 issues (sloglint accepts the new `*Context` forms)
- [x] `task pr-prep` (fast lane) — pass

Resolves holomush-135sn (closed at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)