### PR TITLE
docs(grpc): document busEventToCoreEvent read-back reconstruction exception (holomush-jsrd7)

### DIFF
--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -853,8 +853,13 @@ func (a *busHistoryReaderAdapter) ReplayTail(ctx context.Context, stream string,
 	return result, nil
 }
 
-// busEventToCoreEvent translates an eventbus.Event to a core.Event for plugin
-// consumption. The Actor ID is a ULID string when present.
+// busEventToCoreEvent reconstructs a core.Event from a persisted
+// eventbus.Event on the history read-back path (ReplayTail / QueryHistory).
+// It MUST copy the stored ID and Timestamp verbatim — core.NewEvent() would
+// stamp a fresh ULID + time.Now(), corrupting historical identity and breaking
+// beforeID cursor pagination. This is the read path, not the I-16 append path,
+// so the raw core.Event{} literal is correct here. The Actor ID is a ULID
+// string when present.
 func busEventToCoreEvent(e eventbus.Event, stream string) core.Event {
 	actorID := ""
 	if e.Actor.ID != (ulid.ULID{}) {

--- a/cmd/holomush/sub_grpc_adapters_test.go
+++ b/cmd/holomush/sub_grpc_adapters_test.go
@@ -225,6 +225,7 @@ func TestBusEventToCoreEventPropagatesULIDActorID(t *testing.T) {
 	assert.Equal(t, id.String(), got.Actor.ID, "ULID actor id propagates through busEventToCoreEvent")
 	assert.Equal(t, core.ActorCharacter, got.Actor.Kind)
 	assert.Equal(t, e.ID, got.ID)
+	assert.Equal(t, e.Timestamp, got.Timestamp, "read-back reconstruction preserves the persisted timestamp; core.NewEvent() would overwrite it with time.Now()")
 	assert.Equal(t, "events.main.scene.01ABC", got.Stream)
 }
 

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -1349,7 +1349,10 @@ func (a *focusHistoryReaderAdapter) ReplayTail(ctx context.Context, stream strin
 }
 
 // busEventToCoreEvent translates an eventbus.Event to a core.Event for plugin
-// consumption. Mirrors cmd/holomush/sub_grpc.go:739.
+// consumption. Like its production twin in cmd/holomush/sub_grpc.go, this is a
+// history read-back reconstruction: it copies the stored ID and Timestamp
+// verbatim (core.NewEvent() would overwrite both with a fresh ULID + time.Now()).
+// See that function's comment for the full rationale.
 func busEventToCoreEvent(e eventbus.Event, stream string) core.Event {
 	actorID := ""
 	if e.Actor.ID != (ulid.ULID{}) {


### PR DESCRIPTION
## Summary

`holomush-jsrd7` asked to replace the `core.Event{}` struct literal in
`cmd/holomush/sub_grpc.go` with `core.NewEvent()`. Triage found the bead
**invalid** — that swap would be a **regression**:

- The literal lives in `busEventToCoreEvent`, the history **read-back**
  reconstruction path (`busHistoryReaderAdapter.ReplayTail` → `QueryHistory`).
  It copies `e.ID` and `e.Timestamp` from an **already-persisted** JetStream/
  Postgres event to hand to plugins. `core.NewEvent()` stamps a fresh
  `NewULID()` + `time.Now()`, which would overwrite historical identity and
  timestamp — breaking `beforeID` cursor pagination, consumer dedup, and
  history-time fidelity.
- I-16 scopes itself to events **appended** to the EventStore (write path), not
  read-back reconstruction (`internal/core/event.go:246`).
- The bead's lint premise is stale: **no active analyzer forbids `core.Event{}`
  literals.** The old gocritic "I-16 ruleguard" was dropped in the 2026-05-01
  go-analysis migration; only `ulid.Make()` (`ulidmakeforbidden`) and the
  cursor-package ban were ported. Remaining "I-16 ruleguard" mentions are stale
  doc-comments. The identical reconstruction twin at
  `internal/testsupport/integrationtest/harness.go` is green with no suppression.

Rather than apply the regressive fix, this hardens the sites so the false
positive isn't re-filed:

- Doc-comment at both reconstruction sites explaining the read-back exception
  (must preserve `ID`/`Timestamp`; `NewEvent()` would corrupt them).
- Fixed the harness twin's stale `Mirrors sub_grpc.go:739` line reference.
- Added a timestamp-preservation assertion to
  `TestBusEventToCoreEventPropagatesULIDActorID` to mechanically guard against a
  regressive `NewEvent()` swap.

**No functional change.**

A pre-existing, unrelated flaky test surfaced during `task pr-prep`
(`internal/eventbus/crypto/invalidation` rate-limiter timing flake, passes 3/3
in isolation) and is tracked separately as `holomush-kz7tb` — not part of this PR.

## Test Plan

- [x] `task pr-prep` (fast lane) — **pass** (`status=pass`, `exit=0`)
- [x] `task test -- -run TestBusEventToCoreEvent ./cmd/holomush/` — green, incl. new timestamp assertion
- [x] No behavior change (comments + one test assertion only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)