### PR TITLE
docs(spec+plan+adr): web create-scene design, plan, ADRs (holomush-5rh.22)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Typed RPCs for structural scene writes; command path for human/CLI verbs](holomush-v4qmu-typed-rpcs-structural-scene-writes-command-path-human-cli-ve.md) | 2026-06-20 | Accepted | `holomush-v4qmu` |
+| [Resolve window-per-scene as single-pane workspace; defer multi-window](holomush-x8swp-resolve-window-per-scene-as-single-pane-workspace-defer-mult.md) | 2026-06-20 | Accepted | `holomush-x8swp` |
 | [Scope Lua stub generator to static build-time surfaces only](holomush-vhz3h-scope-lua-stub-generator-static-build-time-surfaces-only.md) | 2026-06-16 | Accepted | `holomush-vhz3h` |
 | [Source ambient stdlib annotations from a parity-tested Go decl table](holomush-nc5v1-source-ambient-stdlib-annotations-from-parity-tested-go-decl.md) | 2026-06-16 | Accepted | `holomush-nc5v1` |
 | [Atomic (big-bang) plugin-capability cutover over phased allowlist rollout](holomush-40ssh-atomic-big-bang-plugin-capability-cutover-over-phased-allowl.md) | 2026-06-14 | Accepted | `holomush-40ssh` |

--- a/docs/adr/holomush-v4qmu-typed-rpcs-structural-scene-writes-command-path-human-cli-ve.md
+++ b/docs/adr/holomush-v4qmu-typed-rpcs-structural-scene-writes-command-path-human-cli-ve.md
@@ -1,0 +1,35 @@
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-v4qmu; do not edit manually; use `/adr update holomush-v4qmu` -->
+
+# Typed RPCs for structural scene writes; command path for human/CLI verbs
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Decision:** holomush-v4qmu
+**Deciders:** Sean Brandt
+
+## Context
+
+The web Scenes Portal (E9.5, holomush-5rh.8) routed all web scene writes through the telnet command path via `sendCommand` / `HandleCommand` — including structural operations like scene creation. E9.5 D4 stated "web writes ride the command path; no new write RPCs." This created a contradiction: create returns a `SceneInfo` the caller must consume, but the command path surfaces it only as unparseable prose (`"Scene created: <id>"`). Typed scene-write RPCs (`WebWatchScene`, `WebExportScene`) already existed as counter-examples on the same surface.
+
+## Decision
+
+Structural / CRUD / management operations on objects (create, set, end, invite, kick, transfer, order, publish-config) MUST be exposed as typed RPCs through the BFF: web client → `WebService` (gateway, protocol-translation only) → `SceneAccessService` facade (session-token→identity + ABAC) → `SceneService`. The command path (`HandleCommand`; surfaces = telnet request/response and the web `/terminal`) is reserved for human / CLI conversational verbs a person performs in the moment: pose, say, ooc, emit, join. This supersedes E9.5 D4 for structural writes.
+
+## Rationale
+
+- Create returns a value the caller consumes (`SceneInfo`); the command path surfaces it only as human-readable prose the web would have to parse.
+- Typed proto fields eliminate the escaping hazard inherent in assembling a command string from user-supplied free-text title/description.
+- Rule of thumb: typed RPC when the op returns something the caller uses (create→`SceneInfo`, watch→participant, export→bytes); command path for fire-and-forget human verbs (pose/say/join). This unifies the existing precedents and generalizes to future web surfaces.
+- Conversational writes (pose/say/ooc/join) on `sendCommand` remain correct and are unchanged; `SceneComposer.svelte` is not touched.
+
+## Alternatives Considered
+
+- **Assemble and send a command string — the E9.5 D4 approach (rejected):** no new proto surface and reuses the `HandleCommand` ABAC gate by construction, but create's result is only prose the web must parse, free-text fields embedded in a single command line create an escaping hazard, and it is inconsistent with the existing `WebWatchScene` / `WebExportScene` typed-RPC precedent on the same surface.
+- **Typed RPC through the BFF facade (chosen):** returns a structured `SceneInfo` (no parsing), title/description cross the wire as typed fields (no escaping), consistent with the existing Watch/Export/SetFocus RPCs, atomic, and works for sessions-only players who have no terminal session. Costs new proto RPCs (with full doc comments), a new facade method, and tests at each layer.
+
+## Consequences
+
+- Positive: callers receive structured responses without prose parsing; free-text user input crosses the wire safely; the telnet-free path is unblocked (a scenes-only player with no terminal can originate a scene); one consistent pattern across all web scene write RPCs.
+- Negative: new proto RPCs require full doc-comment coverage (proto-doc-comments rule); a new facade method (`SceneAccessServer.CreateScene`) to build, test, and review; E9.5 D4 is partially superseded, so sibling bead holomush-5rh.24 (management verbs) must be re-scoped from the command path to typed RPCs.
+- Neutral: pose/say/ooc/join remain on `sendCommand`; the gateway-boundary rule and the BFF-RPC routing invariant (ADR holomush-b0365) continue to apply — this decision complements them (it governs the command-vs-RPC division of labor for writes), it does not supersede them.

--- a/docs/adr/holomush-v4qmu-typed-rpcs-structural-scene-writes-command-path-human-cli-ve.md
+++ b/docs/adr/holomush-v4qmu-typed-rpcs-structural-scene-writes-command-path-human-cli-ve.md
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
 <!-- markdownlint-disable MD013 -->
 <!-- adr-render: source=bd:holomush-v4qmu; do not edit manually; use `/adr update holomush-v4qmu` -->
 

--- a/docs/adr/holomush-x8swp-resolve-window-per-scene-as-single-pane-workspace-defer-mult.md
+++ b/docs/adr/holomush-x8swp-resolve-window-per-scene-as-single-pane-workspace-defer-mult.md
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
 <!-- markdownlint-disable MD013 -->
 <!-- adr-render: source=bd:holomush-x8swp; do not edit manually; use `/adr update holomush-x8swp` -->
 

--- a/docs/adr/holomush-x8swp-resolve-window-per-scene-as-single-pane-workspace-defer-mult.md
+++ b/docs/adr/holomush-x8swp-resolve-window-per-scene-as-single-pane-workspace-defer-mult.md
@@ -1,0 +1,34 @@
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-x8swp; do not edit manually; use `/adr update holomush-x8swp` -->
+
+# Resolve window-per-scene as single-pane workspace; defer multi-window
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Decision:** holomush-x8swp
+**Deciders:** Sean Brandt
+
+## Context
+
+E9.5 D4 specified "window-per-scene routing (web)" as a requirement. The shipped E9.5 portal instead delivered a single-pane scene-switcher workspace (`web/src/lib/scenes/workspaceStore.svelte.ts`, `selectedSceneId` + 3-pane layout) with unread badges and quick-switch, approved via the E9.5 visual-companion mockups (v3, D11). The bead holomush-5rh.22 carried this as residual R1 requiring a recorded disposition.
+
+## Decision
+
+The single-pane workspace with quick-switch and unread badges satisfies D4's intent ("the web renders threads"). True multi-window / pop-out per scene is NOT built and is NOT planned. This is recorded as resolved-by-evolution; no code implements R1.
+
+## Rationale
+
+- The D11 visual-companion mockups explicitly approved the single-pane model over literal multi-window during E9.5 design.
+- The single-pane workspace already covers the core "threads rendered in the web" intent of D4 via unread badges and quick-switch.
+- No current epic or bead targets true pop-out multi-window; recording the disposition prevents future contributors from re-litigating a settled question.
+
+## Alternatives Considered
+
+- **True multi-window / pop-out per scene (rejected):** matches the literal D4 spec text (each scene in its own window/tab), but it was not built in E9.5, is not planned in any bead, and adds significant routing and state-sync complexity; the D11 mockups approved the single-pane approach instead.
+- **Single-pane scene-switcher workspace — resolved-by-evolution (chosen):** already shipped and approved; satisfies D4's intent; simpler state model already integrated with `selectedSceneId` and the 3-pane layout.
+
+## Consequences
+
+- Positive: D4 residual R1 is formally closed with a recorded rationale; future contributors have a clear signal that multi-window is a deliberate non-goal, not an oversight.
+- Negative: players who want true simultaneous side-by-side scene windows cannot have it under this model.
+- Neutral: no code implements R1 in this slice; this ADR is documentation only.

--- a/docs/superpowers/plans/2026-06-19-web-create-scene.md
+++ b/docs/superpowers/plans/2026-06-19-web-create-scene.md
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
 # Web Create-Scene Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-19-web-create-scene.md
+++ b/docs/superpowers/plans/2026-06-19-web-create-scene.md
@@ -1,0 +1,940 @@
+# Web Create-Scene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a web create-scene affordance backed by a typed `WebCreateScene` RPC, restoring the create capability the E9.5 portal dropped (`holomush-5rh.22`).
+
+**Architecture:** A full-stack vertical slice mirroring the existing `WatchScene` path — proto (`SceneAccessService.CreateScene` + `WebService.WebCreateScene`) → facade (`internal/grpc/sceneaccess_service.go`, `resolveAndGate`→`ownedCharacter`→`beginDispatch`→`sceneClient.CreateScene`) → BFF (`internal/web/scene_handlers.go`) → web client → Svelte UI (left-rail toolbar + empty-state CTA → slide-over Sheet with a title + optional-description form). Structural scene writes use typed RPCs, not the command path (supersedes E9.5 D4 for structural writes); the command path stays for human/CLI conversational verbs.
+
+**Tech Stack:** Go (gRPC/Connect, buf, mockery, testify), protobuf, SvelteKit + Svelte 5 runes, shadcn-svelte (`Sheet`/`input`/`label`), pnpm + vitest, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-web-create-scene-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `api/proto/holomush/sceneaccess/v1/sceneaccess.proto` | `CreateScene` facade RPC + messages | 1 |
+| `api/proto/holomush/web/v1/web.proto` | `WebCreateScene` BFF RPC + messages | 1 |
+| `internal/grpc/sceneaccess_service.go` | `SceneAccessServer.CreateScene` facade method | 2 |
+| `internal/grpc/sceneaccess_service_test.go` | facade unit tests | 2 |
+| `internal/web/handler.go` | add `CreateScene` to `SceneAccessClient` interface | 3 |
+| `internal/grpc/client.go` | `Client.CreateScene` gRPC passthrough | 3 |
+| `internal/web/scene_handlers.go` | `Handler.WebCreateScene` BFF handler | 3 |
+| `internal/web/scene_handlers_test.go` | mock method + BFF handler tests | 3 |
+| `web/src/lib/scenes/client.ts` | `createScene()` RPC wrapper | 4 |
+| `web/src/lib/scenes/createFlow.ts` | `submitCreateScene()` orchestration | 4 |
+| `web/src/lib/scenes/createFlow.test.ts` | orchestration unit test | 4 |
+| `web/src/lib/components/scenes/CreateSceneForm.svelte` | the create form (portal-free, testable) | 5 |
+| `web/src/lib/components/scenes/CreateSceneForm.svelte.test.ts` | form render-state + submit test | 5 |
+| `web/src/lib/components/scenes/CreateSceneSheet.svelte` | `Sheet` wrapper around the form | 6 |
+| `web/src/routes/(authed)/scenes/+page.svelte` | toolbar + empty-state CTA + mount Sheet | 6 |
+| `web/e2e/scenes.spec.ts` | no-telnet create E2E | 7 |
+
+---
+
+## Task 1: Proto — `CreateScene` + `WebCreateScene` RPCs
+
+**Files:**
+
+- Modify: `api/proto/holomush/sceneaccess/v1/sceneaccess.proto` (rpc after `:53`, messages after `:232`)
+- Modify: `api/proto/holomush/web/v1/web.proto` (rpc after `:273`, messages after `:1020`)
+
+- [ ] **Step 1: Add the facade RPC to `sceneaccess.proto`**
+
+Insert after the `WatchScene` rpc (currently line 53, inside `service SceneAccessService`):
+
+```proto
+  // CreateScene creates a new scene owned by the verified player's owned
+  // character and returns its full metadata. The facade resolves the acting
+  // character from the player session (INV-SCENE-63) and rejects guests
+  // (INV-SCENE-64), then forwards a CreateScene call to the plugin SceneService
+  // with the server-verified character_id. Unlike WatchScene it requires no
+  // existing game session — creation does not touch focus.
+  rpc CreateScene(CreateSceneRequest) returns (CreateSceneResponse);
+```
+
+- [ ] **Step 2: Add the facade messages to `sceneaccess.proto`**
+
+Insert after `WatchSceneResponse` (currently ends line 232):
+
+```proto
+// CreateSceneRequest is the facade request to create a scene. player_session_token
+// authenticates the calling player (session_id is a reserved client hint, not
+// consulted); the facade resolves the acting character SERVER-SIDE from the
+// player's owned-character set (INV-SCENE-63) and overrides any client identity.
+message CreateSceneRequest {
+  // session_id is the client-declared player-session ULID, retained as a
+  // forward-looking hint; authentication is performed SOLELY against
+  // player_session_token (holomush-5rh.8.23 decision).
+  string session_id = 1;
+  // player_session_token is the raw bearer token; the facade looks up the
+  // session by token hash and rejects unauthenticated callers
+  // (codes.Unauthenticated) and guests (codes.PermissionDenied, INV-SCENE-64).
+  string player_session_token = 2;
+  // character_id selects which owned alt becomes the scene owner; the facade
+  // verifies ownership before passing the server-verified ID downstream
+  // (codes.NotFound when not owned, INV-SCENE-63).
+  string character_id = 3;
+  // title is the scene title; required. The plugin handler rejects empty or
+  // whitespace-only titles after trim.
+  string title = 4;
+  // description is an optional scene synopsis; empty omits it.
+  string description = 5;
+}
+
+// CreateSceneResponse wraps the created scene's full metadata projection.
+message CreateSceneResponse {
+  // scene is the newly created scene; the verified character is its owner and
+  // first participant.
+  holomush.scene.v1.SceneInfo scene = 1;
+}
+```
+
+- [ ] **Step 3: Add the BFF RPC to `web.proto`**
+
+Insert after the `WebWatchScene` rpc (currently line 273, inside `service WebService`):
+
+```proto
+  // WebCreateScene creates a new scene owned by the verified player's owned
+  // character and returns its metadata. Proxies to
+  // SceneAccessService.CreateScene; player_session_token is read from the HTTP
+  // cookie by gateway middleware.
+  rpc WebCreateScene(WebCreateSceneRequest) returns (WebCreateSceneResponse);
+```
+
+- [ ] **Step 4: Add the BFF messages to `web.proto`**
+
+Insert after `WebWatchSceneResponse` (currently ends line 1020):
+
+```proto
+// WebCreateSceneRequest proxies to SceneAccessService.CreateScene.
+// player_session_token is injected from the X-Session-Token cookie.
+message WebCreateSceneRequest {
+  // session_id is the client-declared player-session ULID forwarded to the facade.
+  string session_id = 1;
+  // character_id selects which owned alt becomes the scene owner, forwarded to
+  // the facade for server-side ownership verification.
+  string character_id = 2;
+  // title is the scene title; required.
+  string title = 3;
+  // description is an optional scene synopsis; empty omits it.
+  string description = 4;
+}
+
+// WebCreateSceneResponse re-exports the created scene's metadata from the facade.
+message WebCreateSceneResponse {
+  // scene is the newly created scene's full metadata projection.
+  holomush.scene.v1.SceneInfo scene = 1;
+}
+```
+
+- [ ] **Step 5: Regenerate Go + TS bindings**
+
+Run: `task proto && task web:generate`
+Expected: regenerates `pkg/proto/.../sceneaccess` + `.../web` Go, the internal Connect handlers, and `web/src/lib/connect/holomush/web/v1/web_pb.ts` (adds `webCreateScene` client method + `WebCreateSceneRequest`/`Response` types). No errors.
+
+- [ ] **Step 6: Verify proto lint (doc comments)**
+
+Run: `task lint:proto`
+Expected: PASS (every new element has a grounded, non-name-echo comment).
+
+- [ ] **Step 7: Commit**
+
+`jj commit -m "feat(proto): WebCreateScene + SceneAccessService.CreateScene RPCs (holomush-5rh.22)"`
+
+---
+
+## Task 2: Facade — `SceneAccessServer.CreateScene`
+
+**Files:**
+
+- Modify: `internal/grpc/sceneaccess_service.go` (add method after `WatchScene`, ~`:269`)
+- Test: `internal/grpc/sceneaccess_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/grpc/sceneaccess_service_test.go` (uses the existing helpers `buildSATestPS`, `buildSASessionRepo`, `newTestSceneAccessServer`, `testSAToken`, `scenemocks`, `authmocks`, `sessionmocks`, `stubPluginManager`, `stubFocusCoordinator`):
+
+```go
+func TestSceneAccessCreateScene(t *testing.T) {
+	ctx := context.Background()
+	playerID := idgen.New()
+	char := &world.Character{ID: idgen.New(), PlayerID: playerID, Name: "Alice"}
+	ps := buildSATestPS(t, playerID)
+
+	t.Run("owned character creates scene with verified id, title, description", func(t *testing.T) {
+		playerRepo := authmocks.NewMockPlayerRepository(t)
+		playerRepo.EXPECT().GetByID(mock.Anything, playerID).Return(&auth.Player{ID: playerID, IsGuest: false}, nil).Maybe()
+		charRepo := authmocks.NewMockCharacterRepository(t)
+		charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).Return([]*world.Character{char}, nil).Maybe()
+		sceneMock := scenemocks.NewMockSceneServiceClient(t)
+		want := &scenev1.SceneInfo{Id: idgen.New().String(), Title: "The Manor"}
+		sceneMock.EXPECT().CreateScene(mock.Anything, mock.MatchedBy(func(req *scenev1.CreateSceneRequest) bool {
+			return req.GetCharacterId() == char.ID.String() &&
+				req.GetTitle() == "The Manor" && req.GetDescription() == "dusk"
+		})).Return(&scenev1.CreateSceneResponse{Scene: want}, nil).Once()
+
+		srv := newTestSceneAccessServer(t, buildSASessionRepo(t, ps), playerRepo, charRepo,
+			sessionmocks.NewMockStore(t), &stubFocusCoordinator{}, sceneMock, &stubPluginManager{})
+
+		resp, err := srv.CreateScene(ctx, &sceneaccessv1.CreateSceneRequest{
+			PlayerSessionToken: testSAToken, CharacterId: char.ID.String(),
+			Title: "The Manor", Description: "dusk",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, want.GetId(), resp.GetScene().GetId())
+	})
+
+	// Verifies: INV-SCENE-64
+	t.Run("guest is denied and downstream is never called", func(t *testing.T) {
+		playerRepo := authmocks.NewMockPlayerRepository(t)
+		playerRepo.EXPECT().GetByID(mock.Anything, playerID).Return(&auth.Player{ID: playerID, IsGuest: true}, nil).Maybe()
+		sceneMock := scenemocks.NewMockSceneServiceClient(t)
+		srv := newTestSceneAccessServer(t, buildSASessionRepo(t, ps), playerRepo,
+			authmocks.NewMockCharacterRepository(t), sessionmocks.NewMockStore(t),
+			&stubFocusCoordinator{}, sceneMock, &stubPluginManager{})
+
+		_, err := srv.CreateScene(ctx, &sceneaccessv1.CreateSceneRequest{
+			PlayerSessionToken: testSAToken, CharacterId: char.ID.String(), Title: "X",
+		})
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		sceneMock.AssertNotCalled(t, "CreateScene")
+	})
+
+	t.Run("character not owned returns NotFound", func(t *testing.T) {
+		playerRepo := authmocks.NewMockPlayerRepository(t)
+		playerRepo.EXPECT().GetByID(mock.Anything, playerID).Return(&auth.Player{ID: playerID, IsGuest: false}, nil).Maybe()
+		charRepo := authmocks.NewMockCharacterRepository(t)
+		charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).Return([]*world.Character{char}, nil).Maybe()
+		sceneMock := scenemocks.NewMockSceneServiceClient(t)
+		srv := newTestSceneAccessServer(t, buildSASessionRepo(t, ps), playerRepo, charRepo,
+			sessionmocks.NewMockStore(t), &stubFocusCoordinator{}, sceneMock, &stubPluginManager{})
+
+		_, err := srv.CreateScene(ctx, &sceneaccessv1.CreateSceneRequest{
+			PlayerSessionToken: testSAToken, CharacterId: idgen.New().String(), Title: "X",
+		})
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `task test -- -run TestSceneAccessCreateScene ./internal/grpc/`
+Expected: FAIL — `srv.CreateScene` undefined.
+
+- [ ] **Step 3: Implement `CreateScene`**
+
+Add to `internal/grpc/sceneaccess_service.go` after `WatchScene` (after `:269`):
+
+```go
+// CreateScene creates a new scene owned by the verified player's owned character
+// and returns its metadata. Unlike WatchScene it requires no existing game
+// session — creation does not touch focus or sessions. resolveAndGate enforces
+// the guest gate (INV-SCENE-64); ownedCharacter enforces ownership (INV-SCENE-63).
+func (s *SceneAccessServer) CreateScene(ctx context.Context, req *sceneaccessv1.CreateSceneRequest) (*sceneaccessv1.CreateSceneResponse, error) {
+	ps, err := s.resolveAndGate(ctx, req.GetPlayerSessionToken())
+	if err != nil {
+		return nil, err
+	}
+	char, err := s.ownedCharacter(ctx, ps.PlayerID, req.GetCharacterId())
+	if err != nil {
+		return nil, err
+	}
+	dctx, release, err := s.beginDispatch(ctx, char, ps.PlayerID)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	resp, err := s.sceneClient.CreateScene(dctx, &scenev1.CreateSceneRequest{
+		CharacterId: char.ID.String(),
+		Title:       req.GetTitle(),
+		Description: req.GetDescription(),
+	})
+	if err != nil {
+		return nil, err //nolint:wrapcheck // gRPC status errors pass through as-is
+	}
+	return &sceneaccessv1.CreateSceneResponse{Scene: resp.GetScene()}, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `task test -- -run TestSceneAccessCreateScene ./internal/grpc/`
+Expected: PASS (all three subtests).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(grpc): SceneAccessServer.CreateScene facade (holomush-5rh.22)"`
+
+---
+
+## Task 3: BFF — `Handler.WebCreateScene`
+
+**Files:**
+
+- Modify: `internal/web/handler.go` (add to `SceneAccessClient` interface, `:105-115`)
+- Modify: `internal/grpc/client.go` (add `Client.CreateScene`, mirror `WatchScene`)
+- Modify: `internal/web/scene_handlers.go` (add `WebCreateScene` after `WebWatchScene`, ~`:146`)
+- Test: `internal/web/scene_handlers_test.go` (mock method + two tests)
+
+- [ ] **Step 1: Add `CreateScene` to the `SceneAccessClient` interface**
+
+In `internal/web/handler.go`, inside `type SceneAccessClient interface` (after the `WatchScene` line):
+
+```go
+	CreateScene(ctx context.Context, req *sceneaccessv1.CreateSceneRequest) (*sceneaccessv1.CreateSceneResponse, error)
+```
+
+- [ ] **Step 2: Add the gRPC passthrough to the real client**
+
+In `internal/grpc/client.go`, mirror the existing `WatchScene` wrapper:
+
+```go
+func (c *Client) CreateScene(ctx context.Context, req *sceneaccessv1.CreateSceneRequest) (*sceneaccessv1.CreateSceneResponse, error) {
+	resp, err := c.sceneAccessClient.CreateScene(ctx, req)
+	if err != nil {
+		return nil, oops.Code("RPC_FAILED").With("method", "CreateScene").Wrap(err)
+	}
+	return resp, nil
+}
+```
+
+- [ ] **Step 3: Add the mock method + write the failing tests**
+
+In `internal/web/scene_handlers_test.go`, add a `CreateScene` method to `mockSceneAccessClient` (mirror its `WatchScene` method — record the request, return a configurable response/error), e.g.:
+
+```go
+func (m *mockSceneAccessClient) CreateScene(_ context.Context, req *sceneaccessv1.CreateSceneRequest) (*sceneaccessv1.CreateSceneResponse, error) {
+	m.createSceneReq = req
+	if m.createSceneErr != nil {
+		return nil, m.createSceneErr
+	}
+	return &sceneaccessv1.CreateSceneResponse{Scene: &scenev1.SceneInfo{Id: "scene-123"}}, nil
+}
+```
+
+Add the `createSceneReq *sceneaccessv1.CreateSceneRequest` and `createSceneErr error` fields to the `mockSceneAccessClient` struct. Then add the tests (mirror `TestWebWatchSceneForwardsTokenAndOpFieldsToFacade` / `...PassesStatusErrorThroughAsIs`):
+
+```go
+func TestWebCreateSceneForwardsTokenAndOpFieldsToFacade(t *testing.T) {
+	sc := &mockSceneAccessClient{}
+	h := NewHandler(&mockCoreClient{}, WithSceneAccessClient(sc))
+
+	req := connect.NewRequest(&webv1.WebCreateSceneRequest{
+		SessionId: "sess-1", CharacterId: "char-1", Title: "The Manor", Description: "dusk",
+	})
+	req.Header().Set(headerInjectSessionToken, "tok-abc")
+
+	resp, err := h.WebCreateScene(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "scene-123", resp.Msg.GetScene().GetId())
+	require.NotNil(t, sc.createSceneReq)
+	assert.Equal(t, "tok-abc", sc.createSceneReq.GetPlayerSessionToken())
+	assert.Equal(t, "char-1", sc.createSceneReq.GetCharacterId())
+	assert.Equal(t, "The Manor", sc.createSceneReq.GetTitle())
+	assert.Equal(t, "dusk", sc.createSceneReq.GetDescription())
+}
+
+func TestWebCreateScenePassesStatusErrorThroughAsIs(t *testing.T) {
+	wantErr := status.Error(codes.PermissionDenied, "guests cannot access scenes")
+	sc := &mockSceneAccessClient{createSceneErr: wantErr}
+	h := NewHandler(&mockCoreClient{}, WithSceneAccessClient(sc))
+
+	req := connect.NewRequest(&webv1.WebCreateSceneRequest{SessionId: "s", CharacterId: "c", Title: "X"})
+	req.Header().Set(headerInjectSessionToken, "tok")
+
+	_, err := h.WebCreateScene(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+```
+
+> Match the exact `NewHandler` / `WithSceneAccessClient` construction the sibling `TestWebWatchScene*` tests use in this file; adjust the constructor call if it differs.
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `task test -- -run TestWebCreateScene ./internal/web/`
+Expected: FAIL — `h.WebCreateScene` undefined.
+
+- [ ] **Step 5: Implement `WebCreateScene`**
+
+Add to `internal/web/scene_handlers.go` after `WebWatchScene` (~`:146`):
+
+```go
+// WebCreateScene proxies to SceneAccessService.CreateScene. The gateway reads
+// the player_session_token from the X-Session-Token cookie header and forwards
+// it with character_id, title, and description. Authorization and identity
+// resolution are owned entirely by the facade.
+func (h *Handler) WebCreateScene(ctx context.Context, req *connect.Request[webv1.WebCreateSceneRequest]) (*connect.Response[webv1.WebCreateSceneResponse], error) {
+	slog.DebugContext(ctx, "web: WebCreateScene", "session_id", req.Msg.GetSessionId(), "character_id", req.Msg.GetCharacterId())
+
+	if h.sceneAccess == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, oops.Errorf("scene access client not configured"))
+	}
+
+	token := req.Header().Get(headerInjectSessionToken)
+
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	resp, err := h.sceneAccess.CreateScene(rpcCtx, &sceneaccessv1.CreateSceneRequest{
+		SessionId:          req.Msg.GetSessionId(),
+		PlayerSessionToken: token,
+		CharacterId:        req.Msg.GetCharacterId(),
+		Title:              req.Msg.GetTitle(),
+		Description:        req.Msg.GetDescription(),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "web: create scene RPC failed", "session_id", req.Msg.GetSessionId(), "error", err)
+		return nil, err //nolint:wrapcheck // gRPC status errors pass through as-is
+	}
+
+	return connect.NewResponse(&webv1.WebCreateSceneResponse{Scene: resp.GetScene()}), nil
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `task test -- -run TestWebCreateScene ./internal/web/`
+Expected: PASS. The `var _ webv1connect.WebServiceHandler = (*Handler)(nil)` compile-check (`handler.go`) confirms the new RPC is implemented.
+
+- [ ] **Step 7: Commit**
+
+`jj commit -m "feat(web): WebCreateScene BFF handler + client passthrough (holomush-5rh.22)"`
+
+---
+
+## Task 4: Web client `createScene` + `submitCreateScene` flow
+
+**Files:**
+
+- Modify: `web/src/lib/scenes/client.ts` (add `createScene`)
+- Create: `web/src/lib/scenes/createFlow.ts`
+- Test: `web/src/lib/scenes/createFlow.test.ts`
+
+- [ ] **Step 1: Add the `createScene` RPC wrapper**
+
+In `web/src/lib/scenes/client.ts`, extend the `web_pb` import with `type WebCreateSceneRequest` and add:
+
+```ts
+/**
+ * Creates a new scene owned by the given character and returns its SceneInfo.
+ * The player_session_token rides the X-Session-Token cookie (set by the
+ * gateway); only session_id/character_id/title/description are sent. Used by
+ * the create-scene form — NOT the command path (structural write = typed RPC).
+ */
+export async function createScene(
+	sessionId: string,
+	opts: Pick<WebCreateSceneRequest, 'characterId' | 'title' | 'description'>,
+) {
+	const res = await client.webCreateScene({ sessionId, ...opts });
+	return res.scene;
+}
+```
+
+- [ ] **Step 2: Write the failing orchestration test**
+
+Create `web/src/lib/scenes/createFlow.test.ts`:
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./altSessions.svelte', () => ({
+	ensureSession: vi.fn(async () => 'sess-1'),
+}));
+vi.mock('./client', () => ({
+	createScene: vi.fn(async () => ({ id: 'scene-new' })),
+}));
+vi.mock('./workspaceStore.svelte', () => ({
+	workspaceStore: { refresh: vi.fn(async () => {}), select: vi.fn(async () => {}) },
+}));
+
+import { submitCreateScene } from './createFlow';
+import { ensureSession } from './altSessions.svelte';
+import { createScene } from './client';
+import { workspaceStore } from './workspaceStore.svelte';
+
+const chars = [{ characterId: 'char-1', name: 'Alice' }];
+
+describe('submitCreateScene', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('ensures the alt session, creates, refreshes, and selects the new scene', async () => {
+		const id = await submitCreateScene({
+			characterId: 'char-1', title: 'The Manor', description: 'dusk', characters: chars,
+		});
+		expect(id).toBe('scene-new');
+		expect(ensureSession).toHaveBeenCalledWith('char-1');
+		expect(createScene).toHaveBeenCalledWith('sess-1', {
+			characterId: 'char-1', title: 'The Manor', description: 'dusk',
+		});
+		expect(workspaceStore.refresh).toHaveBeenCalledWith(chars);
+		expect(workspaceStore.select).toHaveBeenCalledWith('scene-new', '', 'char-1');
+	});
+
+	it('skips select when no scene id is returned', async () => {
+		vi.mocked(createScene).mockResolvedValueOnce(undefined);
+		const id = await submitCreateScene({
+			characterId: 'char-1', title: 'X', description: '', characters: chars,
+		});
+		expect(id).toBe('');
+		expect(workspaceStore.refresh).toHaveBeenCalledWith(chars);
+		expect(workspaceStore.select).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd web && pnpm test:unit -- createFlow`
+Expected: FAIL — `./createFlow` not found.
+
+- [ ] **Step 4: Implement the orchestration**
+
+Create `web/src/lib/scenes/createFlow.ts`:
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { ensureSession } from './altSessions.svelte';
+import { createScene } from './client';
+import { workspaceStore } from './workspaceStore.svelte';
+
+/**
+ * Orchestrates web scene creation: ensure the acting alt's session, create the
+ * scene via the typed RPC, refresh My Scenes so the new (owner) scene appears,
+ * then focus it. Returns the new scene id ('' when the server returned none).
+ * The create RPC is authoritative; refresh/select are best-effort UI updates.
+ */
+export async function submitCreateScene(opts: {
+	characterId: string;
+	title: string;
+	description: string;
+	characters: { characterId: string; name?: string; characterName?: string }[];
+}): Promise<string> {
+	const sessionId = await ensureSession(opts.characterId);
+	const scene = await createScene(sessionId, {
+		characterId: opts.characterId,
+		title: opts.title,
+		description: opts.description,
+	});
+	const sceneId = scene?.id ?? '';
+	await workspaceStore.refresh(opts.characters);
+	if (sceneId) {
+		await workspaceStore.select(sceneId, '', opts.characterId);
+	}
+	return sceneId;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd web && pnpm test:unit -- createFlow`
+Expected: PASS (both cases).
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "feat(web): createScene client wrapper + submitCreateScene flow (holomush-5rh.22)"`
+
+---
+
+## Task 5: `CreateSceneForm.svelte`
+
+The portal-free form (so it is unit-testable in jsdom without the `Sheet`'s bits-ui portal). The `Sheet` wrapper is Task 6.
+
+**Files:**
+
+- Create: `web/src/lib/components/scenes/CreateSceneForm.svelte`
+- Test: `web/src/lib/components/scenes/CreateSceneForm.svelte.test.ts`
+
+- [ ] **Step 1: Write the failing render-state test**
+
+Create `web/src/lib/components/scenes/CreateSceneForm.svelte.test.ts` (mirrors the `mount`/`unmount` idiom of `web/src/lib/components/terminal/MovementRenderer.svelte.test.ts`):
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import CreateSceneForm from './CreateSceneForm.svelte';
+
+vi.mock('$lib/scenes/createFlow', () => ({ submitCreateScene: vi.fn(async () => 'scene-new') }));
+
+afterEach(() => document.body.replaceChildren());
+
+function render(characters: { characterId: string; name?: string }[]) {
+	const target = document.createElement('div');
+	document.body.appendChild(target);
+	const onDone = vi.fn();
+	const component = mount(CreateSceneForm, { target, props: { characters, onDone } });
+	return { target, onDone, component };
+}
+
+describe('CreateSceneForm', () => {
+	it('disables Create until a title is entered', () => {
+		const { target } = render([{ characterId: 'c1', name: 'Alice' }]);
+		const create = target.querySelector<HTMLButtonElement>('button[aria-label="Create scene"]')!;
+		expect(create.disabled).toBe(true);
+	});
+
+	it('hides the character selector with a single alt', () => {
+		const { target } = render([{ characterId: 'c1', name: 'Alice' }]);
+		expect(target.querySelector('select[aria-label="Create scene as"]')).toBeNull();
+	});
+
+	it('shows the character selector with multiple alts', () => {
+		const { target } = render([
+			{ characterId: 'c1', name: 'Alice' },
+			{ characterId: 'c2', name: 'Bob' },
+		]);
+		expect(target.querySelector('select[aria-label="Create scene as"]')).not.toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && pnpm test:unit -- CreateSceneForm`
+Expected: FAIL — component not found.
+
+- [ ] **Step 3: Implement the form**
+
+Create `web/src/lib/components/scenes/CreateSceneForm.svelte`:
+
+```svelte
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 HoloMUSH Contributors
+-->
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { Input } from '$lib/components/ui/input/index.js';
+  import { Label } from '$lib/components/ui/label/index.js';
+  import { submitCreateScene } from '$lib/scenes/createFlow';
+
+  let {
+    characters = [],
+    onDone,
+  }: {
+    characters?: { characterId: string; name?: string; characterName?: string }[];
+    onDone?: () => void;
+  } = $props();
+
+  let title = $state('');
+  let description = $state('');
+  let actingCharacterId = $state(characters[0]?.characterId ?? '');
+  let submitting = $state(false);
+  let errorMsg = $state('');
+
+  function charLabel(c: { characterId: string; name?: string; characterName?: string }): string {
+    return c.characterName ?? c.name ?? c.characterId;
+  }
+
+  async function create() {
+    const t = title.trim();
+    if (!t || submitting) return;
+    submitting = true;
+    errorMsg = '';
+    try {
+      await submitCreateScene({
+        characterId: actingCharacterId,
+        title: t,
+        description: description.trim(),
+        characters,
+      });
+      onDone?.();
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : 'Create failed';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<form class="flex flex-col gap-3 px-4 py-3" onsubmit={(e) => { e.preventDefault(); create(); }}>
+  {#if characters.length > 1}
+    <div class="flex flex-col gap-1">
+      <Label for="create-scene-as">Create as</Label>
+      <select
+        id="create-scene-as"
+        aria-label="Create scene as"
+        bind:value={actingCharacterId}
+        class="rounded-md border border-input bg-background px-3 py-2 text-sm"
+      >
+        {#each characters as c (c.characterId)}
+          <option value={c.characterId}>{charLabel(c)}</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+
+  <div class="flex flex-col gap-1">
+    <Label for="create-scene-title">Title</Label>
+    <Input id="create-scene-title" bind:value={title} placeholder="Scene title…" disabled={submitting} />
+  </div>
+
+  <div class="flex flex-col gap-1">
+    <Label for="create-scene-desc">Description <span class="text-muted-foreground">(optional)</span></Label>
+    <textarea
+      id="create-scene-desc"
+      bind:value={description}
+      disabled={submitting}
+      rows={3}
+      placeholder="What's this scene about?"
+      class={cn(
+        'w-full min-h-[72px] resize-y rounded-md border border-input bg-background px-3 py-2',
+        'text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+        'disabled:opacity-50',
+      )}
+    ></textarea>
+  </div>
+
+  <div class="flex items-center justify-end gap-2">
+    <Button type="button" variant="ghost" size="sm" onclick={() => onDone?.()} disabled={submitting}>
+      Cancel
+    </Button>
+    <Button type="submit" variant="default" size="sm" aria-label="Create scene" disabled={submitting || !title.trim()}>
+      {submitting ? 'Creating…' : 'Create scene'}
+    </Button>
+  </div>
+
+  {#if errorMsg}
+    <p class="text-xs text-destructive">{errorMsg}</p>
+  {/if}
+</form>
+```
+
+> If `Input` is not yet present under `web/src/lib/components/ui/`, add it with the shadcn-svelte skill (`/shadcn-svelte` → add `input`) — `input` was confirmed present at spec time; verify before implementing.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web && pnpm test:unit -- CreateSceneForm`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd web && pnpm check`
+Expected: no errors in the new files.
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "feat(web): CreateSceneForm component (holomush-5rh.22)"`
+
+---
+
+## Task 6: `CreateSceneSheet` wrapper + wire into `/scenes`
+
+**Files:**
+
+- Create: `web/src/lib/components/scenes/CreateSceneSheet.svelte`
+- Modify: `web/src/routes/(authed)/scenes/+page.svelte` (toolbar in `<nav>` `:288`; empty state `:406-415`; remove footer link `:347-352`; mount Sheet)
+
+- [ ] **Step 1: Implement the Sheet wrapper**
+
+Create `web/src/lib/components/scenes/CreateSceneSheet.svelte`:
+
+```svelte
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 HoloMUSH Contributors
+-->
+<script lang="ts">
+  import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+  } from '$lib/components/ui/sheet/index.js';
+  import CreateSceneForm from './CreateSceneForm.svelte';
+
+  let {
+    open = $bindable(false),
+    characters = [],
+  }: {
+    open?: boolean;
+    characters?: { characterId: string; name?: string; characterName?: string }[];
+  } = $props();
+</script>
+
+<Sheet bind:open>
+  <SheetContent side="right" class="p-0 flex flex-col">
+    <SheetHeader class="px-4 pt-4 pb-2">
+      <SheetTitle>New scene</SheetTitle>
+      <SheetDescription class="sr-only">Create a new scene you own</SheetDescription>
+    </SheetHeader>
+    <CreateSceneForm {characters} onDone={() => (open = false)} />
+  </SheetContent>
+</Sheet>
+```
+
+- [ ] **Step 2: Add toolbar + state + Sheet to `+page.svelte`**
+
+In the `<script>` block add state:
+
+```ts
+  let createSheetOpen = $state(false);
+```
+
+Import the Sheet component near the other scene-component imports (after `SceneContextRail` import, ~`:24`):
+
+```ts
+  import CreateSceneSheet from '$lib/components/scenes/CreateSceneSheet.svelte';
+```
+
+Insert the toolbar as the first child of the desktop `<nav>` (immediately after `<nav ...>` at `:288`, before the `<div class="p-3 pb-1">` My Scenes header):
+
+```svelte
+    <div class="flex items-center gap-1.5 p-2 border-b border-border/50">
+      <button
+        type="button"
+        aria-label="New scene"
+        onclick={() => (createSheetOpen = true)}
+        class="inline-flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-semibold text-primary-foreground hover:opacity-90"
+      >
+        + New scene
+      </button>
+      <a href="/scenes/browse" class="rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:border-primary">
+        Browse
+      </a>
+      <a href="/scenes/browse#archive" class="rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:border-primary">
+        Archive
+      </a>
+    </div>
+```
+
+Remove the now-redundant footer link block (`:347-352`):
+
+```svelte
+    <!-- DELETE this block (replaced by the top toolbar) -->
+    <div class="mt-auto border-t border-border/50 p-3">
+      <a href="/scenes/browse" class="text-xs text-muted-foreground hover:text-foreground transition-colors">
+        + browse · ⌕ archive
+      </a>
+    </div>
+```
+
+Mount the Sheet once near the end of the markup (sibling of the existing mobile `<Sheet>` blocks, after `:282`):
+
+```svelte
+  <CreateSceneSheet bind:open={createSheetOpen} {characters} />
+```
+
+- [ ] **Step 3: Add the empty-state CTA**
+
+Replace the empty-state block (`:406-415`) with a version that includes the create button:
+
+```svelte
+    {:else}
+      <!-- Empty state -->
+      <div class="flex-1 flex items-center justify-center">
+        <div class="text-center space-y-3">
+          <p class="text-muted-foreground">Select a scene from the list to begin</p>
+          <button
+            type="button"
+            aria-label="New scene"
+            onclick={() => (createSheetOpen = true)}
+            class="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+          >
+            + New scene
+          </button>
+          <p>
+            <a href="/scenes/browse" class="text-sm text-primary hover:underline">
+              Browse open scenes →
+            </a>
+          </p>
+        </div>
+      </div>
+    {/if}
+```
+
+- [ ] **Step 4: Type-check + build**
+
+Run: `cd web && pnpm check`
+Expected: no errors. (`createSheetOpen`, `CreateSceneSheet`, `characters` all resolve.)
+
+- [ ] **Step 5: Manual smoke (optional but recommended)**
+
+Run: `task dev` (separate terminal), open `/scenes` as a registered player, confirm the toolbar **+ New scene** opens the Sheet and a title-only create lands a scene in *My Scenes*.
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "feat(web): create-scene toolbar + empty-state CTA + Sheet on /scenes (holomush-5rh.22)"`
+
+---
+
+## Task 7: E2E — create a scene from the web with no telnet
+
+**Files:**
+
+- Modify: `web/e2e/scenes.spec.ts` (add a test in the `'Scenes workspace (E9.5)'` describe, `:314`)
+
+- [ ] **Step 1: Write the E2E test**
+
+Add to the `describe('Scenes workspace (E9.5)', …)` block. Reuse this file's existing registration flow (a fresh registered — non-guest — player; mirror the `page.goto('/register')` registration used at `web/e2e/scenes.spec.ts:222`). Do NOT use `createSceneViaTerminal` — the whole point is the GUI path with no terminal command:
+
+```ts
+test('registered player creates a scene from the web GUI with no telnet', async ({ page }) => {
+  // Register a fresh (non-guest) player via the existing onboarding helper
+  // (web/e2e/scenes.spec.ts:217). "No telnet" means the SCENE is created via the
+  // GUI below — never a typed `scene create` command; normal registration is fine.
+  await registerAndEnterTerminal(page, 'create-web');
+
+  await page.goto('/scenes');
+
+  // Empty workspace → create affordance is present.
+  const newSceneBtn = page.getByRole('button', { name: 'New scene' }).first();
+  await expect(newSceneBtn).toBeVisible({ timeout: 10000 });
+  await newSceneBtn.click();
+
+  const title = `Web Made ${Date.now()}`;
+  await page.getByLabel('Title').fill(title);
+  await page.getByRole('button', { name: 'Create scene' }).click();
+
+  // The new scene appears in My Scenes and becomes the focused scene.
+  await expect(page.getByRole('listbox', { name: 'My scenes' }).getByText(title)).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole('log', { name: 'scene log' })).toBeVisible({ timeout: 10000 });
+});
+```
+
+> `registerAndEnterTerminal(page, prefix)` (`web/e2e/scenes.spec.ts:217`) is the existing helper the sibling E9.5 tests use (e.g. `registerAndEnterTerminal(page, 'brw')`); it registers a real non-guest player. Reuse it directly with a fresh prefix — do not invent a new helper.
+
+- [ ] **Step 2: Run the E2E test**
+
+Run: `task test:e2e -- scenes.spec.ts`
+Expected: the new test PASSES (needs Docker; the task spins up the Playwright + stack compose).
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "test(e2e): web create-scene with no telnet (holomush-5rh.22)"`
+
+---
+
+## Final verification
+
+- [ ] **Run the full fast lane**
+
+Run: `task pr-prep`
+Expected: `✓ All PR checks passed.` (exit 0). Run as the sole command; read the exit code, not the log tail.
+
+- [ ] **Run scenes integration tests** (capability/manifest regression guard)
+
+Run: `task test:int -- ./test/integration/scenes/...`
+Expected: PASS. (No `plugins/core-scenes/plugin.yaml` change is expected — `CreateScene` is a method on the already-provided `SceneAccessService` and uses the already-declared `eval` capability — but verify nothing regressed.)
+
+- [ ] **Confirm the D4 disposition is recorded** in the spec (`§8`, resolved-by-evolution) — no R1 code is built.
+
+<!-- adr-capture: sha256=5ae236fcb4d0da90; session=535177b8; ts=2026-06-20T00:18:51Z; adrs=holomush-v4qmu,holomush-x8swp -->

--- a/docs/superpowers/specs/2026-06-19-web-create-scene-design.md
+++ b/docs/superpowers/specs/2026-06-19-web-create-scene-design.md
@@ -1,0 +1,286 @@
+# Web Create-Scene — Design
+
+- **Bead:** `holomush-5rh.22` (Scenes web: create-scene affordance) — Epic 9 (`holomush-5rh`)
+- **Theme:** `theme:web-portals` (`holomush-sz0h3`)
+- **Status:** Design (brainstorming) — pending `design-reviewer`
+- **Date:** 2026-06-19
+- **Author:** Sean Brandt (with Claude)
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are
+to be interpreted as in RFC 2119 / RFC 8174.
+
+---
+
+## 1. Problem & scope
+
+The web Scenes Portal (E9.5, `holomush-5rh.8`) shipped **participation-only**:
+browse, read, pose/say/ooc, watch, export. It has **no way to create a scene**.
+"Web client can **CREATE** … scenes" was an explicit original Phase-9 acceptance
+criterion (`holomush-5rh.18`) that the E9.5 redesign silently dropped. The result
+is a self-contradiction in E9.5's own design: §1 makes "a scenes-only player with
+no terminal session" a first-class supported state, yet that player can join,
+watch, and pose but can **never originate** a scene.
+
+This slice restores web create-scene. It satisfies the `theme:web-portals`
+principle (the web is a superset of telnet; `holomush-sz0h3`): a player MUST be
+able to start a scene from the web without ever touching telnet or a raw command
+line.
+
+**In scope:** a web create-scene affordance and the typed RPC path behind it
+(proto → facade → BFF → client → UI), plus recording the D4 / window-per-scene
+disposition.
+
+**Out of scope:**
+- `SceneService.CreateScene` backend — **already exists**
+  (`plugins/core-scenes`, called today by telnet `scene create`).
+- Scene lifecycle / management verbs (end/pause/resume/invite/kick/transfer/
+  set/order/publish-vote) — sibling `holomush-5rh.24`.
+- Guest gating of the Scenes nav link and the terminal `scene` command —
+  sibling `holomush-5rh.23`.
+- Forum integration — `holomush-5rh.9`.
+- Multi-window / pop-out scene routing — see §8 (resolved-by-evolution).
+
+---
+
+## 2. Architecture decision: typed RPC, not the command path
+
+**The web create-scene write MUST be a typed RPC, not an assembled
+`scene create <title>` command string.**
+
+This reframes — and for *structural* writes, supersedes — E9.5 D4 ("web writes
+ride the command path; no new write RPCs"). The governing principle
+(maintainer directive, 2026-06-19):
+
+> The command path (host `HandleCommand`; surfaces = telnet request/response and
+> the web `/terminal`) is for **human / CLI interaction only** — conversational
+> gameplay verbs a person performs in the moment (`scene join`, `pose`, `say`,
+> `ooc`, `emit`). **Everything else** — structural / CRUD / management operations
+> on objects (create, set, end, invite, …) — MUST be exposed as **typed RPCs**
+> through the BFF.
+
+This is not a new pattern on this surface: typed scene-write RPCs already exist —
+`WebWatchScene` and `WebExportScene` (`internal/web/scene_handlers.go:120,152`)
+proxy to `SceneAccessServer` facade mutations
+(`internal/grpc/sceneaccess_service.go:232` `WatchScene`).
+
+Rationale:
+- **Create returns a result the caller consumes** — the new scene. The command
+  path surfaces that only as human-readable prose (`"Scene created: <id>"`,
+  `plugins/core-scenes/commands.go` `handleCreate`) that the web would have to
+  parse. A typed RPC returns a structured `SceneInfo`.
+- **Atomic, no escaping hazard.** Free-text title/description cross the wire as
+  typed fields, not tokens in a single command line.
+- **Consistency** with the existing read + Watch/Export/SetFocus RPCs.
+
+**Rule of thumb (for this and future surfaces):** typed RPC when the operation
+returns something the caller consumes (create→`SceneInfo`, watch→participant,
+export→bytes); command path when it is a fire-and-forget human verb
+(pose/say/join). The existing web pose/say/ooc composer
+(`web/src/lib/components/scenes/SceneComposer.svelte`) and `scene join` staying on
+`sendCommand` is therefore **correct** and is not changed by this slice.
+
+**Cross-cutting consequence (recorded, not actioned here):** sibling
+`holomush-5rh.24`'s current "writes ride the command path per D4" framing is
+superseded by the same principle; its management verbs SHOULD also become typed
+RPCs. Flagged on that bead; not designed here.
+
+---
+
+## 3. Components & data flow
+
+### 3.1 Proto
+
+Two new request/response pairs and two new RPCs MUST be added, each fully
+documented per `.claude/rules/proto-doc-comments.md` (comments grounded in the
+implementing handler, no name-echo).
+
+- `SceneAccessService.CreateScene` (`api/proto/holomush/sceneaccess/v1`):
+  - Request: `player_session_token`, `character_id`, `title`, `description`.
+  - Response: `SceneInfo` (the created scene).
+- `WebService.WebCreateScene` (`api/proto/holomush/web/v1/web.proto`):
+  - Request: `session_id`, `character_id`, `title`, `description`.
+  - Response: `SceneInfo`.
+
+`SceneService.CreateScene` (`scenev1.CreateSceneRequest{CharacterId, Title,
+Description, …}`) is unchanged. `Visibility`, `LocationId`, `PoseOrderMode`,
+`ContentWarnings` default (location-optional = off-grid scene), matching telnet
+`scene create`'s title-only behavior.
+
+### 3.2 Facade (`internal/grpc/sceneaccess_service.go`)
+
+`SceneAccessServer.CreateScene` MUST mirror the established write template used by
+`WatchScene` (`:232`):
+
+1. `ps, err := s.resolveAndGate(ctx, req.GetPlayerSessionToken())` — resolve the
+   player-session token to the player identity **and gate the request**. This is
+   where **guest denial** is enforced for web-portal surfaces
+   (INV-SCENE-64); a guest token MUST be rejected here.
+2. `char, err := s.ownedCharacter(ctx, ps.PlayerID, req.GetCharacterId())` —
+   verify the player owns the requested character (anti-forgery). A character not
+   owned by the resolved player MUST be rejected.
+3. `dctx, release, err := s.beginDispatch(ctx, char, ps.PlayerID)` — establish the
+   host-vouched dispatch context for the downstream service call; `defer release()`.
+4. `resp, err := s.sceneClient.CreateScene(dctx, &scenev1.CreateSceneRequest{
+   CharacterId: char.ID.String(), Title: req.GetTitle(), Description:
+   req.GetDescription()})`.
+5. Return `&sceneaccessv1.CreateSceneResponse{Scene: resp.GetScene()}`.
+
+`CreateScene` MUST NOT require an existing game session (unlike `WatchScene`,
+which does `FindByCharacter` because it piggybacks on focus). Creation does not
+touch focus or sessions.
+
+Errors MUST be opaque at the boundary per `.claude/rules/grpc-errors.md`: log
+inner errors with `errutil.LogErrorContext`; return `status.Errorf(codes.Internal,
+"internal error")`; pass plugin status errors through as-is.
+
+### 3.3 BFF (`internal/web/scene_handlers.go`)
+
+`Handler.WebCreateScene` MUST proxy to `SceneAccessClient.CreateScene`, forwarding
+the session token + op fields exactly as `WebWatchScene` (`:120`) does, returning
+the `SceneInfo`. The gateway remains protocol-translation-only
+(`.claude/rules/gateway-boundary.md`): no DB access, no business logic.
+
+### 3.4 Web client (`web/src/lib/scenes/client.ts`)
+
+Add `createScene(sessionId, { characterId, title, description }) → SceneInfo`,
+wrapping `client.webCreateScene(...)`. It does **not** use `sendCommand`; the
+existing `sendSceneCommand` (`:101`) is untouched and remains for pose/say/ooc/join.
+
+### 3.5 UI
+
+**Acting character.** Create runs as a chosen character. With one character, it is
+used implicitly. With more than one, the Sheet MUST present an acting-character
+selector (default: first). The character's per-alt session is obtained via the
+existing `ensureSession(characterId)` (`web/src/lib/scenes/altSessions.svelte.ts`).
+`connectionId` is **not** required (create is request/response, not command
+routing).
+
+**`CreateSceneSheet.svelte`** (new) — a slide-over `Sheet` (existing
+`web/src/lib/components/ui/sheet` primitive) containing:
+- **Title** (`input`, required; Create disabled until non-empty).
+- **Description** (raw HTML `<textarea>`, styled as in `SceneComposer.svelte` —
+  there is no `ui/textarea` shadcn primitive; optional).
+- Acting-character selector when `characters.length > 1`.
+- **Create scene** button + Cancel.
+
+On submit it calls `createScene`, then `workspaceStore.refresh(characters)`
+(`workspaceStore.svelte.ts:69`) followed by `workspaceStore.select(newScene.id, '', actingCharacterId)`
+(`:135`; the 2nd arg is the unused legacy `_playerSessionId`, the 3rd is the
+acting character's id) so the new scene appears in *My Scenes* and is focused. The Sheet closes
+on success; failures surface inline (no close), mirroring `SceneComposer`'s
+error handling.
+
+**Left-rail toolbar** (`web/src/routes/(authed)/scenes/+page.svelte`) — a new thin
+action bar pinned above the *My Scenes* header (`~:300`): **+ New scene**
+(primary), **Browse**, **Archive**. The current footer link `+ browse · ⌕ archive`
+(`:347-352`) is removed (consolidated into the toolbar). **+ New scene** opens the
+Sheet.
+
+**Empty-state CTA** — the center pane's "No scene selected" empty state
+(`:406-415`) MUST gain a **+ New scene** button (the new-player fix), opening the
+same Sheet.
+
+Brand: the primary action uses brand cyan (`--brand-cyan-bright` /
+tile gradient); amber is **not** used as an accent here
+(`.claude/rules/branding.md`).
+
+---
+
+## 4. Authorization
+
+Create authorization is enforced **at the facade**, reusing the existing template:
+
+- **Guest denial** is inherited from `resolveAndGate` (INV-SCENE-64 — guests
+  denied at the facade for web-portal surfaces). No new guest logic is added here;
+  the terminal-command guest gate and the nav-link gate remain `holomush-5rh.23`.
+- **Character ownership** is enforced by `ownedCharacter` (the player MUST own the
+  acting character).
+
+**Open question for design/ABAC review:** v2 ABAC (§5.4) gates scene creation
+*only* by `command:scene execute` (v1's resource-level `scene:<id> create` action
+was removed). For a registered player owning the character, `resolveAndGate`
+(non-guest) + `ownedCharacter` is the natural facade equivalent and is the default
+"any registered character may create" policy. If the game must support a
+*further configurable* restriction on who may create scenes, the facade MUST
+evaluate an explicit policy (reusing the `command:scene execute` predicate rather
+than minting a new action). This spec assumes the default (guest-denied,
+owner-scoped) and defers any configurable-restriction policy to review. This is
+**not** a new invariant family; it reuses INV-SCENE-64 and the existing
+ownership/dispatch pattern.
+
+---
+
+## 5. Error handling
+
+- Facade & BFF: opaque `Internal` to the client; inner errors logged with
+  `errutil.LogErrorContext(ctx, …)` (`.claude/rules/grpc-errors.md`).
+- Translate gRPC↔oops at one layer only (the BFF boundary); plugin status errors
+  pass through.
+- UI: a failed `createScene` keeps the Sheet open and shows the error message;
+  the draft is preserved. A successful create that then fails to refresh/select
+  MUST still leave the scene created (the create is authoritative); refresh/select
+  is best-effort and retriable by reopening the workspace.
+
+---
+
+## 6. Testing
+
+- **Facade (Go unit, `internal/grpc`):** `CreateScene` — allows a registered owner
+  (calls `sceneClient.CreateScene`, returns `SceneInfo`); denies a guest
+  (resolveAndGate); denies a character the player does not own; opaque error on
+  downstream failure. Mirror the `mockSceneAccessClient` /
+  `scene_handlers_test.go` patterns.
+- **BFF (Go unit, `internal/web`):** `WebCreateScene` forwards token + op fields to
+  the facade and passes status errors through as-is (mirror
+  `TestWebWatchSceneForwardsTokenAndOpFieldsToFacade` /
+  `…PassesStatusErrorThroughAsIs`).
+- **Web (vitest):** `createScene` client wrapper; `CreateSceneSheet` component —
+  required-title validation, calls `createScene`, closes on success, error on
+  failure, acting-character selector appears only when >1 character.
+- **E2E (Playwright):** a registered player with **no telnet session** lands on an
+  empty `/scenes`, clicks **+ New scene**, enters a title (+ optional
+  description), submits, and the new scene appears in *My Scenes* and is focused.
+  This is the telnet-free path that MAY later bind a per-subsystem
+  "web surface is self-sufficient" invariant for scenes (per `holomush-sz0h3`).
+- Run `task test:int -- ./test/integration/scenes/...` and `task pr-prep` before
+  push. (Adding a method to the already-provided `SceneAccessService` needs no
+  manifest change; verify no `plugins/core-scenes/plugin.yaml` capability/`provides`
+  change is required.)
+
+---
+
+## 7. Invariants
+
+- **Reuses** INV-SCENE-64 (guest denied at the facade for web-portal surfaces).
+- Introduces **no** new invariant family. The create-authorization behavior is an
+  instance of existing guest-deny + ownership patterns. A future per-subsystem
+  "scenes web surface requires no telnet" invariant (from `holomush-sz0h3`) MAY be
+  minted and bound by the §6 E2E once the surface is genuinely telnet-free; that
+  is out of scope here.
+
+---
+
+## 8. D4 / window-per-scene disposition (bead R1)
+
+The bead carries a second residual: E9.5 D4 specified "window-per-scene routing
+(web)". The shipped portal instead delivers a **single-pane scene-switcher
+workspace** (`web/src/lib/scenes/workspaceStore.svelte.ts` `selectedSceneId` +
+3-pane layout) with unread badges and quick-switch, which was approved via the
+E9.5 visual-companion mockups (v3, D11).
+
+**Disposition: resolved-by-evolution.** The single-pane workspace satisfies D4's
+intent ("the web renders threads"). True multi-window / pop-out is **not** built
+in this slice and is not planned. This spec records the disposition; no code
+implements R1.
+
+---
+
+## 9. Open questions for the reviewer
+
+1. Facade create-authorization: is guest-deny (INV-SCENE-64) + `ownedCharacter`
+   sufficient, or must the facade additionally evaluate a configurable
+   `command:scene execute`–equivalent policy (§4)?
+2. Acting-character default when `characters.length > 1`: first character is
+   proposed — acceptable, or should it follow a "primary"/most-recent signal?
+3. Toolbar consolidation: removing the footer `+ browse · ⌕ archive` link in favor
+   of the toolbar — confirmed (mockup-approved), flagged here for completeness.

--- a/docs/superpowers/specs/2026-06-19-web-create-scene-design.md
+++ b/docs/superpowers/specs/2026-06-19-web-create-scene-design.md
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
 # Web Create-Scene — Design
 
 - **Bead:** `holomush-5rh.22` (Scenes web: create-scene affordance) — Epic 9 (`holomush-5rh`)
@@ -31,6 +36,7 @@ line.
 disposition.
 
 **Out of scope:**
+
 - `SceneService.CreateScene` backend — **already exists**
   (`plugins/core-scenes`, called today by telnet `scene create`).
 - Scene lifecycle / management verbs (end/pause/resume/invite/kick/transfer/
@@ -64,6 +70,7 @@ proxy to `SceneAccessServer` facade mutations
 (`internal/grpc/sceneaccess_service.go:232` `WatchScene`).
 
 Rationale:
+
 - **Create returns a result the caller consumes** — the new scene. The command
   path surfaces that only as human-readable prose (`"Scene created: <id>"`,
   `plugins/core-scenes/commands.go` `handleCreate`) that the web would have to
@@ -157,6 +164,7 @@ routing).
 
 **`CreateSceneSheet.svelte`** (new) — a slide-over `Sheet` (existing
 `web/src/lib/components/ui/sheet` primitive) containing:
+
 - **Title** (`input`, required; Create disabled until non-empty).
 - **Description** (raw HTML `<textarea>`, styled as in `SceneComposer.svelte` —
   there is no `ui/textarea` shadcn primitive; optional).

--- a/docs/superpowers/specs/2026-06-19-web-create-scene-design.md
+++ b/docs/superpowers/specs/2026-06-19-web-create-scene-design.md
@@ -284,3 +284,5 @@ implements R1.
    proposed — acceptable, or should it follow a "primary"/most-recent signal?
 3. Toolbar consolidation: removing the footer `+ browse · ⌕ archive` link in favor
    of the toolbar — confirmed (mockup-approved), flagged here for completeness.
+
+<!-- adr-capture: sha256=42a5599e370649cc; session=535177b8; ts=2026-06-20T00:18:51Z; adrs=holomush-v4qmu,holomush-x8swp -->


### PR DESCRIPTION
## What

Design + implementation plan + ADRs for restoring the web **create-scene** capability that the E9.5 portal redesign silently dropped (`holomush-5rh.22`, theme `web-portals`). Docs-only — no code yet; the 7 implementation tasks are materialized as bd children `holomush-5rh.22.1…7`.

## Key decision (ADR `holomush-v4qmu`)

Structural scene writes use a **typed `WebCreateScene` RPC** (web → `WebService` → `SceneAccessService.CreateScene` facade → `SceneService`), mirroring the existing `WebWatchScene`/`WebExportScene` pattern — **not** the command path. This supersedes E9.5 D4 ("web writes ride the command path") for structural writes. The command path stays for human/CLI conversational verbs (pose/say/join). ADR `holomush-x8swp` records window-per-scene as resolved-by-evolution (single-pane workspace; no multi-window build).

## Contents

- `docs/superpowers/specs/2026-06-19-web-create-scene-design.md` — design (design-reviewer: READY)
- `docs/superpowers/plans/2026-06-19-web-create-scene.md` — 7-task plan: proto → facade → BFF → web client/flow → form → wire+Sheet → E2E (plan-reviewer: READY)
- `docs/adr/holomush-v4qmu-*.md`, `docs/adr/holomush-x8swp-*.md` + index

## Review notes

Docs-only; the adversarial design-reviewer and plan-reviewer gates already passed (grounded at `path:line`). No code surface, so code-reviewer/abac-reviewer are not applicable to this PR. Implementation lands in follow-up PRs per the materialized beads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)