### PR TITLE
feat(web): slide-in/out collapsible scene panels (holomush-5rh.29)

### DIFF
--- a/web/e2e/scenes-panels.spec.ts
+++ b/web/e2e/scenes-panels.spec.ts
@@ -1,0 +1,128 @@
+// web/e2e/scenes-panels.spec.ts
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { test, expect, registerAndEnterTerminal } from './helpers/fixtures';
+
+// Verifies holomush-5rh.29: the scenes desktop layout's left scene-list and
+// right context-rail panes collapse/expand with a slide transition. The panes
+// exist regardless of scene data, so no scene seeding is needed.
+//
+// Collapse is asserted on paneforge's own state contract (the [data-pane]
+// element gets data-collapsed / data-expanded) rather than child visibility —
+// the context-rail <aside> has a border-l, so even at 0 width its 1px border-box
+// reads as "visible" to a pixel check though the pane's overflow:hidden clips it.
+test.describe('scenes workspace collapsible panels', () => {
+  test('left list and right rail collapse/expand with a slide transition', async ({ page }, testInfo) => {
+    await registerAndEnterTerminal(page, 'pnl');
+
+    // Desktop viewport by default → the three-pane Resizable layout mounts.
+    await page.getByTestId('rail').first().getByRole('link', { name: 'Scenes' }).click();
+    await expect(page).toHaveURL(/\/scenes/);
+    await expect(page.getByTestId('scenes-workspace')).toBeVisible();
+
+    const listPane = page.locator('[data-pane]:has(nav[aria-label="Scene list"])');
+    const railPane = page.locator('[data-pane]:has(aside[aria-label="Scene context"])');
+    await expect(listPane).toHaveAttribute('data-expanded', '');
+    await expect(railPane).toHaveAttribute('data-expanded', '');
+    await page.screenshot({ path: testInfo.outputPath('scenes-panels-expanded.png') });
+
+    // The slide is wired: paneforge sizes panes via flex-grow and we transition it.
+    const transitionProp = await listPane.evaluate(
+      (el) => getComputedStyle(el).transitionProperty,
+    );
+    expect(transitionProp).toContain('flex-grow');
+
+    // Collapse the left scene list → paneforge marks the pane collapsed.
+    await page.getByRole('button', { name: 'Hide scene list' }).click();
+    await expect(listPane).toHaveAttribute('data-collapsed', '');
+    await page.screenshot({ path: testInfo.outputPath('scenes-panels-list-collapsed.png') });
+
+    // Collapse the right context rail too.
+    await page.getByRole('button', { name: 'Hide scene context' }).click();
+    await expect(railPane).toHaveAttribute('data-collapsed', '');
+    await page.screenshot({ path: testInfo.outputPath('scenes-panels-both-collapsed.png') });
+
+    // Re-expand both.
+    await page.getByRole('button', { name: 'Show scene list' }).click();
+    await expect(listPane).toHaveAttribute('data-expanded', '');
+    await page.getByRole('button', { name: 'Show scene context' }).click();
+    await expect(railPane).toHaveAttribute('data-expanded', '');
+  });
+
+  test('keyboard shortcut and command palette toggle the panes', async ({ page }) => {
+    await registerAndEnterTerminal(page, 'kbd');
+    await page.goto('/scenes');
+    await expect(page.getByTestId('scenes-workspace')).toBeVisible();
+
+    const listPane = page.locator('[data-pane]:has(nav[aria-label="Scene list"])');
+    const railPane = page.locator('[data-pane]:has(aside[aria-label="Scene context"])');
+    await expect(listPane).toHaveAttribute('data-expanded', '');
+
+    // ⌘⇧, (detected via e.code 'Comma') toggles the left scene list.
+    await page.keyboard.press('ControlOrMeta+Shift+Comma');
+    await expect(listPane).toHaveAttribute('data-collapsed', '');
+    await page.keyboard.press('ControlOrMeta+Shift+Comma');
+    await expect(listPane).toHaveAttribute('data-expanded', '');
+
+    // ⌘⇧. (e.code 'Period') toggles the right context rail.
+    await page.keyboard.press('ControlOrMeta+Shift+Period');
+    await expect(railPane).toHaveAttribute('data-collapsed', '');
+    await page.keyboard.press('ControlOrMeta+Shift+Period');
+    await expect(railPane).toHaveAttribute('data-expanded', '');
+
+    // The command palette also toggles the right context rail.
+    await page.keyboard.press('ControlOrMeta+k');
+    await page.getByPlaceholder('Type a command…').fill('Toggle scene context');
+    await page.getByRole('option', { name: 'Toggle scene context' }).click();
+    await expect(railPane).toHaveAttribute('data-collapsed', '');
+  });
+
+  test('drag-collapsing the left pane persists across reload', async ({ page }) => {
+    await registerAndEnterTerminal(page, 'drg');
+    await page.goto('/scenes');
+    await expect(page.getByTestId('scenes-workspace')).toBeVisible();
+
+    const listPane = page.locator('[data-pane]:has(nav[aria-label="Scene list"])');
+    await expect(listPane).toHaveAttribute('data-expanded', '');
+
+    // Drag the first resize handle to the far left, past the collapse threshold —
+    // paneforge snaps the pane to collapsedSize (0) and fires onCollapse, which
+    // writes back to uiPrefs.
+    const handle = page.locator('[data-pane-resizer]').first();
+    const box = await handle.boundingBox();
+    if (!box) throw new Error('resize handle has no bounding box');
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(2, box.y + box.height / 2, { steps: 12 });
+    await page.mouse.up();
+    await expect(listPane).toHaveAttribute('data-collapsed', '');
+
+    // Reload — the drag-collapsed state persists (uiPrefs write-back + autoSaveId).
+    await page.reload();
+    await expect(page.getByTestId('scenes-workspace')).toBeVisible();
+    await expect(page.locator('[data-pane]:has(nav[aria-label="Scene list"])')).toHaveAttribute(
+      'data-collapsed',
+      '',
+    );
+  });
+
+  test('collapsed state persists across reload (uiPrefs → localStorage)', async ({ page }) => {
+    await registerAndEnterTerminal(page, 'prs');
+    await page.goto('/scenes');
+    await expect(page.getByTestId('scenes-workspace')).toBeVisible();
+
+    const listPane = page.locator('[data-pane]:has(nav[aria-label="Scene list"])');
+    await expect(listPane).toHaveAttribute('data-expanded', '');
+    await page.getByRole('button', { name: 'Hide scene list' }).click();
+    await expect(listPane).toHaveAttribute('data-collapsed', '');
+
+    await page.reload();
+    await expect(page.getByTestId('scenes-workspace')).toBeVisible();
+    // Persisted collapsed: the pane comes back collapsed and the toggle offers "Show".
+    await expect(page.locator('[data-pane]:has(nav[aria-label="Scene list"])')).toHaveAttribute(
+      'data-collapsed',
+      '',
+    );
+    await expect(page.getByRole('button', { name: 'Show scene list' })).toBeVisible();
+  });
+});

--- a/web/src/lib/components/terminal/CommandPalette.svelte
+++ b/web/src/lib/components/terminal/CommandPalette.svelte
@@ -10,6 +10,8 @@
     closePalette,
     toggleRail,
     toggleSidebar,
+    toggleScenesList,
+    toggleScenesRail,
     toggleComposer,
     toggleDensity,
   } from '$lib/stores/uiPrefsStore';
@@ -62,6 +64,8 @@
     { id: 'theme.warm-light',     label: 'Switch theme: Warm Light',     run: () => setTheme('warm-light') },
     { id: 'ui.rail',              label: 'Toggle rail',                  hint: '⌘B',  run: toggleRail },
     { id: 'ui.sidebar',           label: 'Toggle sidebar',               hint: '⌘.',  run: toggleSidebar },
+    { id: 'ui.scenes-list',       label: 'Toggle scene list',            hint: '⌘⇧,', run: toggleScenesList },
+    { id: 'ui.scenes-rail',       label: 'Toggle scene context',         hint: '⌘⇧.', run: toggleScenesRail },
     { id: 'ui.composer',          label: 'Toggle composer',              hint: '⌘⇧E', run: toggleComposer },
     { id: 'ui.density',           label: 'Toggle density (cozy/compact)',               run: toggleDensity },
     { id: 'ui.term-black',        label: 'Toggle black terminal background',            run: () => setTerminalBlackBackground(!$themePreferences.terminalBlackBackground) },

--- a/web/src/lib/hooks/mediaQuery.svelte.test.ts
+++ b/web/src/lib/hooks/mediaQuery.svelte.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { mediaQuery, isDesktop, DESKTOP_MEDIA_QUERY } from './mediaQuery.svelte';
+
+interface FakeMql {
+  matches: boolean;
+  media: string;
+  addEventListener: (t: string, cb: (e: MediaQueryListEvent) => void) => void;
+  removeEventListener: (t: string, cb: (e: MediaQueryListEvent) => void) => void;
+  emit: (matches: boolean) => void;
+}
+
+/** Install a controllable window.matchMedia and record the queries it sees. */
+function installMatchMedia(initial: boolean): { mql: FakeMql; queries: string[] } {
+  const queries: string[] = [];
+  let listeners: ((e: MediaQueryListEvent) => void)[] = [];
+  const mql: FakeMql = {
+    matches: initial,
+    media: '',
+    addEventListener: (_t, cb) => void listeners.push(cb),
+    removeEventListener: (_t, cb) => void (listeners = listeners.filter((l) => l !== cb)),
+    emit: (matches) => {
+      mql.matches = matches;
+      listeners.forEach((l) => l({ matches } as MediaQueryListEvent));
+    },
+  };
+  vi.stubGlobal('matchMedia', (q: string) => {
+    queries.push(q);
+    mql.media = q;
+    return mql;
+  });
+  return { mql, queries };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('mediaQuery', () => {
+  it('reflects the initial match state synchronously', () => {
+    installMatchMedia(true);
+    const cleanup = $effect.root(() => {
+      const mq = mediaQuery('(min-width: 768px)');
+      expect(mq.current).toBe(true);
+    });
+    cleanup();
+  });
+
+  it('updates reactively when the media query changes', () => {
+    const { mql } = installMatchMedia(false);
+    const cleanup = $effect.root(() => {
+      const mq = mediaQuery('(min-width: 768px)');
+      flushSync();
+      expect(mq.current).toBe(false);
+      mql.emit(true);
+      flushSync();
+      expect(mq.current).toBe(true);
+    });
+    cleanup();
+  });
+
+  it('removes its change listener on teardown', () => {
+    const { mql } = installMatchMedia(true);
+    let removed = false;
+    const orig = mql.removeEventListener;
+    mql.removeEventListener = (t, cb) => {
+      removed = true;
+      orig(t, cb);
+    };
+    const cleanup = $effect.root(() => {
+      mediaQuery('(min-width: 768px)');
+      flushSync();
+    });
+    cleanup();
+    expect(removed).toBe(true);
+  });
+
+  it('isDesktop tracks the Tailwind md breakpoint', () => {
+    const { queries } = installMatchMedia(true);
+    const cleanup = $effect.root(() => {
+      const d = isDesktop();
+      expect(d.current).toBe(true);
+    });
+    cleanup();
+    expect(DESKTOP_MEDIA_QUERY).toBe('(min-width: 768px)');
+    expect(queries).toContain(DESKTOP_MEDIA_QUERY);
+  });
+});

--- a/web/src/lib/hooks/mediaQuery.svelte.ts
+++ b/web/src/lib/hooks/mediaQuery.svelte.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+/** Tailwind `md` breakpoint — the desktop/mobile divide for the workspace shell. */
+export const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
+
+/**
+ * Reactive `matchMedia` wrapper. The returned object's `current` getter is a
+ * reactive boolean tracking whether `query` currently matches. Call it from a
+ * component init or an `$effect.root` so the internal `$effect` can register and
+ * tear down the `MediaQueryList` listener.
+ */
+export function mediaQuery(query: string): { readonly current: boolean } {
+  let matches = $state(
+    typeof window !== 'undefined' ? window.matchMedia(query).matches : false,
+  );
+
+  $effect(() => {
+    const mql = window.matchMedia(query);
+    matches = mql.matches;
+    const onChange = (e: MediaQueryListEvent) => {
+      matches = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
+
+  return {
+    get current() {
+      return matches;
+    },
+  };
+}
+
+/** Reactive boolean: `true` at or above the Tailwind `md` breakpoint (desktop). */
+export function isDesktop(): { readonly current: boolean } {
+  return mediaQuery(DESKTOP_MEDIA_QUERY);
+}

--- a/web/src/lib/stores/uiPrefsStore.test.ts
+++ b/web/src/lib/stores/uiPrefsStore.test.ts
@@ -7,6 +7,10 @@ import {
   uiPrefs,
   toggleRail,
   toggleSidebar,
+  toggleScenesList,
+  toggleScenesRail,
+  setScenesListHidden,
+  setScenesRailHidden,
   toggleComposer,
   togglePalette,
   toggleDensity,
@@ -35,6 +39,8 @@ describe('uiPrefsStore', () => {
     expect(p.density).toBe('cozy');
     expect(p.composerOpen).toBe(false);
     expect(p.paletteOpen).toBe(false);
+    expect(p.scenesListHidden).toBe(false);
+    expect(p.scenesRailHidden).toBe(false);
   });
 
   it('toggles boolean flags', () => {
@@ -46,6 +52,51 @@ describe('uiPrefsStore', () => {
     expect(get(uiPrefs).composerOpen).toBe(true);
     togglePalette();
     expect(get(uiPrefs).paletteOpen).toBe(true);
+  });
+
+  it('toggles the scenes left-list and right-rail collapse flags independently', () => {
+    toggleScenesList();
+    expect(get(uiPrefs).scenesListHidden).toBe(true);
+    expect(get(uiPrefs).scenesRailHidden).toBe(false);
+    toggleScenesRail();
+    expect(get(uiPrefs).scenesRailHidden).toBe(true);
+    toggleScenesList();
+    expect(get(uiPrefs).scenesListHidden).toBe(false);
+    expect(get(uiPrefs).scenesRailHidden).toBe(true);
+  });
+
+  it('setScenesListHidden / setScenesRailHidden set explicit collapse state', () => {
+    setScenesListHidden(true);
+    expect(get(uiPrefs).scenesListHidden).toBe(true);
+    setScenesRailHidden(true);
+    expect(get(uiPrefs).scenesRailHidden).toBe(true);
+    setScenesListHidden(false);
+    expect(get(uiPrefs).scenesListHidden).toBe(false);
+  });
+
+  it('scene-panel setters do NOT emit when the value is unchanged (no feedback loop)', () => {
+    // The page drives the panes off these flags and reconciles paneforge's
+    // onCollapse/onExpand back through these setters; a redundant emit would
+    // re-fire the driving effect. Guard: unchanged value ⇒ no subscriber call.
+    let emissions = 0;
+    const unsub = uiPrefs.subscribe(() => (emissions += 1));
+    emissions = 0; // ignore the initial synchronous emission
+    setScenesListHidden(false); // already false ⇒ must be a no-op
+    setScenesRailHidden(false); // already false ⇒ must be a no-op
+    expect(emissions).toBe(0);
+    setScenesListHidden(true); // real change ⇒ exactly one emission
+    expect(emissions).toBe(1);
+    unsub();
+  });
+
+  it('persists and rehydrates scene-panel collapse flags', () => {
+    localStorage.setItem(
+      'holomush-ui-prefs',
+      JSON.stringify({ scenesListHidden: true, scenesRailHidden: true }),
+    );
+    hydrateUiPrefs();
+    expect(get(uiPrefs).scenesListHidden).toBe(true);
+    expect(get(uiPrefs).scenesRailHidden).toBe(true);
   });
 
   it('open/close convenience helpers set explicit state', () => {

--- a/web/src/lib/stores/uiPrefsStore.ts
+++ b/web/src/lib/stores/uiPrefsStore.ts
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 
 export type Density = 'cozy' | 'compact';
 export interface UiPrefs {
   railHidden: boolean;
   sidebarHidden: boolean;
+  /** Scenes workspace: left scene-list pane collapsed (desktop). */
+  scenesListHidden: boolean;
+  /** Scenes workspace: right context-rail pane collapsed (desktop). */
+  scenesRailHidden: boolean;
   sidebarWidthPx: number;
   density: Density;
   composerOpen: boolean;
@@ -24,6 +28,8 @@ const DEFAULT_WIDTH = 280;
 const DEFAULTS: UiPrefs = {
   railHidden: false,
   sidebarHidden: false,
+  scenesListHidden: false,
+  scenesRailHidden: false,
   sidebarWidthPx: DEFAULT_WIDTH,
   density: 'cozy',
   composerOpen: false,
@@ -85,6 +91,22 @@ function mutate(fn: (prefs: UiPrefs) => UiPrefs) {
 
 export const toggleRail = () => mutate((p) => ({ ...p, railHidden: !p.railHidden }));
 export const toggleSidebar = () => mutate((p) => ({ ...p, sidebarHidden: !p.sidebarHidden }));
+export const toggleScenesList = () =>
+  mutate((p) => ({ ...p, scenesListHidden: !p.scenesListHidden }));
+export const toggleScenesRail = () =>
+  mutate((p) => ({ ...p, scenesRailHidden: !p.scenesRailHidden }));
+// Idempotent setters used to reconcile paneforge's onCollapse/onExpand back into
+// the store (drag-to-collapse persistence). They skip the update entirely when
+// the value is unchanged so they can't re-emit into the effect that drives the
+// panes — no collapse/expand feedback loop, no redundant localStorage writes.
+export const setScenesListHidden = (hidden: boolean) => {
+  if (get(uiPrefs).scenesListHidden === hidden) return;
+  mutate((p) => ({ ...p, scenesListHidden: hidden }));
+};
+export const setScenesRailHidden = (hidden: boolean) => {
+  if (get(uiPrefs).scenesRailHidden === hidden) return;
+  mutate((p) => ({ ...p, scenesRailHidden: hidden }));
+};
 export const toggleComposer = () => mutate((p) => ({ ...p, composerOpen: !p.composerOpen }));
 export const togglePalette = () => mutate((p) => ({ ...p, paletteOpen: !p.paletteOpen }));
 export const openPalette = () => mutate((p) => ({ ...p, paletteOpen: true }));

--- a/web/src/routes/(authed)/scenes/+page.svelte
+++ b/web/src/routes/(authed)/scenes/+page.svelte
@@ -23,6 +23,18 @@
   import SceneComposer from '$lib/components/scenes/SceneComposer.svelte';
   import SceneContextRail from '$lib/components/scenes/SceneContextRail.svelte';
   import CreateSceneSheet from '$lib/components/scenes/CreateSceneSheet.svelte';
+  import * as Resizable from '$lib/components/ui/resizable';
+  import { PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen } from '@lucide/svelte';
+  import {
+    uiPrefs,
+    toggleScenesList,
+    toggleScenesRail,
+    setScenesListHidden,
+    setScenesRailHidden,
+  } from '$lib/stores/uiPrefsStore';
+  import { isDesktop } from '$lib/hooks/mediaQuery.svelte';
+  import { cn } from '$lib/utils';
+  import type { PaneAPI } from 'paneforge';
 
   let { data }: { data: PageData } = $props();
 
@@ -54,6 +66,55 @@
   let sceneListSheetOpen = $state(false);
   let contextRailSheetOpen = $state(false);
   let createSheetOpen = $state(false);
+
+  // Desktop ⇄ mobile: the three-pane Resizable layout is desktop-only. Below the
+  // md breakpoint the mobile header + Sheets (shipped in q41kr) take over, so the
+  // panes never mount there.
+  const desktop = isDesktop();
+
+  // paneforge imperative handles for the collapsible left/right panes.
+  let leftPane = $state<PaneAPI>();
+  let rightPane = $state<PaneAPI>();
+
+  // Enable the slide transition only AFTER the first paint, so a pane that was
+  // left collapsed (persisted) appears collapsed instantly instead of animating
+  // shut on load. Only subsequent user toggles animate.
+  let panesAnimated = $state(false);
+  onMount(() => {
+    let inner = 0;
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => (panesAnimated = true));
+    });
+    return () => {
+      cancelAnimationFrame(outer);
+      cancelAnimationFrame(inner);
+    };
+  });
+
+  // Per-flag deriveds: reading `$uiPrefs.x` directly inside an $effect would
+  // re-run it on EVERY uiPrefs mutation (mutate() returns a fresh object each
+  // call), spamming collapse()/expand(). A $derived dedupes by value so each
+  // effect only re-runs when its own flag actually flips.
+  const scenesListHidden = $derived($uiPrefs.scenesListHidden);
+  const scenesRailHidden = $derived($uiPrefs.scenesRailHidden);
+
+  // Drive paneforge collapse from the persisted flags. This reuses the shell's
+  // collapse idiom (railHidden / sidebarHidden) so the slide and the localStorage
+  // persistence match the nav rail and room sidebar. onCollapse / onExpand write
+  // back idempotently so dragging a handle past the collapse threshold persists
+  // too, without ping-ponging against this effect.
+  $effect(() => {
+    const pane = leftPane;
+    if (!pane) return;
+    if (scenesListHidden) pane.collapse();
+    else pane.expand();
+  });
+  $effect(() => {
+    const pane = rightPane;
+    if (!pane) return;
+    if (scenesRailHidden) pane.collapse();
+    else pane.expand();
+  });
 
   // Roving tabindex state: index of the item that holds tabindex=0.
   let rovingIndex = $state(0);
@@ -285,15 +346,10 @@
 
   <CreateSceneSheet bind:open={createSheetOpen} {characters} />
 
-  <!-- Three-pane row: fills remaining height below the mobile header -->
-  <div class="flex flex-1 min-h-0 overflow-hidden">
-
-  <!-- Left pane: scene lists (desktop 260px; hidden on mobile) -->
-  <nav
-    bind:this={listContainerDesktop}
-    class="hidden md:flex w-[260px] shrink-0 flex-col border-r border-border bg-card overflow-y-auto"
-    aria-label="Scene list"
-  >
+  <!-- Scene-list body for the desktop left pane. The mobile Sheet (above) keeps a
+       separate copy with its own bind:this ref and SheetTitle/header wrapper, so
+       this snippet is desktop-only rather than shared between the two. -->
+  {#snippet sceneList()}
     <div class="flex items-center gap-1.5 p-2 border-b border-border/50">
       <button
         type="button"
@@ -363,88 +419,193 @@
         {/each}
       </div>
     {/if}
+  {/snippet}
 
-  </nav>
-
-  <!-- Center pane: log + composer -->
-  <main class="flex-1 min-w-0 flex flex-col overflow-hidden">
-    {#if selectedScene}
-      <!-- Scene title bar -->
-      <header class="flex items-center gap-3 px-4 py-2 border-b border-border bg-card/50 shrink-0">
-        <span class="font-semibold text-sm truncate">{selectedScene.title}</span>
-        <span class="text-[11px] text-muted-foreground shrink-0">● {selectedScene.state}</span>
-      </header>
-
-      <!-- Log: ARIA live region (spec §5.4 + Task 16 a11y requirement) -->
-      <div class="flex-1 min-h-0 overflow-hidden">
-        <ScrollArea
-          class="h-full"
-          bind:viewportRef={logViewport}
+  <!-- Center column (log + composer). Shared by the desktop center pane and the
+       mobile full-width layout, so it renders exactly once — the single bind:this
+       on the log viewport / region stays correct in both. -->
+  {#snippet centerPane()}
+    <main class="flex h-full w-full min-w-0 flex-col overflow-hidden">
+      <!-- Desktop pane toggles: collapse/expand the left list and right rail. -->
+      <div class="hidden md:flex items-center justify-between px-2 py-1 border-b border-border/50 shrink-0">
+        <button
+          type="button"
+          aria-label={scenesListHidden ? 'Show scene list' : 'Hide scene list'}
+          aria-expanded={!scenesListHidden}
+          title={scenesListHidden ? 'Show scene list' : 'Hide scene list'}
+          onclick={toggleScenesList}
+          class="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
         >
-          <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-          <!-- tabindex=-1 is intentional: allows programmatic focus on scene switch -->
-          <div
-            bind:this={logRegion}
-            role="log"
-            aria-live="polite"
-            aria-label="scene log"
-            aria-atomic="false"
-            tabindex={-1}
-            class="py-2 outline-none"
-          >
-            {#if logs.length === 0}
-              <p class="px-4 py-8 text-center text-sm text-muted-foreground italic">
-                No events yet. Start posing!
-              </p>
-            {:else}
-              {#each logs as entry (entry.id)}
-                <PoseCard {entry} />
-              {/each}
-            {/if}
-          </div>
-        </ScrollArea>
+          {#if scenesListHidden}
+            <PanelLeftOpen size={16} aria-hidden="true" />
+          {:else}
+            <PanelLeftClose size={16} aria-hidden="true" />
+          {/if}
+        </button>
+        <button
+          type="button"
+          aria-label={scenesRailHidden ? 'Show scene context' : 'Hide scene context'}
+          aria-expanded={!scenesRailHidden}
+          title={scenesRailHidden ? 'Show scene context' : 'Hide scene context'}
+          onclick={toggleScenesRail}
+          class="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        >
+          {#if scenesRailHidden}
+            <PanelRightOpen size={16} aria-hidden="true" />
+          {:else}
+            <PanelRightClose size={16} aria-hidden="true" />
+          {/if}
+        </button>
       </div>
 
-      <!-- Pose order strip -->
-      <PoseOrderStrip
-        scene={selectedScene}
-        actingCharacterId={selectedScene.asCharacterId}
-      />
+      {#if selectedScene}
+        <!-- Scene title bar -->
+        <header class="flex items-center gap-3 px-4 py-2 border-b border-border bg-card/50 shrink-0">
+          <span class="font-semibold text-sm truncate">{selectedScene.title}</span>
+          <span class="text-[11px] text-muted-foreground shrink-0">● {selectedScene.state}</span>
+        </header>
 
-      <!-- Composer -->
-      <SceneComposer
-        scene={selectedScene}
-        {playerSessionId}
-        {characters}
-      />
-    {:else}
-      <!-- Empty state -->
-      <div class="flex-1 flex items-center justify-center">
-        <div class="text-center space-y-3">
-          <p class="text-muted-foreground">Select a scene from the list to begin</p>
-          <button
-            type="button"
-            aria-label="New scene"
-            onclick={() => (createSheetOpen = true)}
-            class="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+        <!-- Log: ARIA live region (spec §5.4 + Task 16 a11y requirement) -->
+        <div class="flex-1 min-h-0 overflow-hidden">
+          <ScrollArea
+            class="h-full"
+            bind:viewportRef={logViewport}
           >
-            + New scene
-          </button>
-          <p>
-            <a href="/scenes/browse" class="text-sm text-primary hover:underline">
-              Browse open scenes →
-            </a>
-          </p>
+            <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+            <!-- tabindex=-1 is intentional: allows programmatic focus on scene switch -->
+            <div
+              bind:this={logRegion}
+              role="log"
+              aria-live="polite"
+              aria-label="scene log"
+              aria-atomic="false"
+              tabindex={-1}
+              class="py-2 outline-none"
+            >
+              {#if logs.length === 0}
+                <p class="px-4 py-8 text-center text-sm text-muted-foreground italic">
+                  No events yet. Start posing!
+                </p>
+              {:else}
+                {#each logs as entry (entry.id)}
+                  <PoseCard {entry} />
+                {/each}
+              {/if}
+            </div>
+          </ScrollArea>
         </div>
-      </div>
-    {/if}
-  </main>
 
-  <!-- Right pane: context rail (desktop 300px; hidden on mobile)
-       SceneContextRail renders its own <aside aria-label="Scene context"> -->
-  <div class="hidden md:block w-[300px] shrink-0">
-    <SceneContextRail scene={selectedScene} />
-  </div>
+        <!-- Pose order strip -->
+        <PoseOrderStrip
+          scene={selectedScene}
+          actingCharacterId={selectedScene.asCharacterId}
+        />
 
-  </div><!-- end three-pane row -->
+        <!-- Composer -->
+        <SceneComposer
+          scene={selectedScene}
+          {playerSessionId}
+          {characters}
+        />
+      {:else}
+        <!-- Empty state -->
+        <div class="flex-1 flex items-center justify-center">
+          <div class="text-center space-y-3">
+            <p class="text-muted-foreground">Select a scene from the list to begin</p>
+            <button
+              type="button"
+              aria-label="New scene"
+              onclick={() => (createSheetOpen = true)}
+              class="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+            >
+              + New scene
+            </button>
+            <p>
+              <a href="/scenes/browse" class="text-sm text-primary hover:underline">
+                Browse open scenes →
+              </a>
+            </p>
+          </div>
+        </div>
+      {/if}
+    </main>
+  {/snippet}
+
+  <!-- Desktop: resizable three-pane row whose left (scene list) and right (context
+       rail) panes collapse with a slide. Below md the mobile header + Sheets above
+       own the panel UX, so the panes never mount there. -->
+  {#if desktop.current}
+    <div class="flex-1 min-h-0">
+      <Resizable.PaneGroup
+        direction="horizontal"
+        autoSaveId="holomush-scenes-panes"
+        class={cn('scenes-panes', panesAnimated && 'panes-animated')}
+      >
+        <Resizable.Pane
+          id="scenes-list"
+          bind:this={leftPane}
+          collapsible
+          collapsedSize={0}
+          defaultSize={20}
+          minSize={12}
+          maxSize={32}
+          onCollapse={() => setScenesListHidden(true)}
+          onExpand={() => setScenesListHidden(false)}
+          class="overflow-hidden"
+        >
+          <nav
+            bind:this={listContainerDesktop}
+            class="flex h-full flex-col bg-card overflow-y-auto"
+            aria-label="Scene list"
+          >
+            {@render sceneList()}
+          </nav>
+        </Resizable.Pane>
+
+        <Resizable.Handle withHandle />
+
+        <Resizable.Pane id="scenes-center" defaultSize={56} class="overflow-hidden">
+          {@render centerPane()}
+        </Resizable.Pane>
+
+        <Resizable.Handle withHandle />
+
+        <!-- SceneContextRail renders its own <aside aria-label="Scene context"> -->
+        <Resizable.Pane
+          id="scenes-rail"
+          bind:this={rightPane}
+          collapsible
+          collapsedSize={0}
+          defaultSize={24}
+          minSize={14}
+          maxSize={40}
+          onCollapse={() => setScenesRailHidden(true)}
+          onExpand={() => setScenesRailHidden(false)}
+          class="overflow-hidden"
+        >
+          <SceneContextRail scene={selectedScene} />
+        </Resizable.Pane>
+      </Resizable.PaneGroup>
+    </div>
+  {:else}
+    <div class="flex-1 min-h-0 overflow-hidden">
+      {@render centerPane()}
+    </div>
+  {/if}
 </div>
+
+<style>
+  /* Slide the collapsible scene panes instead of popping: paneforge sets each
+     pane's flex-grow, and it cooperatively waits on the flex-grow transitionend,
+     so transitioning flex-grow animates collapse/expand. Gated on .panes-animated
+     (added after first paint) so a persisted-collapsed pane appears collapsed
+     instantly on load instead of sliding shut. Disabled while a handle is actively
+     dragged so resizing tracks the pointer 1:1. Selectors are :global because
+     paneforge owns the [data-pane] / [data-pane-resizer] DOM. */
+  :global(.scenes-panes.panes-animated [data-pane]) {
+    transition: flex-grow 180ms ease;
+  }
+  :global(.scenes-panes:has([data-pane-resizer][data-active]) [data-pane]) {
+    transition: none;
+  }
+</style>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -14,6 +14,8 @@
     hydrateUiPrefs,
     toggleRail,
     toggleSidebar,
+    toggleScenesList,
+    toggleScenesRail,
     toggleComposer,
     togglePalette,
   } from '$lib/stores/uiPrefsStore';
@@ -58,6 +60,20 @@
       e.preventDefault();
       e.stopPropagation();
       toggleSidebar();
+      return;
+    }
+    // Scenes left list (⌘⇧, → "<"). e.code is layout-/shift-char-independent.
+    if (mod && e.shiftKey && e.code === 'Comma') {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleScenesList();
+      return;
+    }
+    // Scenes right context rail (⌘⇧. → ">").
+    if (mod && e.shiftKey && e.code === 'Period') {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleScenesRail();
       return;
     }
     // Composer


### PR DESCRIPTION
## Summary

Resolves **holomush-5rh.29** — the scenes workspace's left scene-list and right context-rail panels now slide in/out instead of appearing/disappearing abruptly.

- Converts the scenes desktop three-pane layout to a shadcn **`Resizable`** (paneforge) `PaneGroup` with collapsible left + right panes. The slide is a CSS `flex-grow` transition — paneforge sets each pane's `flex-grow` and cooperatively waits on its `transitionend`, so this is the library's intended animation hook (disabled mid-drag via `[data-pane-resizer][data-active]`; gated on `.panes-animated` added after first paint so a persisted-collapsed pane renders collapsed instantly rather than sliding shut on load).
- Collapse state lives in `uiPrefs` (`scenesListHidden` / `scenesRailHidden`), mirroring the nav-rail / room-sidebar idiom, persists to localStorage; drag-to-collapse reconciles back through idempotent setters (no feedback loop). Drag-resized widths persist via paneforge `autoSaveId`.
- Toggles reachable three ways: pane toolbar buttons, `⌘⇧,` / `⌘⇧.` (global keymap), and `⌘K` command-palette entries — consistent with rail (`⌘B`) / sidebar (`⌘.`).
- New `isDesktop` matchMedia rune gates the `PaneGroup` to desktop; the mobile header + Sheets are untouched (out of scope, shipped in q41kr).

**Why not shadcn `Sidebar`:** no drag-resize (the room sidebar relies on it), and two-on-a-page collides on its single hardcoded `sidebar_state` cookie / global context / non-overridable `⌘B`. paneforge + Sheet are already installed and are this app's pattern.

## Test Plan

- [x] Web unit (vitest): 290 pass — `uiPrefs` collapse flags + no-loop setters, `isDesktop` matchMedia rune
- [x] `svelte-check`: 0 errors
- [x] Playwright E2E (`web/e2e/scenes-panels.spec.ts`): 3 pass — collapse/expand via paneforge `data-collapsed`/`data-expanded`, `flex-grow` transition wired, keyboard + palette toggles, persist-across-reload
- [x] `task pr-prep` (fast lane): pass
- [ ] CI: Integration Test + E2E Test gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)