### PR TITLE
docs(plugin): document why test-abac-widget fixture is kept (holomush-6g45d)

### DIFF
--- a/plugins/test-abac-widget/main.go
+++ b/plugins/test-abac-widget/main.go
@@ -4,6 +4,21 @@
 // Package main implements the test-abac-widget binary plugin used by the
 // host's plugin integration tests to exercise the ABAC attribute resolver
 // and command dispatcher contracts. Not deployed in production.
+//
+// Why this fixture is kept (decision holomush-6g45d): it is the only
+// dependency-free, deterministic binary AttributeResolver in the tree.
+// core-scenes is the only other plugin that resolves ABAC attributes, but it
+// requires WorldService + Postgres + scene seeding and resolves
+// non-deterministic, data-dependent values — so it cannot substitute for the
+// deterministic permit/forbid and zero-RPC-preflight assertions in
+// test/integration/plugin/abac_widget_test.go. Replacing the binary with a Lua
+// fixture would exercise the Lua resolver path instead of the host↔binary gRPC
+// AttributeResolverService contract those tests target. Hence: keep.
+//
+// (Unrelated to the keep decision: this manifest's provides: entry for
+// AttributeResolverService is a known anomaly tracked in holomush-vr6yo —
+// AttributeResolverService is host-auto-registered and MUST NOT be declared in
+// provides:. Do not copy that line into a new plugin.)
 package main
 
 import (

--- a/site/src/content/docs/extending/how-to/abac-attribute-resolver.md
+++ b/site/src/content/docs/extending/how-to/abac-attribute-resolver.md
@@ -161,6 +161,14 @@ to add `creator` to your `GetSchema` response and wire it up in
 The minimal correct reference is
 [`plugins/test-abac-widget/main.go`](https://github.com/holomush/holomush/blob/main/plugins/test-abac-widget/main.go).
 
+This fixture is deliberately retained as the project's lightweight,
+deterministic reference resolver: it has no upstream dependencies and hardcodes
+its resolution, so the plugin ABAC integration tests can assert exact
+permit/forbid outcomes against a real binary over gRPC. The production resolver
+in `core-scenes` also implements this contract, but it depends on
+`WorldService`, Postgres, and seeded scene data, so it is not a substitute when
+you want a deterministic, dependency-free example to copy.
+
 It demonstrates three properties every resolver SHOULD have:
 
 1. **Schema/runtime consistency** — `GetSchema` declares exactly the two


### PR DESCRIPTION
## Summary

Resolves the evaluation bead **holomush-6g45d** ("Evaluate removing test-abac-widget fixture; relocate its ABAC-resolver tests").

**Decision: KEEP** the `test-abac-widget` binary fixture (user-ratified, "keep + harden rationale").

- It is the **only** dependency-free, deterministic binary `AttributeResolver` in the tree. The only other AttributeResolver — `core-scenes` — requires `WorldService` + Postgres + scene seeding and resolves non-deterministic data, so it cannot substitute for the deterministic permit/forbid and zero-RPC-preflight assertions in `test/integration/plugin/abac_widget_test.go`. A Lua substitute would exercise the Lua resolver path, not the host↔binary gRPC `AttributeResolverService` contract those tests target. Both substitutes degrade coverage; deletion only removes a ~150-LOC, 3-file, zero-dependency fixture — a clearly negative trade.

**Hardening applied (comment + docs only — no production code):**
- `plugins/test-abac-widget/main.go` — package doc-comment now records the keep rationale, plus a caveat that the `provides: AttributeResolverService` entry is a known anomaly tracked in `holomush-vr6yo` (do-not-copy; `AttributeResolverService` is host-auto-registered and MUST NOT be declared in `provides:` per `attribute.proto`).
- `site/src/content/docs/extending/how-to/abac-attribute-resolver.md` — Canonical Example section now explains why the fixture is the deterministic reference and why `core-scenes` is not a substitute.

> Note: my initial "two registration paths / designed pair with core-scenes" framing was inaccurate — declaring `AttributeResolverService` in `provides:` is a documented MUST NOT, so the hardening reflects only the accurate rationale and points the anomaly at its owning bead (`holomush-vr6yo`).

## Test Plan

- [x] `task pr-prep` (fast lane) — `status=pass, lane=fast, exit=0`
- [x] `task fmt:check` + `task lint:markdown` — both exit 0
- [x] No production code touched; change is package-comment + how-to doc prose only

🤖 Generated with [Claude Code](https://claude.com/claude-code)