### PR TITLE
docs: unified authed workspace shell — spec, plan, ADRs (holomush-q41kr)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,10 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Section registry is the single source of nav truth (Rail + palette)](holomush-stds8-section-registry-is-single-source-nav-truth-rail-palette.md) | 2026-06-20 | Accepted | `holomush-stds8` |
+| [Persistent authed chrome lives in a shared (authed)/+layout.svelte shell](holomush-828tt-persistent-authed-chrome-lives-shared-authed-layout-svelte-s.md) | 2026-06-20 | Accepted | `holomush-828tt` |
+| [Footer content uses a footerBridge store mirroring composerBridge](holomush-xhz3s-footer-content-uses-footerbridge-store-mirroring-composerbri.md) | 2026-06-20 | Accepted | `holomush-xhz3s` |
+| [Mobile navigation uses a Sheet drawer hosting the same Rail](holomush-8p5rx-mobile-navigation-uses-sheet-drawer-hosting-same-rail.md) | 2026-06-20 | Accepted | `holomush-8p5rx` |
 | [Typed RPCs for structural scene writes; command path for human/CLI verbs](holomush-v4qmu-typed-rpcs-structural-scene-writes-command-path-human-cli-ve.md) | 2026-06-20 | Accepted | `holomush-v4qmu` |
 | [Resolve window-per-scene as single-pane workspace; defer multi-window](holomush-x8swp-resolve-window-per-scene-as-single-pane-workspace-defer-mult.md) | 2026-06-20 | Accepted | `holomush-x8swp` |
 | [Scope Lua stub generator to static build-time surfaces only](holomush-vhz3h-scope-lua-stub-generator-static-build-time-surfaces-only.md) | 2026-06-16 | Accepted | `holomush-vhz3h` |

--- a/docs/adr/holomush-828tt-persistent-authed-chrome-lives-shared-authed-layout-svelte-s.md
+++ b/docs/adr/holomush-828tt-persistent-authed-chrome-lives-shared-authed-layout-svelte-s.md
@@ -1,0 +1,44 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-828tt; do not edit manually; use `/adr update holomush-828tt` -->
+
+# Persistent authed chrome lives in a shared (authed)/+layout.svelte shell
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Decision:** holomush-828tt
+**Deciders:** Sean Brandt
+
+## Context
+
+Before this change there was no `web/src/routes/(authed)/+layout.svelte` — only a load-only `+layout.ts`. The Rail, footer, and surrounding chrome existed only on `/terminal` (rendered inside the terminal page) and were absent on `/scenes`, so the two sections read as separate apps. Persistent workspace chrome needed a home that wraps every authed section without coupling to any one section's internals.
+
+## Decision
+
+A new `(authed)/+layout.svelte` is the persistent authed shell: it owns the route-aware Rail, the persistent footer, and the section slot (`{@render children()}`). The root `+layout.svelte` retains only the globally-applicable chrome — TopBar and the global overlays (Composer, CommandPalette). Each section keeps its own inner layout (terminal panes; scenes 3-pane) unchanged.
+
+The global keyboard handlers (⌘B rail, ⌘. sidebar, ⌘⇧E composer, ⌘L clear) STAY in the root layout for this change; relocating them into the authed shell was deferred as out of scope (it is a behavioral-surface change with no functional benefit to the shell unification). ⌘K palette likewise stays global in root.
+
+## Rationale
+
+- Matches SvelteKit's nested-layout design intent for auth-scoped chrome; the shell renders only for authed routes automatically, so the Rail/footer need no internal auth gate.
+- Keeps the root layout from accumulating auth-gated conditionals on top of its existing terminal-gated conditionals.
+- Section inner layouts are untouched, so the migration is additive (wrap), not invasive.
+- Keeping key handlers in root avoids re-binding churn and an avoidable behavioral-surface change during a chrome-only refactor.
+
+## Alternatives Considered
+
+- **New (authed)/+layout.svelte shell (chosen):** idiomatic boundary; sections untouched; TopBar stays in root.
+- **Per-section inner-layout duplication (rejected):** chrome copied into every section; the "one app" feel is never achieved; divergence is guaranteed as sections multiply.
+- **Root layout with auth-conditional Rail/footer (rejected):** compounds the route-conditional logic already in the root TopBar; not idiomatic SvelteKit for auth-scoped chrome.
+- **Relocate key handlers into the shell (deferred):** cleaner scoping, but a behavioral-surface change with no benefit to this refactor — handlers stay in root.
+
+## Consequences
+
+- Positive: adding future authed sections needs no shell change; pre-auth routes (`/login`, `/register`) never render the Rail or footer.
+- Negative: the shell owns viewport height, so each section page must size to its container (the terminal sheds its own `calc(100vh - topbar)` or it overflows the footer).
+- Neutral: key handlers remain in the root layout; a future change may relocate the authed-only ones into the shell if desired.

--- a/docs/adr/holomush-8p5rx-mobile-navigation-uses-sheet-drawer-hosting-same-rail.md
+++ b/docs/adr/holomush-8p5rx-mobile-navigation-uses-sheet-drawer-hosting-same-rail.md
@@ -1,0 +1,40 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-8p5rx; do not edit manually; use `/adr update holomush-8p5rx` -->
+
+# Mobile navigation uses a Sheet drawer hosting the same Rail
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Decision:** holomush-8p5rx
+**Deciders:** Sean Brandt
+
+## Context
+
+On viewports below 768px the persistent left Rail collapses to zero width, so a mobile user has no section navigation. The workspace must let users switch sections on mobile without permanently consuming screen space — especially on the terminal surface, where the software keyboard already limits visible lines.
+
+## Decision
+
+Mobile navigation (<768px) uses a shadcn `Sheet` (slide-over drawer) opened by a ☰ button in the TopBar (shown only when authenticated, on narrow viewports). The drawer hosts the SAME `SectionRail` component in an icon+label variant. Drawer open-state is a transient (non-persisted) store bridging the TopBar trigger to the shell's Sheet; the drawer closes on navigation, scrim tap, and Esc.
+
+## Rationale
+
+- Zero permanent screen space consumed — critical for terminal usability on mobile.
+- One Rail component serves both desktop (icon-only column) and mobile (icon+label drawer); a single navigation mental model and one active-state code path.
+- The `Sheet` primitive is already in the codebase (used by CreateSceneSheet) and provides scrim/Esc dismissal, so no custom dismiss logic is needed.
+
+## Alternatives Considered
+
+- **Sheet drawer reusing the Rail (chosen):** zero permanent space; one component; primitive already present.
+- **Bottom tab bar (rejected):** conventional and always-visible, but permanently occupies vertical space and stacks above the footer — unacceptable on the terminal surface and fights the software keyboard.
+- **Top tab bar / breadcrumb (rejected):** consumes vertical space, competes with the TopBar, and breaks from the desktop icon-rail aesthetic.
+
+## Consequences
+
+- Positive: desktop and mobile share the same section items and active-state logic; no extra permanent chrome on mobile.
+- Negative: navigation takes an extra tap (☰ then section) on mobile; the drawer must be explicitly closed on navigation or it lingers after the route change.
+- Neutral: the TopBar gains a ☰ button visible only to authenticated users on narrow viewports.

--- a/docs/adr/holomush-stds8-section-registry-is-single-source-nav-truth-rail-palette.md
+++ b/docs/adr/holomush-stds8-section-registry-is-single-source-nav-truth-rail-palette.md
@@ -1,0 +1,40 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-stds8; do not edit manually; use `/adr update holomush-stds8` -->
+
+# Section registry is the single source of nav truth (Rail + palette)
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Decision:** holomush-stds8
+**Deciders:** Sean Brandt
+
+## Context
+
+The web client's left Rail and ⌘K CommandPalette had no shared source of navigation items. Rail items were hardcoded in `terminal/Rail.svelte` (Room hardcoded active; DM/Map/Notes disabled placeholders) and the palette had no section-switching entries at all. As the workspace grows to several authed sections (scenes, DMs, forum, wiki, profiles), adding one would require independent edits in two unrelated surfaces — guaranteeing drift between what the Rail shows and what the palette can jump to.
+
+## Decision
+
+A typed `WorkspaceSection[]` registry (`web/src/lib/nav/sections.ts`) is the sole authority for both Rail items and palette "go to <section>" entries. The Rail and the palette MUST derive their items and route-driven active state from this registry and MUST NOT hardcode section lists independently. The registry is pure TypeScript (no Svelte/icon imports); the Rail maps section `id` to a lucide icon locally.
+
+## Rationale
+
+- Eliminates the class of drift bugs where the palette and Rail disagree on available sections.
+- The registry is pure data, so it unit-tests in the plain vitest project without component mounting.
+- The growth path is explicit: a future section (DMs, Forum) is one registry entry plus its route, and it appears in both surfaces automatically.
+- Active state is a per-section prefix predicate, so nested routes (`/scenes/[id]`) resolve to the parent section uniformly across Rail and palette.
+
+## Alternatives Considered
+
+- **Declarative registry feeding both surfaces (chosen):** single source of truth; one edit per new section; testable as plain TS.
+- **Independent hardcoded lists in Rail and palette (rejected):** no abstraction cost, but the lists drift, every new section needs ≥2 edits in unrelated files, and the rail-as-section-switcher goal is unreachable without coupling anyway.
+
+## Consequences
+
+- Positive: Rail and palette cannot disagree on sections; future section authors touch one file.
+- Negative: a small indirection — component authors must read the registry to know what the Rail renders.
+- Neutral: the Rail's bottom ⚙ view-prefs control is pinned outside the registry list and stays a Rail-internal concern; the vestigial `RailView` type and its placeholders are retired.

--- a/docs/adr/holomush-xhz3s-footer-content-uses-footerbridge-store-mirroring-composerbri.md
+++ b/docs/adr/holomush-xhz3s-footer-content-uses-footerbridge-store-mirroring-composerbri.md
@@ -1,0 +1,40 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-xhz3s; do not edit manually; use `/adr update holomush-xhz3s` -->
+
+# Footer content uses a footerBridge store mirroring composerBridge
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Decision:** holomush-xhz3s
+**Deciders:** Sean Brandt
+
+## Context
+
+The persistent shell footer must render content that varies by active section (the terminal's hotkey bar vs. a quiet baseline) without the shell layout importing section-specific components. SvelteKit nested layouts render children downward, so a section page cannot pass a snippet "up" into the shell footer via slots. The codebase already solves an analogous page→layout content-injection problem with `composerBridge.ts` (a writable store plus register/invoke helpers).
+
+## Decision
+
+A new `footerBridge` store (a `writable<Snippet | null>` with `setFooter`/`clearFooter`, the same shape as `composerBridge`) is the mechanism for sections to push footer content. `ShellFooter` renders the registered snippet via `{@render}`, falling back to a baseline (section name + ⌘K hint + connection dot) when nothing is registered. The terminal registers its hotkey bar as a snippet on mount and clears it on destroy.
+
+## Rationale
+
+- The composerBridge precedent is already proven and understood by contributors; reusing the pattern avoids inventing a second coordination mechanism.
+- Register-on-mount / clear-on-destroy means the footer never renders a dead snippet, and a section with no special footer needs zero code — the baseline renders automatically.
+- Storing a Svelte snippet (not plain markup) preserves the terminal's live state (line count, composer nudge) after relocation out of CommandInput.
+
+## Alternatives Considered
+
+- **footerBridge store, mirroring composerBridge (chosen):** decouples shell from section internals; proven pattern; always-present baseline keeps the frame visually closed.
+- **Named slot / snippet passed through the layout hierarchy (rejected):** SvelteKit layouts do not hoist named slots up across layout boundaries cleanly; would require context or prop-drilling through the section's own layout.
+- **Shell imports section-specific footer components (rejected):** couples the shell to every section that has footer content; adding a section means editing the shell.
+
+## Consequences
+
+- Positive: sections are fully decoupled from footer rendering; new sections get the baseline for free.
+- Negative: two indirect coordination stores (composer + footer) make the data flow less obvious to new contributors; a malformed registered snippet could diverge from the footer's visual contract.
+- Neutral: the terminal hotkey bar moves from `CommandInput.svelte` into a bridge-registered snippet — a relocation, not a rewrite. If Svelte scoped styles do not follow the relocated snippet, the `.cmd-hints` rules lift to `:global`.

--- a/docs/superpowers/plans/2026-06-20-unified-authed-shell.md
+++ b/docs/superpowers/plans/2026-06-20-unified-authed-shell.md
@@ -1,0 +1,1130 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Unified Authed Workspace Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every authed web section share one persistent workspace frame — a route-aware left Rail (+ `⌘K` palette nav) and a persistent footer — so `/terminal` and `/scenes` read as one app instead of two.
+
+**Architecture:** A new SvelteKit nested layout `web/src/routes/(authed)/+layout.svelte` owns the persistent chrome (Rail + footer) and renders each section in its slot. A declarative section registry feeds both the Rail and the palette. The terminal's footer hotkeys move into a shell-owned footer via a `footerBridge` store (mirroring the existing `composerBridge`). Mobile collapses the Rail into a `Sheet` drawer.
+
+**Tech Stack:** SvelteKit 2, Svelte 5 runes, Tailwind v4, shadcn-svelte (`Sheet`, `DropdownMenu`), bits-ui, lucide-svelte, vitest (`mount`/`unmount`), Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-unified-authed-shell-design.md`
+
+**Working dir:** all paths are under `web/`. Run commands from `web/` (`cd web` first).
+
+**Scope guard:** chrome/shell only. NOT enabling future sections, terminal game logic, or scene CRUD. Per spec §9: global key handlers **stay in the root layout** (out of scope to relocate); the Rail file **is renamed** `terminal/Rail.svelte` → `shell/SectionRail.svelte`; the footer spans the section-content width.
+
+**Test commands:** `pnpm test:unit` (vitest, both projects), `pnpm check` (svelte-check), `pnpm exec playwright test e2e/<file>` (E2E). Per-file unit run: `pnpm test:unit -- src/lib/nav/sections.test.ts`.
+
+---
+
+## Phase 1: Foundation stores & registry
+
+### Task 1: Section registry (`nav/sections.ts`)
+
+The single source of truth for Rail items and palette nav. Kept **pure** (no Svelte/icon imports) so it runs in the plain `*.test.ts` vitest project. Icons are mapped in the Rail component (Task 4).
+
+**Files:**
+
+- Create: `web/src/lib/nav/sections.ts`
+- Test: `web/src/lib/nav/sections.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// web/src/lib/nav/sections.test.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { describe, expect, it } from 'vitest';
+import { SECTIONS, activeSectionId, activeSectionLabel, sectionNavEntries } from './sections';
+
+describe('section registry', () => {
+  it('lists Room then Scenes with their routes', () => {
+    expect(SECTIONS.map((s) => s.id)).toEqual(['room', 'scenes']);
+    expect(SECTIONS.map((s) => s.href)).toEqual(['/terminal', '/scenes']);
+  });
+});
+
+describe('activeSectionId uses prefix match', () => {
+  it('marks Room active on /terminal', () => {
+    expect(activeSectionId('/terminal')).toBe('room');
+  });
+  it('marks Scenes active on /scenes and nested routes', () => {
+    expect(activeSectionId('/scenes')).toBe('scenes');
+    expect(activeSectionId('/scenes/browse')).toBe('scenes');
+    expect(activeSectionId('/scenes/01HZN3XS')).toBe('scenes');
+  });
+  it('does not false-match a sibling prefix', () => {
+    expect(activeSectionId('/scenesfoo')).toBeNull();
+  });
+  it('returns null for an unregistered route', () => {
+    expect(activeSectionId('/characters')).toBeNull();
+  });
+});
+
+describe('activeSectionLabel', () => {
+  it('returns the active section label', () => {
+    expect(activeSectionLabel('/scenes/x')).toBe('Scenes');
+    expect(activeSectionLabel('/characters')).toBeNull();
+  });
+});
+
+describe('sectionNavEntries', () => {
+  it('derives palette go-to entries from the same registry', () => {
+    expect(sectionNavEntries()).toEqual([
+      { id: 'nav.room', label: 'Go to Room', href: '/terminal' },
+      { id: 'nav.scenes', label: 'Go to Scenes', href: '/scenes' },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:unit -- src/lib/nav/sections.test.ts`
+Expected: FAIL — `Cannot find module './sections'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// web/src/lib/nav/sections.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+/**
+ * A workspace section reachable from the persistent Rail / palette.
+ * Pure data only — the Rail (SectionRail.svelte) maps `id` to a lucide icon,
+ * so this module stays free of Svelte imports and runs in the node test project.
+ */
+export interface WorkspaceSection {
+  id: string;
+  label: string;
+  href: string;
+  /** True when `pathname` is within this section (the route or a child of it). */
+  match: (pathname: string) => boolean;
+}
+
+const prefix = (base: string) => (pathname: string) =>
+  pathname === base || pathname.startsWith(base + '/');
+
+/** Ordered registry. Add a section here (+ its route) to grow the Rail + palette. */
+export const SECTIONS: WorkspaceSection[] = [
+  { id: 'room', label: 'Room', href: '/terminal', match: prefix('/terminal') },
+  { id: 'scenes', label: 'Scenes', href: '/scenes', match: prefix('/scenes') },
+];
+
+export function activeSectionId(pathname: string): string | null {
+  return SECTIONS.find((s) => s.match(pathname))?.id ?? null;
+}
+
+export function activeSectionLabel(pathname: string): string | null {
+  return SECTIONS.find((s) => s.match(pathname))?.label ?? null;
+}
+
+export interface SectionNavEntry {
+  id: string;
+  label: string;
+  href: string;
+}
+
+/** Palette "go to <section>" entries, derived from {@link SECTIONS}. */
+export function sectionNavEntries(): SectionNavEntry[] {
+  return SECTIONS.map((s) => ({ id: `nav.${s.id}`, label: `Go to ${s.label}`, href: s.href }));
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:unit -- src/lib/nav/sections.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(web): section registry for the authed workspace shell (holomush-q41kr)"` (append the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` byline).
+
+---
+
+### Task 2: Footer bridge store (`stores/footerBridge.ts`)
+
+Lets the active section push footer content into the shell's persistent footer. Mirrors `web/src/lib/stores/composerBridge.ts:1-21`. Stores a Svelte `Snippet` so terminal-local reactive state (line count) survives the relocation.
+
+**Files:**
+
+- Create: `web/src/lib/stores/footerBridge.ts`
+- Test: `web/src/lib/stores/footerBridge.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// web/src/lib/stores/footerBridge.test.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import type { Snippet } from 'svelte';
+import { footerContent, setFooter, clearFooter } from './footerBridge';
+
+describe('footerBridge', () => {
+  it('stores and clears a footer snippet', () => {
+    const fake = (() => {}) as unknown as Snippet;
+    clearFooter();
+    expect(get(footerContent)).toBeNull();
+    setFooter(fake);
+    expect(get(footerContent)).toBe(fake);
+    clearFooter();
+    expect(get(footerContent)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:unit -- src/lib/stores/footerBridge.test.ts`
+Expected: FAIL — `Cannot find module './footerBridge'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// web/src/lib/stores/footerBridge.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import type { Snippet } from 'svelte';
+import { writable } from 'svelte/store';
+
+/**
+ * Content the active section renders inside the shell's persistent footer.
+ * `null` => the shell renders its baseline. Mirrors composerBridge: a section
+ * registers on mount and clears on destroy, so the bar never renders a dead
+ * snippet.
+ */
+export const footerContent = writable<Snippet | null>(null);
+
+export function setFooter(snippet: Snippet): void {
+  footerContent.set(snippet);
+}
+
+export function clearFooter(): void {
+  footerContent.set(null);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:unit -- src/lib/stores/footerBridge.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(web): footerBridge store for shell-owned section footer (holomush-q41kr)"` (+ byline).
+
+---
+
+### Task 3: Mobile nav store (`stores/mobileNavStore.ts`)
+
+Transient (never persisted) open-state bridging the TopBar `☰` (root layout) to the drawer `Sheet` (authed layout).
+
+**Files:**
+
+- Create: `web/src/lib/stores/mobileNavStore.ts`
+- Test: `web/src/lib/stores/mobileNavStore.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// web/src/lib/stores/mobileNavStore.test.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { mobileNavOpen, openMobileNav, closeMobileNav, toggleMobileNav } from './mobileNavStore';
+
+beforeEach(() => closeMobileNav());
+
+describe('mobileNavStore', () => {
+  it('opens, closes, and toggles', () => {
+    expect(get(mobileNavOpen)).toBe(false);
+    openMobileNav();
+    expect(get(mobileNavOpen)).toBe(true);
+    toggleMobileNav();
+    expect(get(mobileNavOpen)).toBe(false);
+    toggleMobileNav();
+    expect(get(mobileNavOpen)).toBe(true);
+    closeMobileNav();
+    expect(get(mobileNavOpen)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:unit -- src/lib/stores/mobileNavStore.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// web/src/lib/stores/mobileNavStore.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { writable } from 'svelte/store';
+
+/** Open-state for the mobile nav drawer. Transient — intentionally NOT persisted. */
+export const mobileNavOpen = writable(false);
+
+export const openMobileNav = () => mobileNavOpen.set(true);
+export const closeMobileNav = () => mobileNavOpen.set(false);
+export const toggleMobileNav = () => mobileNavOpen.update((v) => !v);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:unit -- src/lib/stores/mobileNavStore.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(web): transient mobileNav store for drawer toggle (holomush-q41kr)"` (+ byline).
+
+---
+
+## Phase 2: Shell components
+
+### Task 4: SectionRail component (`components/shell/SectionRail.svelte`)
+
+Renders the registry as real `<a>` links with route-driven active state. Pure: takes `pathname` as a prop (no `$app/stores`), so it unit-tests via `mount`. Supersedes `terminal/Rail.svelte` (deleted in Task 10). Styles adapted from `terminal/Rail.svelte:105-186`; theme submenu dropped (dedup → TopBar), `⚙` keeps view-prefs only.
+
+**Files:**
+
+- Create: `web/src/lib/components/shell/SectionRail.svelte`
+- Test: `web/src/lib/components/shell/SectionRail.svelte.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// web/src/lib/components/shell/SectionRail.svelte.test.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { afterEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import SectionRail from './SectionRail.svelte';
+
+function render(props: { pathname: string; variant?: 'rail' | 'drawer' }) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(SectionRail, { target, props });
+  return { target, component };
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe('SectionRail', () => {
+  it('renders one link per registry section, in order, to its href', () => {
+    const { target, component } = render({ pathname: '/terminal' });
+    const hrefs = [...target.querySelectorAll('a.rail-btn')].map((a) => a.getAttribute('href'));
+    expect(hrefs).toEqual(['/terminal', '/scenes']);
+    unmount(component);
+  });
+
+  it('marks the active section from the pathname (prefix match)', () => {
+    const { target, component } = render({ pathname: '/scenes/01HZN' });
+    const active = target.querySelector('a.rail-btn.is-active');
+    expect(active?.getAttribute('href')).toBe('/scenes');
+    expect(active?.getAttribute('aria-current')).toBe('page');
+    unmount(component);
+  });
+
+  it('shows text labels in the drawer variant', () => {
+    const { target, component } = render({ pathname: '/terminal', variant: 'drawer' });
+    expect(target.textContent).toContain('Room');
+    expect(target.textContent).toContain('Scenes');
+    unmount(component);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:unit -- src/lib/components/shell/SectionRail.svelte.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```svelte
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 HoloMUSH Contributors
+-->
+<script lang="ts">
+  import { Home, Clapperboard, Settings } from '@lucide/svelte';
+  import type { Component } from 'svelte';
+  import { SECTIONS } from '$lib/nav/sections';
+  import { uiPrefs, toggleDensity } from '$lib/stores/uiPrefsStore';
+  import { themePreferences, setTerminalBlackBackground } from '$lib/stores/themeStore';
+  import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+
+  interface Props {
+    /** Current route path; drives active state. Passed from the layout. */
+    pathname: string;
+    /** 'rail' = persistent desktop column; 'drawer' = mobile Sheet (shows labels). */
+    variant?: 'rail' | 'drawer';
+    /** Called when a section link is clicked (drawer closes itself via this). */
+    onnavigate?: () => void;
+  }
+  let { pathname, variant = 'rail', onnavigate }: Props = $props();
+
+  // id → icon: kept here so nav/sections.ts stays Svelte-free / node-testable.
+  const icons: Record<string, Component> = { room: Home, scenes: Clapperboard };
+</script>
+
+<aside
+  class="rail"
+  class:is-drawer={variant === 'drawer'}
+  class:is-hidden={variant === 'rail' && $uiPrefs.railHidden}
+  data-testid="rail"
+  aria-label="Navigation rail"
+>
+  <div class="rail-inner">
+    {#each SECTIONS as section (section.id)}
+      {@const Icon = icons[section.id]}
+      {@const active = section.match(pathname)}
+      <a
+        href={section.href}
+        class="rail-btn"
+        class:is-active={active}
+        title={section.label}
+        aria-label={section.label}
+        aria-current={active ? 'page' : undefined}
+        onclick={() => onnavigate?.()}
+      >
+        <Icon size={18} />
+        {#if active}<span class="rail-bar" aria-hidden="true"></span>{/if}
+        {#if variant === 'drawer'}<span class="rail-label">{section.label}</span>{/if}
+      </a>
+    {/each}
+
+    <div class="rail-spacer"></div>
+
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        {#snippet child({ props })}
+          <button {...props} class="rail-btn" title="View preferences" aria-label="View preferences">
+            <Settings size={18} />
+            {#if variant === 'drawer'}<span class="rail-label">Settings</span>{/if}
+          </button>
+        {/snippet}
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="end" side="right" class="w-56">
+        <DropdownMenu.Label>Density</DropdownMenu.Label>
+        <DropdownMenu.CheckboxItem
+          checked={$uiPrefs.density === 'compact'}
+          onCheckedChange={() => toggleDensity()}
+        >
+          Compact
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.Separator />
+        <DropdownMenu.CheckboxItem
+          checked={$themePreferences.terminalBlackBackground}
+          onCheckedChange={(v) => setTerminalBlackBackground(v === true)}
+        >
+          Black terminal background
+        </DropdownMenu.CheckboxItem>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+
+    {#if variant === 'rail'}
+      <div class="rail-hint" aria-hidden="true"><kbd>⌘</kbd><kbd>B</kbd></div>
+    {/if}
+  </div>
+</aside>
+
+<style>
+  .rail {
+    width: var(--rail-w);
+    flex-shrink: 0;
+    overflow: hidden;
+    background: var(--color-sidebar-background);
+    border-right: 1px solid var(--color-border);
+    transition: width 180ms ease;
+  }
+  .rail.is-drawer {
+    width: 100%;
+    border-right: none;
+  }
+  .rail.is-hidden {
+    width: 0;
+    border-right-width: 0;
+  }
+  /* Persistent desktop rail collapses on small screens; the drawer is exempt. */
+  @media (max-width: 767px) {
+    .rail:not(.is-drawer) {
+      width: 0;
+      border-right-width: 0;
+    }
+  }
+  .rail-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 6px 0 4px;
+    height: 100%;
+    gap: 4px;
+  }
+  .rail.is-drawer .rail-inner {
+    align-items: stretch;
+    padding: 10px 8px;
+    gap: 6px;
+  }
+  .rail-btn {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    color: var(--color-status-text);
+    text-decoration: none;
+    position: relative;
+    transition: background 120ms, color 120ms;
+  }
+  .rail.is-drawer .rail-btn {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 10px;
+    padding: 0 10px;
+  }
+  .rail-label {
+    font-family: var(--font-sans, system-ui);
+    font-size: 13px;
+  }
+  .rail-btn:hover {
+    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+    color: var(--color-input-text);
+  }
+  .rail-btn.is-active {
+    color: var(--color-primary);
+  }
+  .rail-btn.is-active .rail-bar {
+    position: absolute;
+    left: -6px;
+    top: 6px;
+    bottom: 6px;
+    width: 2px;
+    background: var(--color-primary);
+    border-radius: 1px;
+  }
+  .rail.is-drawer .rail-btn.is-active {
+    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  }
+  .rail-spacer { flex: 1; }
+  .rail-hint { margin: 4px 0; }
+  .rail-hint kbd {
+    display: inline-block;
+    padding: 1px 3px;
+    font-size: 9px;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    color: var(--color-status-text);
+  }
+  .rail-hint kbd + kbd { margin-left: 1px; }
+</style>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:unit -- src/lib/components/shell/SectionRail.svelte.test.ts`
+Expected: PASS (3 cases). If `DropdownMenu` mounting warns under jsdom, the assertions still pass (they target `a.rail-btn`); only investigate on a hard failure.
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(web): SectionRail — registry-driven, route-aware section switcher (holomush-q41kr)"` (+ byline).
+
+---
+
+### Task 5: ShellFooter component (`components/shell/ShellFooter.svelte`)
+
+Persistent footer bar. Renders the active section's registered snippet, else the baseline (section name + `⌘K go to…` + connection dot). Pure: takes `pathname`.
+
+**Files:**
+
+- Create: `web/src/lib/components/shell/ShellFooter.svelte`
+- Test: `web/src/lib/components/shell/ShellFooter.svelte.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// web/src/lib/components/shell/ShellFooter.svelte.test.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { afterEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import { clearFooter } from '$lib/stores/footerBridge';
+import ShellFooter from './ShellFooter.svelte';
+
+afterEach(() => {
+  clearFooter();
+  document.body.replaceChildren();
+});
+
+describe('ShellFooter baseline', () => {
+  it('renders the active section name and a go-to hint when nothing is registered', () => {
+    clearFooter();
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const component = mount(ShellFooter, { target, props: { pathname: '/scenes' } });
+    expect(target.textContent).toContain('Scenes');
+    expect(target.textContent?.toLowerCase()).toContain('go to');
+    unmount(component);
+  });
+
+  it('falls back to a generic label off any registered section', () => {
+    clearFooter();
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const component = mount(ShellFooter, { target, props: { pathname: '/characters' } });
+    expect(target.textContent).toContain('Workspace');
+    unmount(component);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:unit -- src/lib/components/shell/ShellFooter.svelte.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```svelte
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 HoloMUSH Contributors
+-->
+<script lang="ts">
+  import { footerContent } from '$lib/stores/footerBridge';
+  import { connectionStatus } from '$lib/stores/connectionStore';
+  import { activeSectionLabel } from '$lib/nav/sections';
+
+  interface Props {
+    /** Current route path; selects the baseline section label. */
+    pathname: string;
+  }
+  let { pathname }: Props = $props();
+
+  let label = $derived(activeSectionLabel(pathname) ?? 'Workspace');
+</script>
+
+<div class="shell-footer" data-testid="shell-footer">
+  {#if $footerContent}
+    {@render $footerContent()}
+  {:else}
+    <span class="sf-section">{label}</span>
+    <span class="sf-grow"></span>
+    <span class="sf-hint"><kbd>⌘K</kbd> go to…</span>
+    <span class="sf-conn" data-status={$connectionStatus} title="Connection">
+      <span class="sf-dot" aria-hidden="true"></span>
+      {#if $connectionStatus === 'connected'}connected{:else if $connectionStatus === 'syncing'}syncing{:else}offline{/if}
+    </span>
+  {/if}
+</div>
+
+<style>
+  .shell-footer {
+    flex-shrink: 0;
+    min-height: 26px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 12px;
+    background: var(--color-background);
+    border-top: 1px solid var(--color-border);
+    color: var(--color-status-text);
+    font-size: 12px;
+  }
+  .sf-grow { flex: 1; }
+  .sf-hint kbd {
+    font-family: inherit;
+    padding: 1px 5px;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    font-size: 11px;
+  }
+  .sf-conn { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; }
+  .sf-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-status-text); }
+  .sf-conn[data-status='connected'] .sf-dot { background: var(--color-status-online); }
+  .sf-conn[data-status='syncing'] .sf-dot { background: var(--color-accent); }
+  .sf-conn[data-status='disconnected'] .sf-dot { background: var(--color-status-offline); }
+</style>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:unit -- src/lib/components/shell/ShellFooter.svelte.test.ts`
+Expected: PASS (2 cases).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(web): ShellFooter — persistent bar with section-filled slot + baseline (holomush-q41kr)"` (+ byline).
+
+---
+
+## Phase 3: Assemble the shell & migrate the terminal
+
+### Task 6: Authed shell layout + terminal switch
+
+Create the persistent shell and switch the terminal page off its own Rail/height in the **same task** (avoids a double-rail intermediate). After this, `/terminal` and `/scenes` both show the Rail + footer (terminal footer shows the baseline until Task 7 registers its hotkeys).
+
+**Files:**
+
+- Create: `web/src/routes/(authed)/+layout.svelte`
+- Modify: `web/src/routes/(authed)/terminal/+page.svelte` (remove `import Rail` `:30`; remove `<Rail />` `:701`; height CSS `:731`, `:753-756`)
+
+- [ ] **Step 1: Create the shell layout**
+
+```svelte
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 HoloMUSH Contributors
+-->
+<script lang="ts">
+  import { page } from '$app/stores';
+  import SectionRail from '$lib/components/shell/SectionRail.svelte';
+  import ShellFooter from '$lib/components/shell/ShellFooter.svelte';
+  import { Sheet, SheetContent, SheetTitle, SheetDescription } from '$lib/components/ui/sheet';
+  import { mobileNavOpen, openMobileNav, closeMobileNav } from '$lib/stores/mobileNavStore';
+
+  let { children } = $props();
+  let pathname = $derived($page.url.pathname);
+</script>
+
+<div class="shell">
+  <SectionRail {pathname} variant="rail" />
+  <div class="section-col">
+    <div class="section-slot">{@render children()}</div>
+    <ShellFooter {pathname} />
+  </div>
+</div>
+
+<!-- Mobile drawer: same Rail, controlled by the shared store (controlled mode
+     per holomush-ceon — do not bind:open through a store expression). -->
+<Sheet open={$mobileNavOpen} onOpenChange={(o: boolean) => (o ? openMobileNav() : closeMobileNav())}>
+  <SheetContent side="left" class="p-0 w-[260px]">
+    <SheetTitle class="sr-only">Navigation</SheetTitle>
+    <SheetDescription class="sr-only">Switch workspace section</SheetDescription>
+    <SectionRail {pathname} variant="drawer" onnavigate={closeMobileNav} />
+  </SheetContent>
+</Sheet>
+
+<style>
+  .shell {
+    display: flex;
+    height: calc(100vh - var(--topbar-h));
+    min-height: 0;
+  }
+  .section-col {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+  .section-slot {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+</style>
+```
+
+> The `class="sr-only"` on `SheetTitle`/`SheetDescription` uses Tailwind v4's
+> built-in `sr-only` utility — do **not** redeclare it in this component's
+> `<style>` (avoids the duplicate the plan-reviewer flagged).
+
+- [ ] **Step 2: Remove the Rail import from the terminal page**
+
+In `web/src/routes/(authed)/terminal/+page.svelte`, delete line 30:
+
+```ts
+  import Rail from '$lib/components/terminal/Rail.svelte';
+```
+
+- [ ] **Step 3: Remove the `<Rail />` render**
+
+In the same file, delete the `<Rail />` line (currently `:701`) so the markup begins:
+
+```svelte
+  <div class="terminal-layout" style={$themePreferences.terminalBlackBackground ? terminalBlackOverrideVars() : ''}>
+    <div class="main-area" bind:this={paneGroupEl}>
+```
+
+- [ ] **Step 4: Shed the page's viewport-height CSS**
+
+The shell now owns viewport height (`§3.1`). Change both rules so the page fills its container instead of recomputing the viewport:
+
+```css
+  /* .login-screen — was: height: calc(100vh - var(--topbar-h)); */
+  .login-screen {
+    height: 100%;
+    /* …rest unchanged… */
+  }
+
+  /* .terminal-layout — was: height: calc(100vh - var(--topbar-h)); */
+  .terminal-layout {
+    height: 100%;
+    /* …rest unchanged… */
+  }
+```
+
+- [ ] **Step 5: Type-check and eyeball both sections**
+
+Run: `pnpm check`
+Expected: no errors (no remaining `Rail` reference).
+Run: `pnpm dev`, visit `/terminal` and `/scenes` — both show the left Rail + a bottom footer; the active Rail item matches the route; terminal stream/sidebar/input still work. (Terminal footer shows the baseline for now — fixed in Task 7.)
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "feat(web): shared (authed) shell — Rail + footer + mobile drawer; terminal uses it (holomush-q41kr)"` (+ byline).
+
+---
+
+### Task 7: Move the terminal hotkey bar into the shell footer
+
+Relocate `CommandInput`'s `.cmd-hints` (`CommandInput.svelte:187-199`) into a snippet registered via `footerBridge`. The snippet closes over `lineCount` / `nearMax` / `$uiPrefs`, so the live line-count feedback is preserved.
+
+**Files:**
+
+- Modify: `web/src/lib/components/terminal/CommandInput.svelte` (import bridge; wrap hints in `{#snippet}`; register/clear; remove inline render)
+
+- [ ] **Step 1: Import the bridge**
+
+Add to the import block:
+
+```ts
+  import { setFooter, clearFooter } from '$lib/stores/footerBridge';
+```
+
+- [ ] **Step 2: Register the hints snippet (and clear on destroy)**
+
+Add an effect in the `<script>` (after the existing `onDestroy`):
+
+```ts
+  // Publish the terminal hotkey bar into the shell footer while mounted.
+  $effect(() => {
+    setFooter(cmdHints);
+    return () => clearFooter();
+  });
+```
+
+- [ ] **Step 3: Convert the inline hint bar into a snippet**
+
+Replace the existing `<div class="cmd-hints"> … </div>` block (`:187-199`) with a snippet of the same markup (so it renders inside `ShellFooter` instead of under the input):
+
+```svelte
+{#snippet cmdHints()}
+  <div class="cmd-hints">
+    <span><kbd>↑↓</kbd> history</span>
+    <span><kbd>⇧⏎</kbd> newline</span>
+    <span><kbd>Esc</kbd> clear</span>
+    <span><kbd>⌘K</kbd> palette</span>
+    <span><kbd>⌘B</kbd> rail</span>
+    <span><kbd>⌘.</kbd> sidebar</span>
+    <span><kbd>⌘⇧E</kbd> composer</span>
+    <span class="line-count">{lineCount} line{lineCount === 1 ? '' : 's'}</span>
+    {#if nearMax && !$uiPrefs.composerOpen}
+      <span class="composer-nudge">Press ⌘⇧E for a bigger editor</span>
+    {/if}
+  </div>
+{/snippet}
+```
+
+Leave the `.cmd-hints` styles in this component's `<style>` — Svelte 5 applies the declaring component's scoped styles to a snippet wherever it is `{@render}`ed. **Verify in Step 5;** if the bar renders unstyled inside the footer, lift the `.cmd-hints` rules to `:global(.cmd-hints)` in this file.
+
+- [ ] **Step 4: Run unit tests**
+
+Run: `pnpm test:unit -- src/lib/stores/footerBridge.test.ts`
+Expected: PASS (bridge unchanged). Run `pnpm check` — no errors.
+
+- [ ] **Step 5: Manual verify**
+
+`pnpm dev` → `/terminal`: the hotkey bar (`↑↓ history … ⌘⇧E composer`, line count) now renders in the bottom shell footer and updates as you type. Navigate to `/scenes`: footer reverts to the baseline. Back to `/terminal`: hotkeys return.
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "feat(web): relocate terminal hotkey bar into the shell footer via footerBridge (holomush-q41kr)"` (+ byline).
+
+---
+
+## Phase 4: Chrome wiring
+
+### Task 8: TopBar — mobile drawer toggle + drop redundant Scenes icon
+
+**Files:**
+
+- Modify: `web/src/lib/components/TopBar.svelte` (lucide import `:6`; add `☰`; remove Clapperboard link `:140-142`)
+
+- [ ] **Step 1: Update the lucide import**
+
+Change line 6 — drop `Clapperboard`, add `Menu`:
+
+```ts
+  import { LogOut, ArrowLeftRight, Palette, PanelRightOpen, Command as CommandIcon, Menu } from '@lucide/svelte';
+```
+
+- [ ] **Step 2: Import the mobile-nav action and derive auth state**
+
+Add to the script:
+
+```ts
+  import { toggleMobileNav } from '$lib/stores/mobileNavStore';
+  let isAuthed = $derived($authState.isPlayerAuthenticated || !!$authState.sessionId);
+```
+
+- [ ] **Step 3: Add the `☰` button (mobile-only, authed) at the start of `.left`**
+
+Just inside `<div class="left">`, before the logo `<a>`:
+
+```svelte
+    {#if isAuthed}
+      <button class="icon-btn mobile-only" onclick={toggleMobileNav} title="Menu" aria-label="Open navigation">
+        <Menu size={18} />
+      </button>
+    {/if}
+```
+
+- [ ] **Step 4: Remove the now-redundant Scenes link**
+
+Delete the Clapperboard anchor (`:140-142`):
+
+```svelte
+      <a href="/scenes" class="icon-btn" title="Scenes" aria-label="Scenes">
+        <Clapperboard size={16} />
+      </a>
+```
+
+(The Rail's Scenes item replaces it.)
+
+- [ ] **Step 5: Add the `mobile-only` style**
+
+In the `<style>` block:
+
+```css
+  .mobile-only { display: inline-flex; }
+  @media (min-width: 768px) {
+    .mobile-only { display: none; }
+  }
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `pnpm check` (no unused `Clapperboard`). `pnpm dev`: at desktop width no `☰`; at <768px the `☰` appears and opens the drawer; the old Scenes header icon is gone.
+
+- [ ] **Step 7: Commit**
+
+`jj commit -m "feat(web): TopBar mobile drawer toggle; drop redundant Scenes icon (holomush-q41kr)"` (+ byline).
+
+---
+
+### Task 9: Palette — "Go to <section>" entries from the registry
+
+**Files:**
+
+- Modify: `web/src/lib/components/terminal/CommandPalette.svelte` (import registry `:26`-area; prepend nav items to `items` `:43`)
+
+- [ ] **Step 1: Import the registry helper**
+
+Add to the imports:
+
+```ts
+  import { sectionNavEntries } from '$lib/nav/sections';
+```
+
+- [ ] **Step 2: Build nav items and prepend them to `items`**
+
+Just above `const items: PaletteItem[] = [`:
+
+```ts
+  const navItems: PaletteItem[] = sectionNavEntries().map((e) => ({
+    id: e.id,
+    label: e.label,
+    run: () => goto(e.href),
+  }));
+```
+
+Then change the array head to spread them first:
+
+```ts
+  const items: PaletteItem[] = [
+    ...navItems,
+    { id: 'theme.default-dark', label: 'Switch theme: Default Dark', run: () => setTheme('default-dark') },
+    // …rest unchanged…
+  ];
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `pnpm check`. `pnpm dev` → press `⌘K`, type "Go to" → "Go to Room" / "Go to Scenes" appear; selecting "Go to Scenes" navigates to `/scenes`. (Asserted in the E2E task.)
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "feat(web): palette go-to-section entries sourced from the registry (holomush-q41kr)"` (+ byline).
+
+---
+
+## Phase 5: Cleanup
+
+### Task 10: Delete the old Rail; retire `RailView`
+
+**Files:**
+
+- Delete: `web/src/lib/components/terminal/Rail.svelte`
+- Modify: `web/src/lib/stores/uiPrefsStore.ts` (`RailView` `:7`; `railView` field `:18`,`:36`)
+
+- [ ] **Step 1: Confirm nothing imports the old Rail or `railView`**
+
+Run: `rg -n "terminal/Rail\.svelte|railView|RailView" web/src`
+Expected: only the definitions in `uiPrefsStore.ts` (the terminal page stopped importing Rail in Task 6; SectionRail uses `railHidden`, not `railView`). If any other consumer appears, stop and reassess.
+
+- [ ] **Step 2: Delete the file**
+
+```bash
+rm web/src/lib/components/terminal/Rail.svelte
+```
+
+- [ ] **Step 3: Remove `RailView` and the `railView` field**
+
+In `uiPrefsStore.ts`: delete the `export type RailView = 'room';` line (`:7`), the `railView: RailView;` field in `UiPrefs` (`:18`), and `railView: 'room',` in `DEFAULTS` (`:36`). `hydrateUiPrefs`' `...parsed` tolerates a stale `railView` key in older localStorage (ignored), so no migration is needed.
+
+- [ ] **Step 4: Verify**
+
+Run: `pnpm check` (no dangling references). Run: `pnpm test:unit` (full suite green).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "refactor(web): remove superseded Rail.svelte and vestigial RailView (holomush-q41kr)"` (+ byline).
+
+---
+
+## Phase 6: End-to-end verification
+
+### Task 11: E2E — frame persistence, active state, palette nav, mobile drawer
+
+Promote the local `registerAndEnterTerminal` helper to a shared fixture (it is copy-used 8× in `scenes.spec.ts`), then add the new spec.
+
+**Files:**
+
+- Modify: `web/e2e/helpers/fixtures.ts` (export `registerAndEnterTerminal` + `uniqueSceneUser`, moved from `scenes.spec.ts:217-…`)
+- Modify: `web/e2e/scenes.spec.ts` (import the helpers from `./helpers/fixtures` instead of the local definitions)
+- Create: `web/e2e/authed-shell.spec.ts`
+
+- [ ] **Step 1: Extract the helper to the shared fixture**
+
+Move the `uniqueSceneUser(...)` and `registerAndEnterTerminal(page, prefix)` function definitions verbatim from `web/e2e/scenes.spec.ts` (currently at `:217`) into `web/e2e/helpers/fixtures.ts`, add `export` to each, and import them back into `scenes.spec.ts`:
+
+```ts
+// scenes.spec.ts — replace the local defs with:
+import { test, expect, db, getClientSessionId, registerAndEnterTerminal, uniqueSceneUser } from './helpers/fixtures';
+```
+
+Keep the prefix constraint (memory): prefixes MUST be ≤4 chars, alphanumeric, no hyphen.
+
+- [ ] **Step 2: Verify the extraction is behavior-neutral**
+
+Run: `pnpm exec playwright test e2e/scenes.spec.ts`
+Expected: PASS — same as before the move.
+
+- [ ] **Step 3: Write the new shell spec**
+
+```ts
+// web/e2e/authed-shell.spec.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { test, expect, registerAndEnterTerminal } from './helpers/fixtures';
+
+test.describe('unified authed shell', () => {
+  test('rail + footer persist across /terminal and /scenes with correct active state', async ({ page }) => {
+    await registerAndEnterTerminal(page, 'shl');
+
+    const rail = page.getByTestId('rail').first();
+    await expect(rail).toBeVisible();
+    await expect(page.getByTestId('shell-footer')).toBeVisible();
+    // Room active on the terminal.
+    await expect(rail.getByRole('link', { name: 'Room' })).toHaveAttribute('aria-current', 'page');
+
+    // Navigate to Scenes via the rail.
+    await rail.getByRole('link', { name: 'Scenes' }).click();
+    await expect(page).toHaveURL(/\/scenes/);
+    await expect(page.getByTestId('rail').first()).toBeVisible();
+    await expect(page.getByTestId('shell-footer')).toBeVisible();
+    await expect(page.getByTestId('rail').first().getByRole('link', { name: 'Scenes' }))
+      .toHaveAttribute('aria-current', 'page');
+  });
+
+  test('command palette navigates between sections', async ({ page }) => {
+    await registerAndEnterTerminal(page, 'pal');
+    await page.keyboard.press('Meta+k');
+    await page.getByPlaceholder('Type a command…').fill('Go to Scenes');
+    await page.getByRole('option', { name: 'Go to Scenes' }).click();
+    await expect(page).toHaveURL(/\/scenes/);
+  });
+
+  test('mobile: hamburger opens the drawer and navigates', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await registerAndEnterTerminal(page, 'mnv');
+
+    // Persistent rail is collapsed on mobile.
+    await expect(page.getByRole('button', { name: 'Open navigation' })).toBeVisible();
+    await page.getByRole('button', { name: 'Open navigation' }).click();
+
+    // The drawer is a dialog (labelled by its SheetTitle "Navigation").
+    const drawer = page.getByRole('dialog', { name: 'Navigation' });
+    await expect(drawer).toBeVisible();
+    // Click the Scenes link INSIDE the drawer (the persistent rail also has a
+    // Scenes link in the DOM at mobile width — width:0/hidden — so scope to the
+    // drawer; do NOT assert a global link count).
+    await drawer.getByRole('link', { name: 'Scenes' }).click();
+    await expect(page).toHaveURL(/\/scenes/);
+    await expect(drawer).toHaveCount(0); // drawer unmounted on navigate
+  });
+
+  test('terminal hotkey bar renders in the shell footer (no regression)', async ({ page }) => {
+    await registerAndEnterTerminal(page, 'ftr');
+    const footer = page.getByTestId('shell-footer');
+    await expect(footer).toContainText('history');
+    await expect(footer).toContainText('composer');
+  });
+});
+```
+
+- [ ] **Step 4: Run the new spec**
+
+Run: `pnpm exec playwright test e2e/authed-shell.spec.ts`
+Expected: PASS (4 tests). If the palette option role differs, inspect with `--debug`; the bits-ui `Command.Item` renders as `[data-command-item]` — adjust the selector to `page.locator('[data-command-item]', { hasText: 'Go to Scenes' })` if `getByRole('option')` does not resolve.
+
+- [ ] **Step 5: Full gate**
+
+Run: `pnpm check && pnpm test:unit && pnpm exec playwright test e2e/terminal.spec.ts e2e/scenes.spec.ts e2e/authed-shell.spec.ts`
+Expected: all green (no terminal/scenes regression).
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "test(web): e2e for unified authed shell — frame, active state, palette nav, mobile drawer (holomush-q41kr)"` (+ byline).
+
+---
+
+## Done criteria (maps to spec §7 + bead acceptance)
+
+- Navigating `/terminal` ↔ `/scenes` (and nested `/scenes/*`) preserves the Rail + footer; active item tracks the route (Task 6, 11).
+- Rail is the registry-driven section switcher; palette mirrors it (Task 1, 4, 9).
+- Persistent footer: terminal hotkeys via bridge, baseline elsewhere (Task 5, 7).
+- Mobile drawer reuses the Rail (Task 6, 8, 11).
+- No terminal regression; `pnpm check` + unit + E2E green (Task 11 Step 5).
+- Chrome dedup: theme only in TopBar; redundant Scenes icon removed; `RailView` retired (Task 4, 8, 10).

--- a/docs/superpowers/plans/2026-06-20-unified-authed-shell.md
+++ b/docs/superpowers/plans/2026-06-20-unified-authed-shell.md
@@ -1128,3 +1128,4 @@ Expected: all green (no terminal/scenes regression).
 - Mobile drawer reuses the Rail (Task 6, 8, 11).
 - No terminal regression; `pnpm check` + unit + E2E green (Task 11 Step 5).
 - Chrome dedup: theme only in TopBar; redundant Scenes icon removed; `RailView` retired (Task 4, 8, 10).
+<!-- adr-capture: sha256=82666128a5ccca9c; session=3b5de5d0; ts=2026-06-20T13:53:43Z; adrs=holomush-stds8,holomush-828tt,holomush-xhz3s,holomush-8p5rx -->

--- a/docs/superpowers/specs/2026-06-20-unified-authed-shell-design.md
+++ b/docs/superpowers/specs/2026-06-20-unified-authed-shell-design.md
@@ -1,0 +1,277 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Unified Authed Workspace Shell — Design
+
+- **Bead:** `holomush-q41kr` (Web: unify authed workspace chrome — shared `(authed)` shell + rail-as-section-switcher)
+- **Theme:** `theme:web-portals` (`holomush-sz0h3`)
+- **Status:** Design (brainstorming) — pending `design-reviewer`
+- **Date:** 2026-06-20
+- **Author:** Sean Brandt (with Claude)
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are
+to be interpreted as in RFC 2119 / RFC 8174.
+
+---
+
+## 1. Problem & scope
+
+The authed web client renders as two different apps. `/terminal` has the full
+workspace chrome — a left icon **Rail**, a rich **TopBar** (`Char @ Location`,
+`⌘K` hint, connection pill, sidebar toggle), a right **Sidebar**
+(location/exits/presence), and a **footer hotkey bar**. `/scenes` has none of
+it: no rail, a stripped TopBar (logo + theme + identity + swap + logout only),
+no footer, and its own bespoke 3-pane. Switching between them feels like
+leaving one app and entering another.
+
+The governing product principle (memory `a4baea60`, decision `holomush-sz0h3`)
+is that the web client is a **superset of telnet**: `/terminal` is the
+first-class on-grid surface, and a growing set of subsystems (scenes, DMs,
+forums, wiki, character profiles, settings, admin) each get a rich web GUI.
+For that to read as **one workspace**, every authed section MUST share a
+persistent frame, and moving between sections MUST be clean and effortless.
+
+**Root cause (grounded).**
+
+- There is **no shared authed shell**. `web/src/routes/(authed)/+layout.ts`
+  is load-only (`web/src/routes/(authed)/+layout.ts:10-31`); there is no
+  `(authed)/+layout.svelte`. `web/src/routes/(authed)/scenes/+layout.svelte`
+  is a bare `{@render children()}` pass-through (lines `8,11`).
+- The **Rail** is rendered only by the terminal page
+  (`web/src/routes/(authed)/terminal/+page.svelte:701`), inside
+  `.terminal-layout` — so `/scenes` has no rail at all. Its items are
+  placeholders: `Room` is hardcoded `is-active`
+  (`web/src/lib/components/terminal/Rail.svelte:34`); `DM/Map/Notes` are
+  disabled "coming soon" (`Rail.svelte:38-61`); there is no `Scenes` entry, so
+  the rail cannot act as a section switcher.
+- The **TopBar** is already global (rendered in the root layout,
+  `web/src/routes/+layout.svelte:105`) but conditionally hides its
+  terminal-context bits via `onTerminal = $page.route.id?.includes('/terminal')`
+  (`web/src/lib/components/TopBar.svelte:41`, gates at `:61-87,:124-133`) —
+  which is why `/scenes` looks sparse.
+- The **footer hotkey bar** lives inside the terminal's `CommandInput`
+  (`web/src/lib/components/terminal/CommandInput.svelte`) — terminal-only.
+
+**In scope:** the persistent shell, the rail-as-section-switcher (route-aware),
+a persistent footer bar, mobile nav, and de-duplication of chrome that the
+unification makes redundant.
+
+**Out of scope (unchanged from the bead):** enabling future placeholder
+sections (DMs/Forum/Wiki etc. land with their own work), terminal
+game/stream logic, scene CRUD, and the terminal's internal right-Sidebar
+mobile behavior (a separate concern).
+
+---
+
+## 2. Decisions
+
+Settled during brainstorming (traces on `holomush-q41kr`):
+
+| # | Decision | Rationale |
+| - | -------- | --------- |
+| D1 | **Navigation = persistent left icon Rail** (route-aware section switcher) **plus** a `⌘K` "go to…" palette accelerator. | Rail matches the terminal aesthetic the user set as the shell baseline and is already built; palette is the keyboard power-path. Rejected top-tabs (eats vertical space, crowds past ~5 sections) and palette-only (undiscoverable). |
+| D2 | **Shell boundary:** a new `(authed)/+layout.svelte` owns Rail + persistent footer + the section slot; TopBar stays global in the root layout; each section keeps its own inner layout. | Idiomatic SvelteKit nested layout (context7 `/sveltejs/kit`); the section-local inner content (terminal panes, scenes 3-pane) does not move. |
+| D3 | **Footer = persistent shell-owned bar** with **section-filled contents**. | The frame must always be visually closed ("don't fall off into nowhere"), but the hotkey contents stay terminal-specific. |
+| D4 | **Mobile (<768px) = slide-over drawer** (shadcn `Sheet`) hosting the same Rail. | Zero permanent vertical space (terminal keyboard concern); reuses the Rail + an existing primitive; one mental model with desktop. |
+| D5 | **Rail items come from a declarative section registry** that also feeds the palette. | "Real sections only" now (Room, Scenes) with a *defined* growth zone, so adding a section is one entry and rail/palette never drift. |
+| D6 | **`Room` is always present**; a no-session click lands on `/terminal`'s existing Sign-In/Reconnect screen. | Keeps "scenes-only player is first-class" (memory `a4baea60`) without special gating. |
+
+---
+
+## 3. Architecture
+
+### 3.1 Layout nesting
+
+```text
+root +layout.svelte                      (unchanged ownership)
+├── TopBar                               global — incl. mobile ☰ (authed, <768px)
+├── <main>
+│   └── (authed)/+layout.svelte          NEW — the persistent authed shell
+│       ├── Rail (desktop, full height)  route-aware switcher
+│       └── section column
+│           ├── {@render children()}     the active section's page
+│           └── ShellFooter              persistent bar (section-filled)
+├── Composer                             global overlay (unchanged)
+└── CommandPalette                       global overlay (+ "go to" entries)
+```
+
+- The shell renders only for authed routes, so the Rail/footer never appear on
+  `/login` or `/register`. The TopBar stays in the **root** layout because it
+  already renders pre-auth states (`TopBar.svelte:135-137`).
+- Desktop shell body is a horizontal row: **Rail (full height) | section
+  column**. The section column is vertical: **page slot (flex:1) + ShellFooter**.
+  The footer therefore spans the section content width (below both the terminal
+  column and its right Sidebar), giving a single closed bottom edge.
+- **The shell owns viewport height.** The shell sizes to
+  `calc(100vh - var(--topbar-h))`, the page slot is `flex:1`, and the footer is
+  a fixed-height bar below it. Each section page MUST therefore size to its
+  container (`height:100%` / `flex:1`) and MUST NOT recompute viewport height
+  itself; the terminal page sheds its own `calc(100vh - …)` (§4) or it will
+  overflow behind the footer (§6 no-overflow check).
+- Active-section derivation MUST use a **route prefix match** against
+  `$page.url.pathname` (`$app/stores`, matching the existing TopBar convention),
+  so `/scenes`, `/scenes/browse`, and `/scenes/[id]` all resolve to the Scenes
+  item. Exact-equality matching is insufficient and MUST NOT be used.
+
+### 3.2 The section registry
+
+A new module (e.g. `web/src/lib/nav/sections.ts`) exports a typed, ordered list
+— the **single source of truth** for both the Rail and the palette's "go to…"
+entries:
+
+```ts
+export interface WorkspaceSection {
+  id: string;            // 'room' | 'scenes' | …
+  label: string;        // 'Room', 'Scenes'  (tooltip on desktop, label in drawer)
+  icon: Component;      // lucide icon
+  href: string;         // '/terminal', '/scenes'
+  match: (pathname: string) => boolean;  // prefix predicate for active state
+}
+```
+
+- Today the registry contains exactly **Room → `/terminal`** and
+  **Scenes → `/scenes`**, in that order.
+- Items render in the Rail's **top group** (the defined growth zone, above the
+  spacer). The bottom `⚙` view-prefs control is pinned **below** the spacer and
+  is NOT a registry entry.
+- Adding a future section is one registry entry plus its route; it appears in
+  the Rail and the palette automatically. The Rail and palette MUST NOT
+  hardcode section lists independently.
+- The vestigial `RailView` type (`web/src/lib/stores/uiPrefsStore.ts:7`,
+  `'room'` with a `// future: 'dm' | 'map' | 'notes'` comment) is retired by
+  this change.
+
+### 3.3 The persistent footer (bridge)
+
+The footer mirrors the existing **composer bridge** pattern
+(`web/src/lib/stores/composerBridge.ts:1-21` — a `writable` store plus
+register/invoke helpers). A new `footerBridge` store lets the active section
+push footer content; `ShellFooter.svelte` renders it, falling back to a
+baseline when nothing is registered.
+
+- **Mechanism:** the active section registers a footer snippet on mount and
+  clears it on destroy (`afterNavigate`/`onDestroy`), exactly as the composer
+  bridge registers its submit handler.
+- **Terminal:** its hotkey row moves **out of** `CommandInput`
+  (`CommandInput.svelte:187-194`) into a footer snippet registered via the
+  bridge. The labels are the existing `cmd-hints` bar — at the time of writing
+  `↑↓ history · ⇧⏎ newline · Esc clear · ⌘K palette · ⌘B rail · ⌘. sidebar ·
+  ⌘⇧E composer` (note: `Esc` clears the draft; `⌘L` clears the output buffer —
+  a different action). The plan MUST **relocate the existing snippet from code**,
+  not re-type from this prose, so the hints can never drift. Contents remain
+  terminal-only.
+- **Baseline (any section that registers nothing):** *section name* (left) +
+  *`⌘K go to…`* hint + *connection dot* (right). The baseline MUST always
+  render so the bar is never empty/absent.
+
+---
+
+## 4. Component changes
+
+| File | Change |
+| ---- | ------ |
+| `web/src/routes/(authed)/+layout.svelte` | **NEW.** The persistent shell: Rail (desktop) + section slot + `ShellFooter`. Hosts the authed-only key handlers that today live in the root layout for rail/sidebar/composer/clear (`+layout.svelte:49-76`, scope confirmation in §9 Q3); `⌘K` palette stays global in root. |
+| `web/src/lib/components/terminal/Rail.svelte` → (rename to a shell location, e.g. `web/src/lib/components/shell/SectionRail.svelte`) | Render items from the registry as real `<a>` links; active state from the prefix predicate; remove the hardcoded `is-active` (`:34`) and the disabled `DM/Map/Notes` placeholders (`:38-61`). Keep the bottom `⚙`, but reduce it to **view prefs** (density, black-terminal-bg); the **theme** submenu is removed here (dedup → TopBar). |
+| `web/src/routes/(authed)/terminal/+page.svelte` | Remove `<Rail />` (`:701`); the shell now provides it. Register the hotkey row via `footerBridge` instead of rendering it in `CommandInput`. **Shed the page's own `height: calc(100vh - var(--topbar-h))`** (`:731` login-screen, `:753-756` `.terminal-layout`) — the shell owns viewport height (§3.1), so the terminal sizes to its container (`height:100%`) and does not overflow the `ShellFooter`. |
+| `web/src/lib/components/terminal/CommandInput.svelte` | Footer hotkey bar extracted to the shell footer snippet. |
+| `web/src/routes/(authed)/scenes/+layout.svelte` | Stays a thin pass-through; the shell supplies rail + footer. Its sparse look resolves automatically. |
+| `web/src/lib/components/TopBar.svelte` | Remove the now-redundant Clapperboard "→ Scenes" icon (`:140-142`); add a mobile `☰` drawer toggle (authed + `<768px`). Keep theme/identity/swap/logout and the terminal-gated bits. |
+| `web/src/lib/components/terminal/CommandPalette.svelte` | Add "go to <section>" entries from the registry to `items` (`:43`), using the existing `goto` path (`:26`). |
+| `web/src/lib/stores/uiPrefsStore.ts` | Retire `RailView` (`:7`); reuse `railHidden` (`:10`) for desktop collapse; add a transient mobile-drawer-open state (need not persist). |
+| `web/src/lib/nav/sections.ts`, `web/src/lib/stores/footerBridge.ts`, `web/src/lib/components/shell/ShellFooter.svelte` | **NEW** per §3.2–3.3. |
+
+---
+
+## 5. Responsive / mobile (D4)
+
+- **≥768px:** Rail is a persistent full-height column; `⌘B` toggles
+  `railHidden` (existing pref). Desktop items are **icon-only with a tooltip**
+  (today's behavior).
+- **<768px:** the persistent Rail collapses (today it is already `width:0`,
+  `Rail.svelte:118-123`). A `☰` button in the TopBar opens the **same** Rail
+  inside a shadcn `Sheet` left drawer (precedent: `Sheet` primitives at
+  `web/src/lib/components/ui/sheet/*`, used by `CreateSceneSheet.svelte`).
+  Drawer items show **icon + label**.
+- The drawer MUST close on selection (navigation), on scrim tap, and on `Esc`
+  (the `Sheet` primitive provides scrim/Esc).
+
+---
+
+## 6. Edge cases & no-regression
+
+- **No active game session:** the `Room` item is always present; clicking it
+  navigates to `/terminal`, which renders its existing Sign-In/Reconnect screen
+  (`terminal/+page.svelte:688-698`). No section gating; scenes-only players are
+  unaffected.
+- **Active-state correctness:** nested routes under a section MUST highlight
+  that section (prefix match, §3.1).
+- **Layout height / no overflow:** with the `ShellFooter` below the section
+  slot, the terminal MUST size to its container, not the viewport — verify it
+  does not overflow behind the footer (the §4 height-shed). Applies to any
+  section that previously assumed full viewport height.
+- **Keyboard shortcuts:** `⌘K` (palette), `⌘B` (rail), `⌘.` (sidebar), `⌘⇧E`
+  (composer), `⌘L` (clear) MUST continue to work with no behavior change. Moving
+  their handlers from root into the authed shell MUST NOT drop any binding.
+- **Terminal UX:** stream, composer, right Sidebar, resizable panes, and all
+  hotkeys MUST be unchanged — only the Rail's owner and the footer's host move.
+
+---
+
+## 7. Testing
+
+Per `.claude/rules/testing.md` (ACE names; vitest unit + Playwright E2E).
+
+**Unit (vitest):**
+
+- The registry renders the expected Rail items in order; each is a real link to
+  its `href`.
+- Active state resolves via prefix: `/scenes`, `/scenes/browse`, `/scenes/abc`
+  all mark Scenes active; `/terminal` marks Room active.
+- `footerBridge` baseline renders when no section registers content; a
+  registered snippet replaces the baseline and is cleared on navigation.
+- Palette "go to…" entries are derived from the same registry (no second list).
+
+**E2E (Playwright):**
+
+- Navigating `/terminal` ↔ `/scenes` preserves the Rail and footer; the active
+  Rail item tracks the route.
+- `⌘K` → "go to Scenes" switches sections.
+- Narrow viewport: `☰` opens the drawer, selecting a section navigates and
+  closes it.
+- No terminal regression: existing `web/e2e/terminal.spec.ts` and
+  `scenes.spec.ts` pass. New `registerAndEnterTerminal` callers, if any, MUST
+  use a ≤4-char alphanumeric (no-hyphen) prefix (memory `a600e10f`).
+
+**Gate:** `cd web && pnpm check` clean; relevant vitest + the two E2E specs green.
+
+---
+
+## 8. Invariants
+
+No **new registry invariant** (`docs/architecture/invariants.yaml`) is minted.
+The durable guarantee here — "every authed section preserves the persistent
+frame and the Rail tracks the route" — is a **product/UX requirement** verified
+by the §7 E2E acceptance, not a system-level invariant in the registry sense
+(consistent with prior web-frontend work, which kept TS-store/UI properties out
+of the registry; memory note on the bare-`INV-6` web-store overload). Per
+`.claude/rules/invariants.md`, a local feature requirement is not an invariant,
+and no ad-hoc invariant family is introduced.
+
+---
+
+## 9. Open questions for the plan phase
+
+1. **Rail component home/rename.** Moving `terminal/Rail.svelte` →
+   `shell/SectionRail.svelte` is the clean boundary, but it widens the diff and
+   any test importing the old path. Acceptable, or keep the path and just
+   relocate the render site? (Plan-phase call.)
+2. **Key-handler relocation.** Moving rail/sidebar/composer/clear handlers from
+   the root layout into the authed shell is cleaner but is a behavioral-surface
+   move; confirm it is in scope for this change rather than a follow-up.
+
+**Resolved during review:** *Footer span* — the footer spans the **section
+content width** (right of the Rail), per §3.1, matching today's terminal footer
+placement. Full-shell-width (VS Code-style, under the Rail too) is a viable
+plan-time alternative if preferred, but the default stands.


### PR DESCRIPTION
## What

Design docs (no implementation code) for unifying the authed web workspace
chrome so `/scenes` (and future sections) feel like part of the same workspace
as `/terminal` — a shared `(authed)/+layout.svelte` shell with a route-aware
section Rail, a `⌘K` palette nav accelerator, and a persistent footer.

Epic: **`holomush-q41kr`** — "Unified authed workspace shell" (theme `web-portals`).

## Contents

- **Spec** — `docs/superpowers/specs/2026-06-20-unified-authed-shell-design.md` (design-reviewer: **READY**)
- **Plan** — `docs/superpowers/plans/2026-06-20-unified-authed-shell.md` (plan-reviewer: **READY**, 11 TDD tasks)
- **ADRs** — 4 decisions captured + README index:
  - `holomush-stds8` — section registry as the single source of nav truth (Rail + palette)
  - `holomush-828tt` — persistent authed chrome lives in a shared `(authed)/+layout.svelte` shell (key handlers stay in root)
  - `holomush-xhz3s` — footer content via a `footerBridge` store mirroring `composerBridge`
  - `holomush-8p5rx` — mobile nav = a `Sheet` drawer hosting the same Rail

## Decisions (brainstorm outcomes)

Left **icon rail** as the primary section switcher (+ `⌘K` "go to…"); persistent
**shell-owned footer bar** with section-filled contents (terminal hotkeys via the
bridge, quiet baseline elsewhere); mobile **slide-over drawer** reusing the Rail;
a declarative **section registry** feeding both Rail and palette so they never
drift. Scope is chrome/shell only — not enabling future sections, terminal game
logic, or scene CRUD.

## Tracking

bd epic `holomush-q41kr` materialized into 11 child beads (`.1`–`.11`) with
dependency edges + `model:`/`skills:` routing; 4 `related` edges to the ADRs.
Implementation lands in follow-up PRs.

## Validation

`task pr-prep` green (fast lane; docs-only diff). No runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)