### PR TITLE
test(cluster): widen synthetic-member eviction window to de-flake invalidation rate-limit test (holomush-kz7tb)

### DIFF
--- a/internal/cluster/clustertest/harness.go
+++ b/internal/cluster/clustertest/harness.go
@@ -60,6 +60,24 @@ func WithPillRateLimit(d time.Duration) Option {
 	return func(cfg *cluster.Config) { cfg.PillRateLimit = d }
 }
 
+// WithEvictAfterMissed overrides the harness's default EvictAfterMissed (3).
+// The eviction sweeper reaps a member whose last heartbeat is older than
+// EvictAfterMissed × HeartbeatInterval (default 3 × 100ms = 300ms).
+//
+// A synthetic peer injected via PublishSyntheticHeartbeat heartbeats only
+// once, so with the default window it becomes a sweep candidate after only
+// ~300ms. Tests that inject a synthetic peer and then exercise it across
+// an unbounded scheduling gap (e.g. a coordinator rate-limit assertion run
+// under parallel -race, where the test goroutine can be descheduled past
+// 300ms while the sweeper fires on schedule) race that window. Bumping it
+// beyond plausible inter-step latency keeps the synthetic peer present for
+// the whole test, eliminating the wall-clock race.
+//
+// Resolves holomush-kz7tb (P2 flake).
+func WithEvictAfterMissed(n int) Option {
+	return func(cfg *cluster.Config) { cfg.EvictAfterMissed = n }
+}
+
 // New constructs a Harness with n Registry members on a shared NATS
 // connection. All members use cluster_id=clusterID. Optional [Option] values
 // override the harness defaults (e.g. [WithPillRateLimit]).

--- a/internal/cluster/clustertest/harness_test.go
+++ b/internal/cluster/clustertest/harness_test.go
@@ -71,6 +71,40 @@ func TestAwaitMemberPresentFatalsOnDeadlineWhenHeartbeatNeverArrives(t *testing.
 		"AwaitMemberPresent MUST Fatalf when deadline expires without a join")
 }
 
+// TestWithEvictAfterMissedKeepsSyntheticMemberPastDefaultWindow is the
+// regression guard for holomush-kz7tb. A one-shot synthetic heartbeat
+// keeps a member present only for EvictAfterMissed × HeartbeatInterval
+// before the sweeper reaps it (default 3×100ms = 300ms). Tests that
+// inject a synthetic peer and then exercise it across an unbounded
+// scheduling gap (the coordinator rate-limit assertion under parallel
+// -race) raced that 300ms window: when the gap stretched past 300ms the
+// member was swept, RequestInvalidation saw a single-member snapshot,
+// self-acked, and returned nil instead of the expected rate-limited
+// error. WithEvictAfterMissed widens the window so the member survives
+// well past any plausible inter-step latency.
+func TestWithEvictAfterMissedKeepsSyntheticMemberPastDefaultWindow(t *testing.T) {
+	t.Parallel()
+
+	// 100 × 100ms = 10s eviction window — far beyond the 400ms sleep
+	// below, which itself exceeds the DEFAULT 300ms window.
+	h := clustertest.New(t, "test-game", 1, clustertest.WithEvictAfterMissed(100))
+	target := cluster.MemberID("01HSYNTHETIC0EVICTWINDOW001")
+
+	h.PublishSyntheticHeartbeat(t, "test-game", target, "test")
+	h.AwaitMemberPresent(t, 0, target, 5*time.Second)
+
+	// Sleep well past the default ~300ms nominal window but far under the
+	// configured window (10s). Determinism here comes from the 10s window,
+	// not the sleep length: with the default EvictAfterMissed=3 the member
+	// would be a sweep candidate by now, whereas at 100 it cannot be reaped
+	// for ~10s, so the member MUST still be present.
+	time.Sleep(400 * time.Millisecond)
+
+	_, ok := h.Members[0].Registry.Member(target)
+	require.True(t, ok,
+		"synthetic member evicted within 400ms; WithEvictAfterMissed(100) must extend the window to 10s")
+}
+
 // mockTB satisfies clustertest.TB while recording Fatalf so a test can
 // assert the deadline path without aborting the outer test.
 type mockTB struct {

--- a/internal/eventbus/crypto/invalidation/coordinator_send_test.go
+++ b/internal/eventbus/crypto/invalidation/coordinator_send_test.go
@@ -66,7 +66,19 @@ func TestCoordinatorRequestInvalidationReturnsRateLimitedWhenProbeAndPillRefuses
 	// event-driven (holomush-1r0v.15) — its deadline is a fast-fail
 	// diagnostic, not a propagation timer. 5s is generous; healthy
 	// runs return in <50ms.
-	h := clustertest.New(t, "test-game", 2, clustertest.WithPillRateLimit(10*time.Second))
+	//
+	// EvictAfterMissed is bumped to 100 (10s eviction window, default
+	// 3×100ms = 300ms) so the synthetic member 1 — which heartbeats only
+	// once per PublishSyntheticHeartbeat — stays in member 0's snapshot
+	// across the whole test. Under parallel -race the gap between the
+	// synthetic heartbeat and RequestInvalidation's LiveMembers snapshot
+	// could exceed 300ms while the sweeper fired on schedule, reaping
+	// member 1; RequestInvalidation then saw a single-member snapshot,
+	// self-acked, and returned nil instead of the rate-limited error
+	// (holomush-kz7tb).
+	h := clustertest.New(t, "test-game", 2,
+		clustertest.WithPillRateLimit(10*time.Second),
+		clustertest.WithEvictAfterMissed(100))
 	h.AwaitConverged(t, 2*time.Second)
 
 	// Stop member 1 to make it unresponsive.


### PR DESCRIPTION
## Summary

Fixes the flaky `TestCoordinatorRequestInvalidationReturnsRateLimitedWhenProbeAndPillRefuses` (holomush-kz7tb), which intermittently failed under the parallel `-race` run with `expected oops error, got <nil>`.

**Root cause — the eviction sweeper, not the rate-limiter window the bead suspected.** The test's member 1 is a *synthetic* peer that heartbeats only once via `clustertest.PublishSyntheticHeartbeat`. The cluster eviction sweeper (`internal/cluster/heartbeat.go:sweepEvictions`) reaps a member after `EvictAfterMissed × HeartbeatInterval = 3 × 100ms = 300ms`. Under load the gap between the synthetic heartbeat and `RequestInvalidation`'s `LiveMembers()` snapshot could exceed 300ms while the sweeper fired on schedule, reaping member 1. `RequestInvalidation` then saw a single-member snapshot, self-acked via NATS loopback, and returned `nil` *before reaching the probe-and-pill rate-limit path*. (`PillRateLimit` was already 10s per holomush-ivnc, and the pill-rate map lives separate from `r.members`, so it was never the cause.)

**Fix — test-harness only, no production change:**
- Add `clustertest.WithEvictAfterMissed(n)`, mirroring the existing `WithPillRateLimit` option.
- The flaky test now passes `WithEvictAfterMissed(100)` (10s eviction window) so the synthetic member stays in member 0's snapshot across the whole test.
- Add deterministic regression test `TestWithEvictAfterMissedKeepsSyntheticMemberPastDefaultWindow`.

## Crypto-reviewer note

`coordinator_send_test.go` lives under `internal/eventbus/crypto/`, so the crypto-reviewer gate nominally fires. It was run and returned **READY**: the change is pure test-timing config (eviction-window widening) with zero impact on any crypto invariant — no DEK/KEK material, AAD, codec/envelope, `crypto.emits`, or `crypto_keys`/`events_audit` migration. The assertion the test protects (`INVALIDATION_RATE_LIMITED`) is a cluster pill-rate-limit guarantee, not a crypto one.

## Test Plan

- [x] Deterministic repro: a temporary 400ms sleep reproduced the exact `expected oops error, got <nil>` failure; with the fix the same forced gap passes.
- [x] 50× `-race` stress of the previously-flaky test — all green.
- [x] `invalidation` + `cluster` + `clustertest` packages (73 tests) green under `-race`.
- [x] `task pr-prep` fast lane: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)