### PR TITLE
fix(scenes): gate guests from the Scenes nav and scene commands (holomush-5rh.23)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -505,3 +505,23 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   same exposure pre-xakba). DURABLE LESSON CONFIRMED: gate the SHARED read primitive (here:
   wrap the HistoryReader once), not one handler — the capability service is never the only
   path to a primitive when ambient hostfuncs exist.
+- **Guest scene-command gate (5rh.23, 2026-06-20) — READY**: `character.is_guest`
+  bit added to CharacterProvider via optional `PlayerKindLookup` (same func type +
+  exact shape as player.go), gated at core-scenes `execute-scene-commands` permit
+  `&& principal.character.is_guest == false`. KEY rationale: command dispatch
+  evaluates a `character:<ulid>` subject; `resolveEntity` (resolver.go:350) calls
+  every provider with the SAME ref, so the `player:` namespace NEVER merges onto a
+  character principal → gating on `principal.player.is_guest` would silently
+  never-match = fail-OPEN. Hence the guest bit MUST live on the character bag.
+  Fail-closed verified: missing is_guest → evalComparison false (evaluator.go:134)
+  → permit doesn't fire → default-deny. Sole grant for scene/scenes execute confirmed
+  (siblings grant only own command names; admin wildcard role-gated, guest≠admin).
+  Dual-emit on ResolveResource is harmless surplus (no policy reads
+  resource.character.is_guest). Lookup-error → fail-closed deny for registered
+  players (availability-only regression, intended). Single cfg.PlayerKindLookup
+  feeds both providers (setup.go:146,239) — no drift. ONE Low: terminal-path gate
+  is a durable fail-closed guarantee parallel to INV-SCENE-64 (web facade) but is
+  NOT yet registered in invariants.yaml — SHOULD add an INV entry (pending is fine).
+  PATTERN: when gating on a subject attr, verify the attr's namespace actually
+  merges onto THAT subject type's principal via resolveEntity — cross-namespace
+  gates (player attr on character principal) fail-open silently.

--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -78,6 +78,20 @@
 - **Gateway scene-RPC passthrough (5rh.8.12 READY, 2026-06-08).** RECURRING gateway-wide trap (NOT per-PR, non-blocking): `*grpc.Client` wrappers `oops.Code("RPC_FAILED").Wrap` a grpc-go status.Status err; web handler returns it to connect-go (server.go:69 NewWebServiceHandler, NO error interceptor) under a FALSE `//nolint:wrapcheck // pass through as-is`. connect-go CodeOf only sees `*connect.Error` via errors.As → oops-wrapped status collapses to CodeUnknown/HTTP500; facade PERMISSION_DENIED/NOT_FOUND all become Unknown at browser. IDENTICAL to WebListFocusPresence (handler.go:792) etc → track separately. `...PassesStatusErrorThroughAsIs` unit tests use the MOCK (no wrap) so CANNOT catch it. Token header-injected (headerInjectSessionToken), never body/logged.
 
 - **Frontend/E2E ports + proto-vocab traps (5rh.8.15/.16/.17/.19, 2026-06-08) — CONSOLIDATED.** (a) .svelte.ts ports DROP hard parts: backoff inside recursive fn (hoist to while-loop), gate resolved only in STREAM_OPENED, counter declared-never-incremented=inert, Map keyed charId but delete(sessionId)=dead cache; "N pass" proves nothing — `grep -c 'it('` the NEW file. (b) Load-bearing blocker often in the CONSUMED store not the diff (refresh() hardcoded asCharacterId:'' → blank roster): trace each consumed field to its PRODUCER, verify POPULATED not just typed; pnpm-check blind to empty-but-valid. (c) proto STRING field vs literal: grep the proto/Go const set — UI authors cross state↔visibility↔role vocab (SceneInfo.state∈{active,paused,ended,archived}, 'open' is VISIBILITY → state==='open' never true). nav params DEAD unless +page reads searchParams; charId='' → RPC never fires. (d) re-check a prior NOT-READY blocker STILL holds in CURRENT source before failing a dependent PR (upstream may have fixed). Honest-degradation OK iff test title+comment scope it + cite a tracked bead. Flakiness: no sleeps; expect.poll/toPass; conn-pill gate; unique titles.
+- **Guest/auth-flag gate via one-shot get(store) in PERSISTENT component (5rh.23 NOT READY, 2026-06-20).**
+  Svelte 5: a gate reading `get(authState).isGuest` ONCE at `const`-init is stale if the component lives in the
+  ROOT +layout.svelte (unauthed shell, mounts once, no {#if}/{#key}) — isGuest defaults false and is set LATER by
+  route load fns ((authed)/+layout.ts, +page.ts, login). restoreSession restores sessionId/characterName but NOT
+  isGuest. So palette froze isGuest:false → guest sees "Go to Scenes" dead-end (the exact thing the bead removed).
+  Sibling Rail was CORRECT: $derived(visibleSections({isGuest})) inside (authed) layout. LESSON: for any
+  auth/session-derived gate, trace the CONSUMER's mount point + lifetime vs WHEN the flag is set; `get()` one-shot
+  is only safe if the instance is created AFTER the flag resolves AND never outlives a transition. Pure-fn unit test
+  (sections.test.ts) passes — it CANNOT catch consumer staleness; demand a mount-then-flip-store test. Backend GAP
+  was CLEAN: CharacterProvider WithCharacterKindLookup emits character.is_guest (omit-don't-sentinel ti1b), manifest
+  `&& principal.character.is_guest == false` fail-closed (evalComparison !leftOK→false, evaluator.go:134), resolver
+  merges to bags.Subject["character.is_guest"] + Schema() registers keys (else merge rejects). Prod wiring
+  subsystem.go always supplies PlayerKindLookup. character: principal is what command dispatch evaluates (player:
+  never reached) → gate MUST live on character bag not player bag.
 - **Proto god-service→capability-service decomposition (eykuh.1.2 READY, 2026-06-11).** Proto-only/additive,
   14 svcs across 11 host/v1 files. CHECKLIST: (1) count each svc's RPCs vs plan table. (2) carved-msg fidelity:
   `PluginHostServiceX{}`→`X{}` keep SAME field#+type+validate-constraint+doc (prefix-drop only) vs ORIGINAL
@@ -211,23 +225,11 @@
   dc.Attributes["location"] as action attr "dispatch_location" (interceptor.go:208). Non-blocking:
   no single host->ferry->server e2e test (legs proven separately; cross-process needs subprocess).
 - **Two-path stream-read gate, qualify-before-ABAC (xakba R2 READY, 2026-06-19) -- CLEAN dual-gate.**
-  R1 NOT READY: ABAC built resource from UN-qualified req.GetStream() so system forbid never fired;
-  tests used DenyAll+pre-qualified inputs (couldn't catch). R2 FIX: new pluginauthz.AuthorizeStreamRead
-  (streamread.go) eventbus.Qualify(GameID,Stream) BEFORE EvaluateCapabilityAccess on qualified
-  "stream:<qual>"; fail-closed on qualify err (Qualify "" gameID + relative ref -> error). SHARED gate
-  called by BOTH hostcap/servers.go QueryStreamHistory (brokered, both runtimes) AND hostfunc
-  authorizingHistoryReader decorator wrapping f.historyReader at functions.go:331 (ambient Lua path the
-  abac-reviewer flagged in R1) -> runtime-symmetry closed. ReplayTail DIVERGENCE harmless: handler passes
-  RELATIVE req.GetStream() to ReplayTail (servers.go:888) but busHistoryReaderAdapter.ReplayTail
-  (sub_grpc.go:811) re-Qualifies idempotently (Qualify returns events.* unchanged). Declared:true SOUND:
-  stream.history NOT in declarationExemptCapabilities, interceptor proves declaration before handler.
-  Tests have TEETH: recordingEngine asserts EXACT qualified resource "stream:events.main.system.rekey..."
-  (removing qualify flips it -> assert fails) + reader.called==false on deny + fail-closed-on-qualify-err
-  asserts engine NEVER consulted. Fixture channel:abc->channel.abc CORRECT (subjectTokenRe=^[A-Za-z0-9_-]+$
-  rejects colon; channel.abc splits to 2 valid tokens). NON-BLOCKING latent: binary Host.gameID set ONLY
-  via WithCA(ca,gameID) (host.go:136) gated on cfg.CertsDir!=""+CA-load-ok (subsystem.go:309-316); no-mTLS
-  binary plugins DO run (host.go:361 fallback) -> Host.gameID="" -> every binary stream.history fails
-  closed Internal. Lua path UNAFFECTED (WithGameID(cfg.GameID) direct, subsystem.go:195). Fail-closed safe
-  + no-mTLS flagged non-prod, but binary gameID should be independent of CA option. LESSON: gating a
-  capability handler -> rg the underlying read primitive (ReplayTail) across internal/plugin; ambient
-  hostfuncs bypass the interceptor (decorator-wrap the reader, don't just gate the broker handler).
+  R1 NOT READY: ABAC built resource from UN-qualified req.GetStream() (system forbid never fired); DenyAll+pre-
+  qualified test inputs couldn't catch. R2: pluginauthz.AuthorizeStreamRead Qualify(GameID,Stream) BEFORE
+  EvaluateCapabilityAccess on "stream:<qual>", fail-closed on qualify err. SHARED by hostcap QueryStreamHistory
+  (both runtimes) AND hostfunc authorizingHistoryReader decorator (functions.go:331, ambient Lua path) → symmetry
+  closed. LESSON: gating a capability handler → rg the underlying read primitive (ReplayTail) across
+  internal/plugin; ambient hostfuncs bypass the interceptor (decorator-wrap the reader, not just the broker handler).
+  Tests have TEETH only if recordingEngine asserts the EXACT qualified resource + reader.called==false on deny.
+  Latent non-blocking: binary Host.gameID set only via WithCA → no-mTLS binary plugins get gameID="" → fail closed.

--- a/internal/access/policy/attribute/character.go
+++ b/internal/access/policy/attribute/character.go
@@ -5,6 +5,7 @@ package attribute
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
@@ -30,15 +31,40 @@ type RoleResolver interface {
 type CharacterProvider struct {
 	repo         world.CharacterRepository
 	roleResolver RoleResolver
+	// kindLookup optionally resolves whether a character's owning player is an
+	// ephemeral guest. When nil the provider omits the is_guest key
+	// (has_is_guest=false) per the omit-don't-sentinel rule (ADR holomush-ti1b).
+	// Shares the PlayerKindLookup type with PlayerAttributeProvider; it is keyed
+	// on the character's PlayerID, so the guest gate is reachable from a
+	// character: principal (the subject command dispatch evaluates against —
+	// player: subjects never reach Layer-1 command auth). Per holomush-5rh.23.
+	kindLookup PlayerKindLookup
+}
+
+// CharacterProviderOption configures optional behaviour on CharacterProvider at
+// construction time.
+type CharacterProviderOption func(*CharacterProvider)
+
+// WithCharacterKindLookup supplies an optional guest-lookup keyed on the
+// character's owning-player ID. Without it the provider omits is_guest
+// (has_is_guest=false) per the omit-don't-sentinel rule (ADR holomush-ti1b).
+func WithCharacterKindLookup(fn PlayerKindLookup) CharacterProviderOption {
+	return func(p *CharacterProvider) { p.kindLookup = fn }
 }
 
 // NewCharacterProvider creates a new character attribute provider.
 // roleResolver may be nil, in which case all characters default to "player" role.
-func NewCharacterProvider(repo world.CharacterRepository, roleResolver RoleResolver) *CharacterProvider {
-	return &CharacterProvider{
+// Optional CharacterProviderOption values configure additional behaviour such as
+// the guest-kind lookup (WithCharacterKindLookup).
+func NewCharacterProvider(repo world.CharacterRepository, roleResolver RoleResolver, opts ...CharacterProviderOption) *CharacterProvider {
+	p := &CharacterProvider{
 		repo:         repo,
 		roleResolver: roleResolver,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // Namespace returns "character".
@@ -121,6 +147,35 @@ func (p *CharacterProvider) resolve(ctx context.Context, entityID string) (map[s
 		attrs["has_location"] = false
 	}
 
+	// Resolve is_guest for the owning player per ADR holomush-ti1b
+	// (omit-don't-sentinel): when has_is_guest=false the is_guest key MUST be
+	// OMITTED (not emitted as a false sentinel). The DSL evaluator's
+	// missing-attr-→-false comparison semantics then keep the fail-closed
+	// scene-command gate (plugins/core-scenes execute-scene-commands:
+	// `principal.character.is_guest == false`) denying when guest-ness cannot
+	// be determined. Emitting a false sentinel would satisfy `false == false`
+	// and let a guest whose lookup failed slip through. Per holomush-5rh.23.
+	if p.kindLookup != nil {
+		isGuest, lookupErr := p.kindLookup(ctx, char.PlayerID.String())
+		if lookupErr != nil {
+			// Lookup failure → omit is_guest, emit witness false (fail-safe).
+			slog.WarnContext(
+				ctx,
+				"character kind lookup failed — omitting is_guest attribute (fail-safe)",
+				"character_id", id.String(),
+				"player_id", char.PlayerID.String(),
+				"err", lookupErr,
+			)
+			attrs["has_is_guest"] = false
+		} else {
+			attrs["is_guest"] = isGuest
+			attrs["has_is_guest"] = true
+		}
+	} else {
+		// No lookup configured → omit is_guest key entirely (ADR holomush-ti1b).
+		attrs["has_is_guest"] = false
+	}
+
 	return attrs, nil
 }
 
@@ -136,6 +191,8 @@ func (p *CharacterProvider) Schema() *types.NamespaceSchema {
 			"location_id":  types.AttrTypeString,
 			"location":     types.AttrTypeString,
 			"has_location": types.AttrTypeBool,
+			"is_guest":     types.AttrTypeBool,
+			"has_is_guest": types.AttrTypeBool,
 		},
 	}
 }

--- a/internal/access/policy/attribute/character_test.go
+++ b/internal/access/policy/attribute/character_test.go
@@ -90,6 +90,8 @@ func TestCharacterProviderSchema(t *testing.T) {
 	assert.Equal(t, types.AttrTypeString, schema.Attributes["location_id"])
 	assert.Equal(t, types.AttrTypeString, schema.Attributes["location"])
 	assert.Equal(t, types.AttrTypeBool, schema.Attributes["has_location"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["is_guest"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["has_is_guest"])
 }
 
 func TestCharacterProvider_ResolveSubject(t *testing.T) {
@@ -132,6 +134,8 @@ func TestCharacterProvider_ResolveSubject(t *testing.T) {
 				"location_id":  locationID.String(),
 				"location":     locationID.String(),
 				"has_location": true,
+				// nil kindLookup → is_guest omitted, witness false (ADR holomush-ti1b).
+				"has_is_guest": false,
 			},
 		},
 		{
@@ -160,6 +164,8 @@ func TestCharacterProvider_ResolveSubject(t *testing.T) {
 				"description":  "",
 				"roles":        []string{"player"},
 				"has_location": false,
+				// nil kindLookup → is_guest omitted, witness false (ADR holomush-ti1b).
+				"has_is_guest": false,
 			},
 		},
 		{
@@ -246,6 +252,94 @@ func TestCharacterProvider_ResolveSubject(t *testing.T) {
 			assert.Equal(t, tt.expectAttrs, attrs)
 		})
 	}
+}
+
+// --- is_guest attribute (omit-don't-sentinel, ADR holomush-ti1b) -------------
+//
+// The character namespace carries is_guest so a Layer-1 command-execution
+// policy can gate on the acting character's owning-player kind (guests have a
+// character: principal at command dispatch, never a player: one — so the gate
+// must live on the character bag, not the player bag). Per holomush-5rh.23.
+
+// TestCharacterProviderEmitsIsGuestWitnessWhenLookupConfigured verifies that
+// when a PlayerKindLookup is configured, ResolveSubject emits both is_guest and
+// has_is_guest on every code path: true/true when the owning player is a guest,
+// false/true when registered. The lookup is keyed on the character's PlayerID.
+func TestCharacterProviderEmitsIsGuestWitnessWhenLookupConfigured(t *testing.T) {
+	charID := ulid.Make()
+	guestPlayerID := ulid.Make()
+	registeredPlayerID := ulid.Make()
+
+	// Typed as PlayerKindLookup so its always-nil error result is dictated by the
+	// named signature (keeps unparam from flagging the happy-path stub).
+	var lookup PlayerKindLookup = func(_ context.Context, playerID string) (bool, error) {
+		return playerID == guestPlayerID.String(), nil
+	}
+
+	newProvider := func(playerID ulid.ULID) *CharacterProvider {
+		repo := &mockCharacterRepository{
+			getFunc: func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+				return &world.Character{ID: charID, PlayerID: playerID, Name: "C"}, nil
+			},
+		}
+		return NewCharacterProvider(repo, nil, WithCharacterKindLookup(lookup))
+	}
+
+	t.Run("guest player's character emits is_guest true and has_is_guest true", func(t *testing.T) {
+		attrs, err := newProvider(guestPlayerID).ResolveSubject(context.Background(), access.CharacterSubject(charID.String()))
+		require.NoError(t, err)
+		require.NotNil(t, attrs)
+		assert.Equal(t, true, attrs["is_guest"], "is_guest must be true when the owning player is a guest")
+		assert.Equal(t, true, attrs["has_is_guest"], "has_is_guest must always be present when lookup configured")
+	})
+
+	t.Run("registered player's character emits is_guest false and has_is_guest true", func(t *testing.T) {
+		attrs, err := newProvider(registeredPlayerID).ResolveSubject(context.Background(), access.CharacterSubject(charID.String()))
+		require.NoError(t, err)
+		require.NotNil(t, attrs)
+		assert.Equal(t, false, attrs["is_guest"], "is_guest must be false for a registered player's character")
+		assert.Equal(t, true, attrs["has_is_guest"], "has_is_guest must always be present when lookup configured")
+	})
+}
+
+// TestCharacterProviderOmitsIsGuestWhenLookupAbsentOrFails verifies the
+// omit-don't-sentinel invariant (ADR holomush-ti1b): when no lookup is
+// configured or it returns an error, the is_guest key MUST be absent (never a
+// false sentinel) and the witness has_is_guest MUST be false. This keeps the
+// fail-closed scene-command gate denying when guest-ness cannot be determined.
+func TestCharacterProviderOmitsIsGuestWhenLookupAbsentOrFails(t *testing.T) {
+	charID := ulid.Make()
+	playerID := ulid.Make()
+	repoFor := func() *mockCharacterRepository {
+		return &mockCharacterRepository{
+			getFunc: func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+				return &world.Character{ID: charID, PlayerID: playerID, Name: "C"}, nil
+			},
+		}
+	}
+
+	t.Run("no lookup configured: is_guest key absent and has_is_guest false", func(t *testing.T) {
+		p := NewCharacterProvider(repoFor(), nil)
+		attrs, err := p.ResolveSubject(context.Background(), access.CharacterSubject(charID.String()))
+		require.NoError(t, err)
+		require.NotNil(t, attrs)
+		_, ok := attrs["is_guest"]
+		assert.False(t, ok, "is_guest key MUST be absent when no lookup configured (omit-don't-sentinel, ADR holomush-ti1b)")
+		assert.Equal(t, false, attrs["has_is_guest"], "has_is_guest must be false when lookup not configured")
+	})
+
+	t.Run("lookup returns error: is_guest key absent and has_is_guest false", func(t *testing.T) {
+		lookup := func(_ context.Context, _ string) (bool, error) {
+			return false, errors.New("player not found")
+		}
+		p := NewCharacterProvider(repoFor(), nil, WithCharacterKindLookup(lookup))
+		attrs, err := p.ResolveSubject(context.Background(), access.CharacterSubject(charID.String()))
+		require.NoError(t, err, "lookup errors must not bubble out of ResolveSubject")
+		require.NotNil(t, attrs)
+		_, ok := attrs["is_guest"]
+		assert.False(t, ok, "is_guest key MUST be absent when lookup errors (omit-don't-sentinel, ADR holomush-ti1b)")
+		assert.Equal(t, false, attrs["has_is_guest"], "has_is_guest must be false when lookup fails")
+	})
 }
 
 func TestCharacterProvider_RoleResolution(t *testing.T) {
@@ -374,6 +468,8 @@ func TestCharacterProvider_ResolveResource(t *testing.T) {
 				"location_id":  locationID.String(),
 				"location":     locationID.String(),
 				"has_location": true,
+				// nil kindLookup → is_guest omitted, witness false (ADR holomush-ti1b).
+				"has_is_guest": false,
 			},
 		},
 		{

--- a/internal/access/setup/setup.go
+++ b/internal/access/setup/setup.go
@@ -136,7 +136,17 @@ func BuildABACStack(ctx context.Context, cfg ABACConfig) (*ABACStack, error) {
 		if cfg.RoleStore != nil {
 			roleResolver = store.NewPostgresRoleResolver(cfg.RoleStore)
 		}
-		charProvider := attribute.NewCharacterProvider(cfg.CharacterRepo, roleResolver)
+		// The guest-kind lookup is wired onto the character namespace so the
+		// Layer-1 scene-command gate (plugins/core-scenes execute-scene-commands)
+		// can read principal.character.is_guest — command dispatch evaluates a
+		// character: subject, which never carries the player: namespace. Omitted
+		// when nil (tests / alternate entrypoints); production wiring at
+		// internal/access/setup/subsystem.go always supplies it. Per holomush-5rh.23.
+		charOpts := []attribute.CharacterProviderOption{}
+		if cfg.PlayerKindLookup != nil {
+			charOpts = append(charOpts, attribute.WithCharacterKindLookup(cfg.PlayerKindLookup))
+		}
+		charProvider := attribute.NewCharacterProvider(cfg.CharacterRepo, roleResolver, charOpts...)
 		if err := resolver.RegisterProvider(charProvider); err != nil {
 			return nil, eb.Wrapf(err, "register character provider")
 		}

--- a/plugins/core-scenes/plugin.yaml
+++ b/plugins/core-scenes/plugin.yaml
@@ -229,11 +229,20 @@ commands:
     usage: "scenes [tag:<t>] [hide:<cw>]"
 
 policies:
-  # ─── Layer 1: command execution gate (unchanged from Phase 1) ─────────
+  # ─── Layer 1: command execution gate ─────────────────────────────────
+  # Scenes are registered-player-only (a guest is ephemeral, not a scene
+  # participant), so this permit excludes guests: `is_guest == false` is
+  # fail-CLOSED — a missing is_guest attribute (guest-lookup unconfigured or
+  # erroring) makes the comparison false, so the permit does not fire and the
+  # command default-denies. The character namespace carries is_guest because
+  # command dispatch evaluates a character: principal, which never resolves the
+  # player: namespace (the guest bit is keyed off the character's owning player
+  # via the host's PlayerKindLookup). Per holomush-5rh.23 (INV-SCENE-64 enforces
+  # the same guest exclusion on the web scene-access facade).
   - name: execute-scene-commands
     dsl: >-
       permit(principal is character, action in ["execute"], resource is command) when { resource.command.name in ["scene",
-      "scenes"] };
+      "scenes"] && principal.character.is_guest == false };
 
   # ─── Per-action authorization gates ───────────────────────────────────
   # These policies gate WHO (ownership / participation). Scene STATE validity

--- a/test/integration/plugin/binary_plugin_test.go
+++ b/test/integration/plugin/binary_plugin_test.go
@@ -429,6 +429,16 @@ var _ = Describe("Binary Plugin Lifecycle", func() {
 			cmdProvider := attribute.NewCommandProvider()
 			Expect(resolver.RegisterProvider(cmdProvider)).To(Succeed())
 
+			// 2b. Register a character-namespace provider so the fail-closed
+			// execute-scene-commands gate (principal.character.is_guest == false)
+			// resolves the acting character's guest status. char-alice is a
+			// registered player; char-guest is an ephemeral guest. Per holomush-5rh.23.
+			charProvider := &guestCharProvider{isGuestBySubject: map[string]bool{
+				"character:char-alice": false,
+				"character:char-guest": true,
+			}}
+			Expect(resolver.RegisterProvider(charProvider)).To(Succeed())
+
 			// 3. Discover scene schema from the plugin and register proxy provider.
 			arClient := abacHost.AttributeResolverClient("core-scenes")
 			Expect(arClient).NotTo(BeNil())
@@ -488,15 +498,25 @@ var _ = Describe("Binary Plugin Lifecycle", func() {
 			}
 		})
 
-		It("permits scene command execution via Layer 1 execute policy", func() {
+		It("permits a registered player's scene command execution via Layer 1 execute policy", func() {
 			req, err := policytypes.NewAccessRequest("character:char-alice", "execute", "command:scene", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			decision, err := abacEngine.Evaluate(abacCtx, req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(decision.IsAllowed()).To(BeTrue(),
-				"execute-scene-commands policy should permit Layer 1 command execution")
+				"execute-scene-commands policy should permit a non-guest character (is_guest == false)")
 			Expect(decision.Effect()).To(Equal(policytypes.EffectAllow))
+		})
+
+		It("denies a guest's scene command execution via the fail-closed Layer 1 gate", func() {
+			req, err := policytypes.NewAccessRequest("character:char-guest", "execute", "command:scene", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			decision, err := abacEngine.Evaluate(abacCtx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decision.IsAllowed()).To(BeFalse(),
+				"execute-scene-commands must deny a guest character (is_guest == true) per holomush-5rh.23")
 		})
 
 		It("permits the owner to read their own scene via per-resource policy", func() {
@@ -1134,3 +1154,41 @@ var _ = Describe("Binary Plugin Lifecycle", func() {
 		})
 	})
 })
+
+// guestCharProvider is a minimal character-namespace attribute provider for the
+// Layer-1 scene-command tests. It maps a character: subject ID to its
+// owning-player guest status so the fail-closed execute-scene-commands gate
+// (principal.character.is_guest == false) can be exercised without a real
+// character repository — these tests use synthetic non-ULID IDs that the real
+// CharacterProvider would skip. Per holomush-5rh.23.
+type guestCharProvider struct {
+	isGuestBySubject map[string]bool
+}
+
+func (p *guestCharProvider) Namespace() string { return "character" }
+
+func (p *guestCharProvider) ResolveSubject(_ context.Context, subjectID string) (map[string]any, error) {
+	isGuest, ok := p.isGuestBySubject[subjectID]
+	if !ok {
+		return nil, nil
+	}
+	return map[string]any{
+		"is_guest":     isGuest,
+		"has_is_guest": true,
+		"roles":        []string{"player"},
+	}, nil
+}
+
+func (p *guestCharProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *guestCharProvider) Schema() *policytypes.NamespaceSchema {
+	return &policytypes.NamespaceSchema{
+		Attributes: map[string]policytypes.AttrType{
+			"is_guest":     policytypes.AttrTypeBool,
+			"has_is_guest": policytypes.AttrTypeBool,
+			"roles":        policytypes.AttrTypeStringList,
+		},
+	}
+}

--- a/web/e2e/negative-journeys.spec.ts
+++ b/web/e2e/negative-journeys.spec.ts
@@ -222,12 +222,13 @@ test.describe('Terminal — Negative Journeys', () => {
     await expect(input).toBeEditable();
   });
 
-  // A malformed/missing scene ID produces a client-visible error event.
-  // The `scene end` command requires a valid ULID; a garbage argument reaches
-  // the plugin which returns "Usage: scene end #<scene id>" or the store
-  // returns a not-found error surfaced as "Failed to end scene: ...".
+  // A non-existent (but well-formed ULID) scene ID produces a client-visible
+  // error event. Scene commands are registered-player-only (guests are denied
+  // at Layer-1 per holomush-5rh.23), so this runs as a registered player; the
+  // command reaches the store, which returns a not-found error surfaced as
+  // "Failed to end scene: ...".
   test('scene end with bogus id shows error event in terminal', async ({ page }) => {
-    await connectAsGuest(page);
+    await registerAndEnterTerminal(page, 'nse');
     const input = page.locator('textarea');
 
     const before = await currentEventCount(page);

--- a/web/e2e/scenes.spec.ts
+++ b/web/e2e/scenes.spec.ts
@@ -5,17 +5,6 @@ import { test, expect, db, getClientSessionId, registerAndEnterTerminal } from '
 import type { Page, BrowserContext } from '@playwright/test';
 
 /**
- * Connect as guest via the landing page and wait for the terminal to load.
- * Same pattern as web/e2e/terminal.spec.ts.
- */
-async function connectAsGuest(page: Page) {
-  await page.goto('/');
-  await page.getByRole('main').getByRole('button', { name: 'Try as Guest' }).click();
-  await expect(page).toHaveURL(/\/terminal/, { timeout: 10000 });
-  await expect(page.locator('.terminal-layout')).toBeVisible({ timeout: 10000 });
-}
-
-/**
  * Send a command via the terminal textarea. The caller is responsible for
  * waiting for any specific output.
  */
@@ -98,7 +87,9 @@ async function extractSceneIdFromOutput(page: Page, sinceIndex: number): Promise
 
 test.describe('Scene lifecycle (Phase 2)', () => {
   test('create -> pause -> resume -> end with DB verification', async ({ page }) => {
-    await connectAsGuest(page);
+    // Scene commands are registered-player-only (guests are denied at Layer-1
+    // per holomush-5rh.23), so drive the lifecycle as a registered player.
+    await registerAndEnterTerminal(page, 'sla');
     const sessionId = await getClientSessionId(page);
     expect(sessionId).toBeTruthy();
     const session = await db.getSessionById(sessionId!);
@@ -143,7 +134,7 @@ test.describe('Scene lifecycle (Phase 2)', () => {
   });
 
   test('scene set updates the title', async ({ page }) => {
-    await connectAsGuest(page);
+    await registerAndEnterTerminal(page, 'slb');
 
     let before = await currentEventCount(page);
     await sendCommand(page, 'scene create Original Title');
@@ -161,7 +152,7 @@ test.describe('Scene lifecycle (Phase 2)', () => {
   });
 
   test('cannot end an already-ended scene', async ({ page }) => {
-    await connectAsGuest(page);
+    await registerAndEnterTerminal(page, 'slc');
 
     let before = await currentEventCount(page);
     await sendCommand(page, 'scene create Will End Twice');
@@ -178,7 +169,7 @@ test.describe('Scene lifecycle (Phase 2)', () => {
   });
 
   test('scene info shows scene metadata', async ({ page }) => {
-    await connectAsGuest(page);
+    await registerAndEnterTerminal(page, 'sld');
 
     let before = await currentEventCount(page);
     await sendCommand(page, 'scene create Info Test Scene');
@@ -208,14 +199,14 @@ test.describe('Scene focus routing (Phase 5, holomush-dble7)', () => {
   // the web client captures from the STREAM_OPENED ControlFrame and echoes on
   // SendCommand). If the live stream is up but the command carries an empty
   // connection_id, the plugin rejects with "requires a live connection"
-  // (plugins/core-scenes/commands.go:1146 for focus, :1092 for grid). A guest
-  // is auto-joined as the owner of the scene it creates, so membership is
-  // satisfied and the ONLY thing that can produce that message is an empty
-  // connection_id reaching the handler.
+  // (plugins/core-scenes/commands.go:1146 for focus, :1092 for grid). The
+  // scene creator is auto-joined as the owner of the scene it creates, so
+  // membership is satisfied and the ONLY thing that can produce that message is
+  // an empty connection_id reaching the handler.
   test('scene focus on a joined scene succeeds (does not report no live connection)', async ({
     page,
   }) => {
-    await connectAsGuest(page);
+    await registerAndEnterTerminal(page, 'sfa');
 
     let before = await currentEventCount(page);
     await sendCommand(page, 'scene create Focus Routing Test');
@@ -244,7 +235,7 @@ test.describe('Scene focus routing (Phase 5, holomush-dble7)', () => {
   });
 
   test('scene grid succeeds (does not report no live connection)', async ({ page }) => {
-    await connectAsGuest(page);
+    await registerAndEnterTerminal(page, 'sfb');
 
     // No scene needed — `scene grid` only requires a live per-connection id.
     const before = await currentEventCount(page);
@@ -533,7 +524,7 @@ test.describe('Scenes workspace (E9.5)', () => {
   // '/terminal') when session.isGuest is true. This is the client-side
   // convenience guard for INV-SCENE-64.
   test('guest player navigating to /scenes is redirected to /terminal', async ({ page }) => {
-    // Enter as guest using the same connectAsGuest flow defined above.
+    // Enter as a guest via the landing page (this guard test must stay a guest).
     await page.goto('/');
     await page.getByRole('main').getByRole('button', { name: 'Try as Guest' }).click();
     await expect(page).toHaveURL(/\/terminal/, { timeout: 10000 });

--- a/web/src/lib/components/shell/SectionRail.svelte
+++ b/web/src/lib/components/shell/SectionRail.svelte
@@ -5,7 +5,7 @@
 <script lang="ts">
   import { Home, Clapperboard, Settings } from '@lucide/svelte';
   import type { Component } from 'svelte';
-  import { SECTIONS, type SectionId } from '$lib/nav/sections';
+  import { visibleSections, type SectionId } from '$lib/nav/sections';
   import { uiPrefs, toggleDensity } from '$lib/stores/uiPrefsStore';
   import { themePreferences, setTerminalBlackBackground } from '$lib/stores/themeStore';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
@@ -16,14 +16,20 @@
     pathname: string;
     /** 'rail' = persistent desktop column; 'drawer' = mobile Sheet (shows labels). */
     variant?: 'rail' | 'drawer';
+    /** True for an ephemeral guest session — hides registered-player-only sections. */
+    isGuest?: boolean;
     /** Called when a section link is clicked (drawer closes itself via this). */
     onnavigate?: () => void;
   }
-  let { pathname, variant = 'rail', onnavigate }: Props = $props();
+  let { pathname, variant = 'rail', isGuest = false, onnavigate }: Props = $props();
 
   // id → icon: kept here so nav/sections.ts stays Svelte-free / node-testable.
   // Keyed by SectionId so a new section without an icon is a compile error.
   const icons: Record<SectionId, Component> = { room: Home, scenes: Clapperboard };
+
+  // Guest sessions never see registered-player-only sections (e.g. Scenes);
+  // the registry's visibleSections is the single gate the palette shares.
+  let sections = $derived(visibleSections({ isGuest }));
 </script>
 
 <aside
@@ -35,7 +41,7 @@
   aria-label="Navigation rail"
 >
   <div class="rail-inner">
-    {#each SECTIONS as section (section.id)}
+    {#each sections as section (section.id)}
       {@const Icon = icons[section.id]}
       {@const active = section.match(pathname)}
       <a

--- a/web/src/lib/components/shell/SectionRail.svelte.test.ts
+++ b/web/src/lib/components/shell/SectionRail.svelte.test.ts
@@ -30,7 +30,7 @@ vi.hoisted(() => {
   })) as typeof globalThis.matchMedia;
 });
 
-function render(props: { pathname: string; variant?: 'rail' | 'drawer' }) {
+function render(props: { pathname: string; variant?: 'rail' | 'drawer'; isGuest?: boolean }) {
   const target = document.createElement('div');
   document.body.appendChild(target);
   const component = mount(SectionRail, { target, props });
@@ -59,6 +59,13 @@ describe('SectionRail', () => {
     const { target, component } = render({ pathname: '/terminal', variant: 'drawer' });
     expect(target.textContent).toContain('Room');
     expect(target.textContent).toContain('Scenes');
+    unmount(component);
+  });
+
+  it('hides the Scenes link for a guest session', () => {
+    const { target, component } = render({ pathname: '/terminal', isGuest: true });
+    const hrefs = [...target.querySelectorAll('a.rail-btn')].map((a) => a.getAttribute('href'));
+    expect(hrefs).toEqual(['/terminal']);
     unmount(component);
   });
 });

--- a/web/src/lib/components/terminal/CommandPalette.svelte
+++ b/web/src/lib/components/terminal/CommandPalette.svelte
@@ -19,7 +19,7 @@
     setTheme,
     setTerminalBlackBackground,
   } from '$lib/stores/themeStore';
-  import { clearAuth } from '$lib/stores/authStore';
+  import { clearAuth, authState } from '$lib/stores/authStore';
   import { createClient } from '@connectrpc/connect';
   import { WebService } from '$lib/connect/holomush/web/v1/web_pb';
   import { transport } from '$lib/transport';
@@ -41,13 +41,20 @@
     goto('/');
   }
 
-  const navItems: PaletteItem[] = sectionNavEntries().map((e) => ({
-    id: e.id,
-    label: e.label,
-    run: () => goto(e.href),
-  }));
+  // Guest sessions don't get registered-player-only go-to entries (e.g. Scenes),
+  // mirroring the Rail (same registry gate, ADR holomush-stds8). This MUST be
+  // reactive: the palette mounts in the persistent root layout before route
+  // loads resolve the session, so a one-shot snapshot would freeze the pre-auth
+  // isGuest=false and leave "Go to Scenes" in a guest's palette (holomush-5rh.23).
+  const navItems: PaletteItem[] = $derived(
+    sectionNavEntries({ isGuest: $authState.isGuest }).map((e) => ({
+      id: e.id,
+      label: e.label,
+      run: () => goto(e.href),
+    })),
+  );
 
-  const items: PaletteItem[] = [
+  const items: PaletteItem[] = $derived([
     ...navItems,
     { id: 'theme.default-dark',   label: 'Switch theme: Default Dark',   run: () => setTheme('default-dark') },
     { id: 'theme.default-light',  label: 'Switch theme: Default Light',  run: () => setTheme('default-light') },
@@ -60,7 +67,7 @@
     { id: 'ui.term-black',        label: 'Toggle black terminal background',            run: () => setTerminalBlackBackground(!$themePreferences.terminalBlackBackground) },
     { id: 'term.clear',           label: 'Clear terminal',               hint: '⌘L',  run: clearLines },
     { id: 'auth.sign-out',        label: 'Sign out',                                   run: signOut },
-  ];
+  ]);
 
   function runAndClose(item: PaletteItem) {
     item.run();

--- a/web/src/lib/components/terminal/CommandPalette.svelte.test.ts
+++ b/web/src/lib/components/terminal/CommandPalette.svelte.test.ts
@@ -1,0 +1,97 @@
+// web/src/lib/components/terminal/CommandPalette.svelte.test.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount, tick } from 'svelte';
+import CommandPalette from './CommandPalette.svelte';
+import { authState } from '$lib/stores/authStore';
+import { openPalette, closePalette } from '$lib/stores/uiPrefsStore';
+
+// themeStore reads localStorage/matchMedia at module load — before test-setup's
+// beforeEach polyfill runs. Hoist a stub so the module evaluates. Same pattern
+// as SectionRail.svelte.test.ts.
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  } as Storage;
+  globalThis.matchMedia ??= ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof globalThis.matchMedia;
+  // bits-ui Command observes its list size; jsdom has no ResizeObserver.
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof globalThis.ResizeObserver;
+  // bits-ui Command scrolls the active item into view; jsdom lacks the method.
+  if (!globalThis.Element.prototype.scrollIntoView) {
+    globalThis.Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+// The palette imports goto from $app/navigation; stub it so the module mounts.
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+
+function setAuth(isGuest: boolean) {
+  // Both a guest and a registered player are authenticated; only isGuest differs.
+  authState.set({
+    isPlayerAuthenticated: true,
+    sessionId: null,
+    characterName: null,
+    playerName: null,
+    playerId: null,
+    isGuest,
+    characters: [],
+  });
+}
+
+// The bits-ui dialog portal mounts its content a macrotask after open; flush
+// Svelte's microtask queue around it so the rendered items settle.
+async function flush() {
+  await tick();
+  await new Promise((r) => setTimeout(r, 0));
+  await tick();
+}
+
+afterEach(() => {
+  closePalette();
+  setAuth(false);
+  document.body.replaceChildren();
+});
+
+describe('CommandPalette guest gate', () => {
+  // The palette mounts once in the persistent ROOT layout, before route load
+  // functions resolve the session's guest status — so its go-to entries MUST
+  // react to authState rather than snapshot it at construction. Per holomush-5rh.23.
+  it('drops the Scenes go-to entry when the session resolves as a guest after mount', async () => {
+    setAuth(false); // pre-auth default — the palette mounts with this snapshot
+    openPalette(); // open before mount so the portal renders its items
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const component = mount(CommandPalette, { target });
+    await flush();
+    expect(document.body.textContent).toContain('Go to Scenes');
+    expect(document.body.textContent).toContain('Go to Room');
+
+    // Auth resolves as a guest AFTER the palette already mounted.
+    setAuth(true);
+    await flush();
+    expect(document.body.textContent).not.toContain('Go to Scenes');
+    expect(document.body.textContent).toContain('Go to Room');
+
+    unmount(component);
+  });
+});

--- a/web/src/lib/nav/sections.test.ts
+++ b/web/src/lib/nav/sections.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 import { describe, expect, it } from 'vitest';
-import { SECTIONS, activeSectionId, activeSectionLabel, sectionNavEntries } from './sections';
+import {
+  SECTIONS,
+  activeSectionId,
+  activeSectionLabel,
+  sectionNavEntries,
+  visibleSections,
+} from './sections';
 
 describe('section registry', () => {
   it('lists Room then Scenes with their routes', () => {
@@ -36,10 +42,27 @@ describe('activeSectionLabel', () => {
 });
 
 describe('sectionNavEntries', () => {
-  it('derives palette go-to entries from the same registry', () => {
-    expect(sectionNavEntries()).toEqual([
+  it('derives palette go-to entries from the same registry for a registered player', () => {
+    expect(sectionNavEntries({ isGuest: false })).toEqual([
       { id: 'nav.room', label: 'Go to Room', href: '/terminal' },
       { id: 'nav.scenes', label: 'Go to Scenes', href: '/scenes' },
+    ]);
+  });
+});
+
+describe('visibleSections gates registered-player-only sections', () => {
+  it('hides Scenes for a guest session (requiresPlayer)', () => {
+    expect(visibleSections({ isGuest: true }).map((s) => s.id)).toEqual(['room']);
+  });
+  it('shows every section for a registered player', () => {
+    expect(visibleSections({ isGuest: false }).map((s) => s.id)).toEqual(['room', 'scenes']);
+  });
+});
+
+describe('sectionNavEntries respects guest visibility', () => {
+  it('omits the Scenes go-to entry for a guest', () => {
+    expect(sectionNavEntries({ isGuest: true })).toEqual([
+      { id: 'nav.room', label: 'Go to Room', href: '/terminal' },
     ]);
   });
 });

--- a/web/src/lib/nav/sections.ts
+++ b/web/src/lib/nav/sections.ts
@@ -13,6 +13,20 @@ export interface WorkspaceSection {
   href: string;
   /** True when `pathname` is within this section (the route or a child of it). */
   match: (pathname: string) => boolean;
+  /**
+   * When true, the section is registered-player-only and is hidden from guest
+   * sessions (a guest is ephemeral and not a scene participant). The route
+   * itself still guards server-side (the /scenes layout redirect + the
+   * scene-access facade's guest denial, INV-SCENE-64); this flag only removes
+   * the dead-end nav affordance. Per holomush-5rh.23.
+   */
+  requiresPlayer?: boolean;
+}
+
+/** Viewer context that gates section visibility. */
+export interface SectionVisibility {
+  /** True for an ephemeral guest session. */
+  isGuest: boolean;
 }
 
 const prefix = (base: string) => (pathname: string) =>
@@ -26,7 +40,7 @@ const prefix = (base: string) => (pathname: string) =>
  */
 export const SECTIONS = [
   { id: 'room', label: 'Room', href: '/terminal', match: prefix('/terminal') },
-  { id: 'scenes', label: 'Scenes', href: '/scenes', match: prefix('/scenes') },
+  { id: 'scenes', label: 'Scenes', href: '/scenes', match: prefix('/scenes'), requiresPlayer: true },
 ] as const satisfies readonly WorkspaceSection[];
 
 /** The `id` of a registered section — the exhaustive key type for any per-section map. */
@@ -40,13 +54,34 @@ export function activeSectionLabel(pathname: string): string | null {
   return SECTIONS.find((s) => s.match(pathname))?.label ?? null;
 }
 
+/**
+ * The sections a viewer may see, in registry order. `requiresPlayer` sections
+ * are filtered out for guests. This is the single gate both the Rail and the
+ * palette go-to entries flow through, so a section is never shown in one
+ * surface but hidden in the other (ADR holomush-stds8).
+ */
+export function visibleSections(viewer: SectionVisibility): readonly (typeof SECTIONS)[number][] {
+  // Param annotated as the wider WorkspaceSection so optional `requiresPlayer`
+  // is readable across the `as const` union (only some members carry it).
+  return SECTIONS.filter((s: WorkspaceSection) => !(s.requiresPlayer && viewer.isGuest));
+}
+
 export interface SectionNavEntry {
   id: string;
   label: string;
   href: string;
 }
 
-/** Palette "go to <section>" entries, derived from {@link SECTIONS}. */
-export function sectionNavEntries(): SectionNavEntry[] {
-  return SECTIONS.map((s) => ({ id: `nav.${s.id}`, label: `Go to ${s.label}`, href: s.href }));
+/**
+ * Palette "go to <section>" entries, derived from the viewer-visible subset of
+ * {@link SECTIONS}. `viewer` is required (no default) so a caller can never
+ * accidentally fall back to the registered-player view and leak a guest-hidden
+ * section into the palette — the fail-safe posture must be explicit.
+ */
+export function sectionNavEntries(viewer: SectionVisibility): SectionNavEntry[] {
+  return visibleSections(viewer).map((s) => ({
+    id: `nav.${s.id}`,
+    label: `Go to ${s.label}`,
+    href: s.href,
+  }));
 }

--- a/web/src/routes/(authed)/+layout.svelte
+++ b/web/src/routes/(authed)/+layout.svelte
@@ -8,13 +8,18 @@
   import ShellFooter from '$lib/components/shell/ShellFooter.svelte';
   import { Sheet, SheetContent, SheetTitle, SheetDescription } from '$lib/components/ui/sheet';
   import { mobileNavOpen, openMobileNav, closeMobileNav } from '$lib/stores/mobileNavStore';
+  import { authState } from '$lib/stores/authStore';
 
   let { children } = $props();
   let pathname = $derived($page.url.pathname);
+  // Guests don't see registered-player-only sections (e.g. Scenes); the Rail
+  // and palette share the same registry gate (ADR holomush-stds8). The /scenes
+  // route + scene-access facade (INV-SCENE-64) remain the server-side guard.
+  let isGuest = $derived($authState.isGuest);
 </script>
 
 <div class="shell">
-  <SectionRail {pathname} variant="rail" />
+  <SectionRail {pathname} {isGuest} variant="rail" />
   <div class="section-col">
     <div class="section-slot">{@render children()}</div>
     <ShellFooter {pathname} />
@@ -27,7 +32,7 @@
   <SheetContent side="left" class="p-0 w-[260px]">
     <SheetTitle class="sr-only">Navigation</SheetTitle>
     <SheetDescription class="sr-only">Switch workspace section</SheetDescription>
-    <SectionRail {pathname} variant="drawer" onnavigate={closeMobileNav} />
+    <SectionRail {pathname} {isGuest} variant="drawer" onnavigate={closeMobileNav} />
   </SheetContent>
 </Sheet>
 


### PR DESCRIPTION
## Summary

Closes two guest-gating gaps for Scenes (a guest is ephemeral, not a scene participant), surfaced while walking the running app.

- **Gap 1 — frontend dead-end:** the Scenes nav affordance was shown to guests and silently bounced back to `/terminal` by the existing route redirect. Added a declarative `requiresPlayer` flag to the nav registry (`web/src/lib/nav/sections.ts`) + a `visibleSections({isGuest})` filter that **both** the Rail and the ⌘K palette honor — single source of truth (ADR holomush-stds8). The palette derives its entries reactively from `authState` (it mounts in the persistent root layout before auth resolves, so a one-shot snapshot would freeze the pre-auth `isGuest=false`).
- **Gap 2 — backend authz:** a guest could still run `scene`/`scenes` at the terminal. Layer-1 command auth evaluates a `character:` principal, and the `player:` namespace is never merged onto a character subject — so the bead's suggested `principal.player.is_guest` policy would silently never match (fail-open). Instead, `CharacterProvider` now resolves `character.is_guest`/`has_is_guest` from the owning player via the existing `PlayerKindLookup` (omit-don't-sentinel, ADR holomush-ti1b), and the core-scenes `execute-scene-commands` permit is narrowed with `&& principal.character.is_guest == false` — **fail-closed** (a missing attribute denies). Parallel to INV-SCENE-64 (the web scene-access facade guest denial).

The `/scenes` route redirect and the scene-access facade denial remain the server-side guard; Gap 1 only removes the dead-end affordance.

## Test Plan

- [x] `task test -- ./internal/access/...` — provider + setup unit tests (1231 pass), incl. new `character.is_guest` omit-don't-sentinel cases
- [x] Web `vitest run` (287 pass) + `svelte-check` (0 errors) — registry filter, Rail guest gate, and a new `CommandPalette.svelte.test.ts` proving the palette drops "Go to Scenes" when the session resolves as a guest *after* mount (RED→GREEN)
- [x] `task test:int -- ./test/integration/plugin/... ./test/integration/scenes/...` — guest denied + registered player permitted + scene commands unbroken
- [x] `task pr-prep` fast lane = pass; full lane (int + E2E) running
- [x] Pre-push reviews: abac-reviewer READY; code-reviewer (fixed the palette-staleness finding)
- [ ] CI required checks: Integration Test + E2E Test

Follow-up: holomush-fdu2b (register the terminal guest-deny as a named invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)