### PR TITLE
fix(plugin): thread derived ctx into stdlib_streams.go hostfunc guard logs (holomush-thw6t)

### DIFF
--- a/internal/plugin/hostfunc/slog_trace_propagation_test.go
+++ b/internal/plugin/hostfunc/slog_trace_propagation_test.go
@@ -111,6 +111,48 @@ func TestJoinFocusGuardLogUsesBackgroundWhenLuaStateHasNoTraceContext(t *testing
 		"with no ctx on the Lua state, the guard log must carry no trace context (Background fallback)")
 }
 
+func TestAddSessionStreamNotInitializedGuardLogCarriesTraceContext(t *testing.T) {
+	h := installCapturingDefaultLogger(t)
+
+	// No stream registry → getStreamRegistry returns nil → the "stream registry
+	// not initialized" guard fires before the function derives its own ctx.
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+	hf := hostfunc.New(nil)
+	hf.Register(L, "test-plugin")
+
+	ctx, wantTraceID := tracedTestContext()
+	L.SetContext(ctx)
+
+	require.NoError(t, L.DoString(`holomush.add_session_stream("sess-1", "channel:abc")`))
+
+	sc := h.capturedSpanContext()
+	require.True(t, sc.IsValid(),
+		"guard log must carry the Lua state's trace context (use slog.WarnContext with a derived ctx)")
+	assert.Equal(t, wantTraceID, sc.TraceID(), "log ctx must carry the same trace as the Lua state")
+}
+
+func TestRemoveSessionStreamNotInitializedGuardLogCarriesTraceContext(t *testing.T) {
+	h := installCapturingDefaultLogger(t)
+
+	// No stream registry → getStreamRegistry returns nil → the "stream registry
+	// not initialized" guard fires before the function derives its own ctx.
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+	hf := hostfunc.New(nil)
+	hf.Register(L, "test-plugin")
+
+	ctx, wantTraceID := tracedTestContext()
+	L.SetContext(ctx)
+
+	require.NoError(t, L.DoString(`holomush.remove_session_stream("sess-1", "channel:abc")`))
+
+	sc := h.capturedSpanContext()
+	require.True(t, sc.IsValid(),
+		"guard log must carry the Lua state's trace context (use slog.WarnContext with a derived ctx)")
+	assert.Equal(t, wantTraceID, sc.TraceID(), "log ctx must carry the same trace as the Lua state")
+}
+
 func TestKVGetStoreUnavailableGuardLogCarriesTraceContext(t *testing.T) {
 	h := installCapturingDefaultLogger(t)
 

--- a/internal/plugin/hostfunc/stdlib_streams.go
+++ b/internal/plugin/hostfunc/stdlib_streams.go
@@ -45,7 +45,7 @@ func addSessionStreamFn(ls *lua.LState) int {
 
 	r := getStreamRegistry(ls)
 	if r == nil {
-		slog.Warn("holomush.add_session_stream: stream registry not initialized")
+		slog.WarnContext(luaContext(ls), "holomush.add_session_stream: stream registry not initialized")
 		return 0
 	}
 
@@ -73,7 +73,7 @@ func removeSessionStreamFn(ls *lua.LState) int {
 
 	r := getStreamRegistry(ls)
 	if r == nil {
-		slog.Warn("holomush.remove_session_stream: stream registry not initialized")
+		slog.WarnContext(luaContext(ls), "holomush.remove_session_stream: stream registry not initialized")
 		return 0
 	}
 


### PR DESCRIPTION
## Summary

- The two early-return guard logs in `addSessionStreamFn` / `removeSessionStreamFn` (`internal/plugin/hostfunc/stdlib_streams.go`) used bare `slog.Warn` where `ctx` is derivable via `ls.Context()`, producing log lines with no `trace_id`/`span_id` correlation.
- `sloglint context:scope` does not flag these — the guard returns *before* `ctx := ls.Context()` is bound, so no `ctx` variable is in lexical scope. This is a spirit-level violation of the `logging.md` "derivable value" rule, not a lint failure.
- Fix: `slog.Warn(...)` → `slog.WarnContext(luaContext(ls), ...)` at both sites, mirroring the holomush-135sn fix (#4469) and the `stdlib_focus.go` idiom. `luaContext` (`cap_session.go:193`) returns `ls.Context()` with a `context.Background()` fallback.
- Adds two trace-propagation tests reusing the existing `ctxCapturingHandler` harness; both RED before the fix, GREEN after.

Out of scope (per bead): `manager.go` (4 sites, needs API-signature changes) and `gateway_handler.go` (pure no-ctx helpers).

Closes holomush-thw6t.

## Test Plan

- [x] `task test -- ./internal/plugin/hostfunc/` — 442 pass (incl. 2 new trace-propagation tests)
- [x] `task lint:go` — 0 issues
- [x] `task pr-prep` (fast lane) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)