### PR TITLE
docs(scenes): host-side name-resolution design, plan + ADR (holomush-vdy2z)

### DIFF
--- a/.claude/rules/plugin-runtime-symmetry.md
+++ b/.claude/rules/plugin-runtime-symmetry.md
@@ -30,3 +30,22 @@ Any host-side trust check, validation, or feature MUST apply to both binary and 
 ## Host RPC parity
 
 Every new `PluginHostService` RPC MUST ship both the Go SDK method and the Lua hostfunc together. Adding only one creates a privilege gradient: the runtime that has the method gets the capability, the other doesn't. Same root cause as the broader symmetry invariant.
+
+## Permitted asymmetry: same capability, different transport
+
+The invariant is about **trust, policy, and manifest-gate enforcement** — NOT about the wire transport a runtime uses to reach a capability. Two runtimes may reach the *same* ABAC-gated capability through *different* mechanisms without creating a privilege gradient, **provided the policy chokepoint is identical**. This is a permitted asymmetry, not a violation.
+
+**Canonical case — world reads (`WorldQuerier`).** The two runtimes reach world-model reads (`GetLocation` / `GetCharacter` / `GetCharactersByLocation` / `GetObject`) by different transports:
+
+| Runtime | Transport | Reaches |
+| --- | --- | --- |
+| **Lua** | `world.query` **host capability** (`hostfunc.WorldQuerierAdapter`) | `world.Service.*` → `checkAccess(subject, …)` |
+| **Binary** | `holomush.world.v1.WorldService` **service** (broker-dialed from manifest `requires:`) | `world.Service.*` → `checkAccess(subject, …)` |
+
+Both funnel through the **same** `world.Service` ABAC chokepoint with the same plugin-subject stamping. So `goplugin.Host.WorldQuerier()` returning **nil** (binary host exposes no world *host-capability* surface) is **intentional and correct** — binary plugins use the service transport. It is NOT a parity gap.
+
+> **Do NOT "fix" the nil binary `WorldQuerier` by building a binary world *host-capability* surface.** That re-opens deliberately-retired epic `holomush-q42fh` ("Binary World-Query Parity"), whose founding premise — "binary plugins cannot query the world" — is false. A reviewer/agent seeing the nil stub and concluding "binary has no world access" is the exact trap this section exists to prevent (June 2026: a scene-name-resolution design briefly filed a duplicate parity bead off this misread).
+
+**How to tell a permitted asymmetry from a violation:** ask *"does either runtime reach a different policy/trust outcome?"* If both hit the same gate (ABAC chokepoint, manifest capability check, emit fence) and differ only in transport or availability-shape, it is permitted. If one runtime gets a capability, trust level, or gate-bypass the other does not, it is a violation — fix it at the common path.
+
+The fuller catalogue of permitted Lua/binary asymmetries (e.g. manifest-validation gradients: `audit` / `provides` / `storage: postgres` / `resource_types` are Lua-rejected) is tracked by `holomush-dj95.10`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Resolve scene roster names host-side via facade, not plugin](holomush-sv1ei-resolve-scene-roster-names-host-side-via-facade-not-plugin.md) | 2026-06-20 | Accepted | `holomush-sv1ei` |
 | [Section registry is the single source of nav truth (Rail + palette)](holomush-stds8-section-registry-is-single-source-nav-truth-rail-palette.md) | 2026-06-20 | Accepted | `holomush-stds8` |
 | [Persistent authed chrome lives in a shared (authed)/+layout.svelte shell](holomush-828tt-persistent-authed-chrome-lives-shared-authed-layout-svelte-s.md) | 2026-06-20 | Accepted | `holomush-828tt` |
 | [Footer content uses a footerBridge store mirroring composerBridge](holomush-xhz3s-footer-content-uses-footerbridge-store-mirroring-composerbri.md) | 2026-06-20 | Accepted | `holomush-xhz3s` |

--- a/docs/adr/holomush-sv1ei-resolve-scene-roster-names-host-side-via-facade-not-plugin.md
+++ b/docs/adr/holomush-sv1ei-resolve-scene-roster-names-host-side-via-facade-not-plugin.md
@@ -1,0 +1,42 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-sv1ei; do not edit manually; use `/adr update holomush-sv1ei` -->
+
+# Resolve scene roster names host-side via facade, not plugin
+
+**Date:** 2026-06-21
+**Status:** Accepted
+**Decision:** holomush-sv1ei
+**Deciders:** Sean Brandt
+
+## Context
+
+Three web scene surfaces rendered character ULIDs instead of display names because the `core-scenes` plugin stubs `ParticipantInfo.CharacterName = id`. Two plugin-side resolution approaches were evaluated and rejected before settling on facade-side resolution mirroring the established `ListFocusPresence` pattern. The decision constrains where all future scene roster enrichment lives and why plugin-side resolution is structurally unsafe. Originating bug: holomush-5rh.25; design: holomush-vdy2z.
+
+## Decision
+
+Scene roster display names MUST be resolved host-side in the `GetSceneForViewer` facade (`internal/grpc`) via `characterNameResolver.Names()`, after the plugin's collection-level ABAC gate has already authorized the roster. Plugin-side resolution is structurally prohibited because both available transport paths are gated by constraints incompatible with cross-location scene membership.
+
+## Rationale
+
+- The `seed:player-character-colocation` guard on `WorldService.GetCharacter` silently degrades cross-location roster reads to ULIDs, reproducing the bug under a different name.
+- The binary plugin host intentionally exposes no `world.query` host capability (`WorldQuerier() -> nil`); Lua-only by design. Plugin-side resolution would require opening a new trust surface (retired epic holomush-q42fh).
+- The facade already holds an authorized roster post-`resolveAndGate`; name enrichment of an authorized set is downstream display, not a new ABAC decision — identical reasoning to `ListFocusPresence`.
+- Resolution in `internal/grpc` (not the web BFF) preserves the gateway-boundary invariant: the BFF proxies, the facade computes.
+- Best-effort semantics (ULID fallback on miss) prevent resolver failures from surfacing as RPC errors.
+
+## Alternatives Considered
+
+- **Host-side resolution in facade via characterNameResolver (chosen):** mirrors the proven ListFocusPresence pattern — one collection-level ABAC gate, then a `characterNameResolver.Names()` batch with no per-character ABAC; the resolver sees an already-authorized set so the co-location seed is irrelevant.
+- **Plugin resolves via world.query host capability (rejected):** the binary plugin host intentionally exposes no `world.query` surface (`WorldQuerier() -> nil`, Lua-only); would re-open deliberately-retired epic holomush-q42fh and violate plugin-runtime-symmetry.
+- **Plugin resolves via WorldService.GetCharacter (rejected):** gated by `seed:player-character-colocation`, which denies reads of non-co-located characters; scene participants routinely span locations, so roster reads would silently fall back to ULIDs — indistinguishable from the original bug.
+
+## Consequences
+
+- Positive: cross-location scene participants (the common case) get display names; the pattern is reusable for future roster-like surfaces; no new ABAC attributes or policies required.
+- Negative: `SceneAccessServer` gains a `characterNameResolver` dependency + a wiring change; the telnet roster remains unresolved (separate follow-up, out of scope).
+- Neutral: ULID fallback is preserved on resolver miss / deleted character (no regression); the pose author name (#3) is resolved differently — the dispatcher stamps `req.CharacterName` at command dispatch, no resolution needed.

--- a/docs/superpowers/plans/2026-06-20-scene-character-name-resolution.md
+++ b/docs/superpowers/plans/2026-06-20-scene-character-name-resolution.md
@@ -1,0 +1,481 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Scene Character Name Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render character display names (not raw ULIDs) on the three web scene surfaces — roster, pose-order strip, and pose author.
+
+**Architecture:** Host-side resolution. The scene **facade** (`GetSceneForViewer`, `internal/grpc`) resolves roster names via the existing in-process `characterNameResolver` after the scene gate has already authorized the roster — mirroring `ListFocusPresence`. The **pose author** rides the display name the host command dispatcher already puts on every `CommandRequest` (`CharacterName`), which `handleEmit` stamps into the IC payload; the gateway already reads it. No new host capability, no new ABAC, no client changes.
+
+**Tech Stack:** Go, ConnectRPC/gRPC, testify + mockery (unit), Ginkgo/Gomega + testcontainers (integration). Design spec: `docs/superpowers/specs/2026-06-20-scene-character-name-resolution-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `internal/grpc/sceneaccess_service.go` | Scene facade — add resolver field, `WithCharacterNameResolver` method, roster resolution in `GetSceneForViewer` | Modify |
+| `cmd/holomush/sub_grpc.go` | Production wiring — attach the resolver to the facade | Modify |
+| `internal/grpc/sceneaccess_service_test.go` | Facade unit tests (fake resolver) | Modify |
+| `plugins/core-scenes/commands.go` | `handleEmit` — add `character_name` to the IC payload | Modify |
+| `plugins/core-scenes/commands_emit_test.go` | Plugin emit unit test | Modify |
+| `internal/web/translate_test.go` | Gateway regression-lock: scene IC `character_name` → `GameEvent.actor` | Modify |
+| `test/integration/scenes/scene_name_resolution_test.go` | End-to-end: cross-location roster names + pose author | Create |
+
+---
+
+### Task 1: Inject `characterNameResolver` into the scene facade
+
+Pure plumbing — adds the dependency with no behavior change yet. Mirrors the existing post-construction `WithSceneDEKAdder` method (`sceneaccess_service.go`) and the `characterNameResolver` already wired into `CoreServer` (`sub_grpc.go:526`).
+
+**Files:**
+
+- Modify: `internal/grpc/sceneaccess_service.go` (struct `SceneAccessServer:47-63`; add method)
+- Modify: `cmd/holomush/sub_grpc.go:581-597` (construction site)
+- Test: `internal/grpc/sceneaccess_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/grpc/sceneaccess_service_test.go`:
+
+```go
+func TestWithCharacterNameResolverSetsTheField(t *testing.T) {
+	srv := &SceneAccessServer{}
+	r := &fakeNameResolver{}
+	srv.WithCharacterNameResolver(r)
+	assert.Same(t, r, srv.characterNameResolver)
+}
+```
+
+Also add the fake (used here and in Task 2), near the top of the test file:
+
+```go
+// fakeNameResolver is a hand-rolled double for the unexported
+// characterNameResolver interface (mockery does not generate mocks for
+// unexported interfaces).
+type fakeNameResolver struct {
+	names map[ulid.ULID]string
+	err   error
+}
+
+func (f *fakeNameResolver) Names(_ context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make(map[ulid.ULID]string, len(ids))
+	for _, id := range ids {
+		if n, ok := f.names[id]; ok {
+			out[id] = n
+		}
+	}
+	return out, nil
+}
+```
+
+Ensure the test file imports `"github.com/oklog/ulid/v2"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestWithCharacterNameResolverSetsTheField ./internal/grpc/`
+Expected: FAIL — `srv.characterNameResolver` undefined and `WithCharacterNameResolver` undefined (compile error).
+
+- [ ] **Step 3: Add the field and method**
+
+In `internal/grpc/sceneaccess_service.go`, add a field to the `SceneAccessServer` struct (after `dekAdder`):
+
+```go
+	// characterNameResolver resolves participant/observer display names by ID
+	// for GetSceneForViewer roster enrichment. Optional: nil leaves rosters
+	// with raw ULIDs (best-effort). Mirrors CoreServer's resolver (5b2j).
+	characterNameResolver characterNameResolver
+```
+
+Add the method next to `WithSceneDEKAdder`:
+
+```go
+// WithCharacterNameResolver attaches the roster name resolver. Call after
+// construction; when set, GetSceneForViewer overwrites ParticipantInfo
+// CharacterName with the resolved display name (ULID fallback on a miss).
+func (s *SceneAccessServer) WithCharacterNameResolver(r characterNameResolver) {
+	s.characterNameResolver = r
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestWithCharacterNameResolverSetsTheField ./internal/grpc/`
+Expected: PASS
+
+- [ ] **Step 5: Wire it in production**
+
+In `cmd/holomush/sub_grpc.go`, add the call **unconditionally**, after the `if s.cfg.RekeyManager != nil { saSrv.WithSceneDEKAdder(...) }` block (lines 594-596) and **before** `sceneAccessSrv = saSrv` (line 597). It MUST NOT go inside the `RekeyManager` guard — name resolution is independent of crypto and must run in KEK-less deployments:
+
+```go
+		if s.cfg.RekeyManager != nil {
+			saSrv.WithSceneDEKAdder(s.cfg.RekeyManager)
+		}
+		saSrv.WithCharacterNameResolver(holoGRPC.NewRepoCharacterNameResolver(charRepo))
+		sceneAccessSrv = saSrv
+```
+
+`charRepo` (the `world.CharacterRepository` from `worldpostgres.NewCharacterRepository(pool)`, `sub_grpc.go:312`) is already in scope — it is the same repo passed to the CoreServer resolver at line 526.
+
+- [ ] **Step 6: Build + commit**
+
+Run: `task build`
+Expected: success.
+Commit using VCS-appropriate commands per `references/vcs-preamble.md` (message: `feat(scenes): inject character name resolver into scene facade (holomush-5rh.25)`).
+
+---
+
+### Task 2: Resolve roster names in `GetSceneForViewer`
+
+After the plugin returns the (already gated) roster, overwrite each `CharacterName` with the resolved display name, keeping the ULID on a miss. Resolves participants **and** observers (INV-SCENE-61).
+
+**Files:**
+
+- Modify: `internal/grpc/sceneaccess_service.go:180-203` (`GetSceneForViewer`; add a `resolveRosterNames` helper)
+- Test: `internal/grpc/sceneaccess_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/grpc/sceneaccess_service_test.go`. This mirrors the mock setup in `TestSceneAccessOverridesClientSuppliedCharacterWithOwnedAlt` (same file, ~line 162) for the gate (`buildSATestPS`, `buildSASessionRepo`, `playerRepo.GetByID`, `charRepo.ListByPlayer`); it adds a `GetScene` expectation returning a ULID-stubbed roster and asserts resolution.
+
+```go
+func TestGetSceneForViewerResolvesRosterNames(t *testing.T) {
+	ctx := context.Background()
+
+	playerID := idgen.New()
+	viewer := &world.Character{ID: idgen.New(), PlayerID: playerID, Name: "Viewer"}
+	ps := buildSATestPS(t, playerID)
+
+	playerRepo := authmocks.NewMockPlayerRepository(t)
+	playerRepo.EXPECT().GetByID(mock.Anything, playerID).
+		Return(&auth.Player{ID: playerID, IsGuest: false}, nil).Maybe()
+	psRepo := buildSASessionRepo(t, ps)
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return([]*world.Character{viewer}, nil).Maybe()
+	sessStore := sessionmocks.NewMockStore(t)
+	mgr := &stubPluginManager{}
+
+	ownerID := idgen.New()   // resolves
+	memberID := idgen.New()  // resolves
+	missingID := idgen.New() // NOT in the resolver map → ULID fallback
+	observerID := idgen.New()
+
+	sceneMock := scenemocks.NewMockSceneServiceClient(t)
+	sceneMock.EXPECT().GetScene(mock.Anything, mock.Anything).Return(&scenev1.GetSceneResponse{
+		Scene: &scenev1.SceneInfo{
+			Id: "sc-1",
+			Participants: []*scenev1.ParticipantInfo{
+				{CharacterId: ownerID.String(), CharacterName: ownerID.String(), Role: "owner"},
+				{CharacterId: missingID.String(), CharacterName: missingID.String(), Role: "member"},
+			},
+			Observers: []*scenev1.ParticipantInfo{
+				{CharacterId: observerID.String(), CharacterName: observerID.String(), Role: "observer"},
+			},
+		},
+	}, nil).Maybe()
+
+	srv := newTestSceneAccessServer(t, psRepo, playerRepo, charRepo, sessStore, &stubFocusCoordinator{}, sceneMock, mgr)
+	srv.WithCharacterNameResolver(&fakeNameResolver{names: map[ulid.ULID]string{
+		ownerID:    "Owner One",
+		memberID:   "Member One",
+		observerID: "Observer One",
+		// missingID intentionally absent
+	}})
+
+	resp, err := srv.GetSceneForViewer(ctx, &sceneaccessv1.GetSceneForViewerRequest{
+		SessionId:          "ignored",
+		PlayerSessionToken: testSAToken,
+		CharacterId:        viewer.ID.String(),
+		SceneId:            "sc-1",
+	})
+	require.NoError(t, err)
+
+	parts := resp.GetScene().GetParticipants()
+	require.Len(t, parts, 2)
+	assert.Equal(t, "Owner One", parts[0].GetCharacterName())
+	assert.Equal(t, missingID.String(), parts[1].GetCharacterName(), "unresolved id keeps the ULID")
+	obs := resp.GetScene().GetObservers()
+	require.Len(t, obs, 1)
+	assert.Equal(t, "Observer One", obs[0].GetCharacterName())
+}
+```
+
+> If `GetSceneForViewer`'s `beginDispatch` requires additional mock expectations to reach the `GetScene` call, copy them from the nearest existing happy-path facade test in this file (the gate scaffolding is shared). The assertions above are the behavior under test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestGetSceneForViewerResolvesRosterNames ./internal/grpc/`
+Expected: FAIL — names are still the ULIDs (`parts[0].GetCharacterName()` == ownerID string, not `"Owner One"`).
+
+- [ ] **Step 3: Implement resolution**
+
+In `internal/grpc/sceneaccess_service.go`, change the tail of `GetSceneForViewer` (currently `return &sceneaccessv1.GetSceneForViewerResponse{Scene: resp.GetScene()}, nil`) to resolve first:
+
+```go
+	scene := resp.GetScene()
+	s.resolveRosterNames(ctx, scene)
+	return &sceneaccessv1.GetSceneForViewerResponse{Scene: scene}, nil
+```
+
+Add the helper (same file). It is best-effort: a nil resolver or a resolver error leaves the ULIDs in place and never fails the RPC (mirrors `ListFocusPresence` graceful degradation, but keeps the ULID rather than skipping).
+
+```go
+// resolveRosterNames overwrites participant + observer CharacterName fields with
+// resolved display names, in place. Best-effort: nil resolver, parse failure, a
+// resolver error, or a missing id all leave the raw ULID. The scene gate already
+// authorized this roster (plugin GetScene privacy gate), so name resolution is
+// downstream display — no per-character ABAC (mirrors ListFocusPresence).
+func (s *SceneAccessServer) resolveRosterNames(ctx context.Context, scene *scenev1.SceneInfo) {
+	if s.characterNameResolver == nil || scene == nil {
+		return
+	}
+	roster := append(append([]*scenev1.ParticipantInfo{}, scene.GetParticipants()...), scene.GetObservers()...)
+	if len(roster) == 0 {
+		return
+	}
+	ids := make([]ulid.ULID, 0, len(roster))
+	for _, p := range roster {
+		id, err := ulid.Parse(p.GetCharacterId())
+		if err != nil {
+			continue // leave unparseable ids as-is
+		}
+		ids = append(ids, id)
+	}
+	names, err := s.characterNameResolver.Names(ctx, ids)
+	if err != nil {
+		// Log via slog.ErrorContext, as ListFocusPresence does at
+		// list_focus_presence.go:161-162. DELIBERATE DIVERGENCE: presence
+		// HARD-FAILS on a resolver error (returns INTERNAL, line 164); the
+		// scene roster instead DEGRADES — keep the ULIDs and return the scene,
+		// never failing GetSceneForViewer on a name miss (spec G3, best-effort).
+		slog.ErrorContext(ctx, "scene roster name resolution failed", "error", err, "scene_id", scene.GetId())
+		return // keep ULIDs
+	}
+	for _, p := range roster {
+		id, err := ulid.Parse(p.GetCharacterId())
+		if err != nil {
+			continue
+		}
+		if n, ok := names[id]; ok && n != "" {
+			p.CharacterName = n
+		}
+	}
+}
+```
+
+Confirm imports in `sceneaccess_service.go` include `"github.com/oklog/ulid/v2"` and `"log/slog"` (already used in the file, e.g. `slog.ErrorContext` at the `WatchScene`/`GetSceneForViewer` error paths); add `ulid` if missing.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestGetSceneForViewerResolvesRosterNames ./internal/grpc/`
+Expected: PASS
+
+- [ ] **Step 5: Run the package + commit**
+
+Run: `task test -- ./internal/grpc/`
+Expected: PASS (no regressions).
+Commit (message: `feat(scenes): resolve roster display names in GetSceneForViewer (holomush-5rh.25)`).
+
+---
+
+### Task 3: Stamp the pose author name at emit (`handleEmit`)
+
+`handleEmit` already holds the author's display name as `req.CharacterName` (the dispatcher sets it at `internal/command/dispatcher.go:310`). Add it to the IC payload; the gateway's `translateEvent` already reads `character_name` (`internal/web/translate.go:82`).
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go:1310-1314` (`handleEmit` payload marshal)
+- Test: `plugins/core-scenes/commands_emit_test.go`
+- Test: `internal/web/translate_test.go`
+
+- [ ] **Step 1: Write the failing plugin test**
+
+Add to `plugins/core-scenes/commands_emit_test.go` (mirrors `TestSceneSubcommand_Pose_EmitsSceneEventOnICFacet`):
+
+```go
+func TestSceneSubcommand_Pose_IncludesAuthorCharacterName(t *testing.T) {
+	t.Parallel()
+	p, sink := newTestPluginWithMember(t, "scene-author-test")
+
+	resp, err := p.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:       "scene",
+		Args:          "pose smiles",
+		CharacterID:   "char-alice",
+		CharacterName: "Alice",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+
+	found := findIntentByType(sink.intents, "core-scenes:scene_pose")
+	require.NotNil(t, found)
+	assert.Contains(t, found.Payload, `"character_name":"Alice"`)
+}
+
+func TestSceneSubcommand_Pose_OmitsCharacterNameWhenEmpty(t *testing.T) {
+	t.Parallel()
+	p, sink := newTestPluginWithMember(t, "scene-noauthor-test")
+
+	resp, err := p.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "pose smiles",
+		CharacterID: "char-alice",
+		// CharacterName intentionally empty
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+
+	found := findIntentByType(sink.intents, "core-scenes:scene_pose")
+	require.NotNil(t, found)
+	assert.NotContains(t, found.Payload, "character_name")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run 'TestSceneSubcommand_Pose_IncludesAuthorCharacterName' ./plugins/core-scenes/`
+Expected: FAIL — payload has no `character_name`.
+
+- [ ] **Step 3: Implement the payload change**
+
+In `plugins/core-scenes/commands.go`, replace the `payload, err := json.Marshal(map[string]string{...})` block at `handleEmit` (lines 1310-1314) with a conditional build:
+
+```go
+	payloadMap := map[string]string{
+		"actor_id": req.CharacterID,
+		"scene_id": sceneID,
+		"text":     text,
+	}
+	// Stamp the author display name when the dispatcher provided one
+	// (internal/command/dispatcher.go:310). Empty → omit; the gateway falls
+	// back to actor_id exactly as before. Rides the encrypted IC payload
+	// (crypto.emits) — no more sensitive than the pose text it labels.
+	if req.CharacterName != "" {
+		payloadMap["character_name"] = req.CharacterName
+	}
+	payload, err := json.Marshal(payloadMap)
+```
+
+`handleEmit` is the **shared** content-emit handler for all four IC verbs (`scene_pose` / `scene_say` / `scene_ooc` / `scene_emit`), so this single change carries `character_name` for OOC too (spec §8 R3) — `PoseCard` renders the OOC author from `actorName` at `PoseCard.svelte:64`.
+
+- [ ] **Step 4: Run plugin tests to verify they pass**
+
+Run: `task test -- -run 'TestSceneSubcommand_Pose' ./plugins/core-scenes/`
+Expected: PASS (both new tests + the existing pose tests).
+
+- [ ] **Step 5: Add the gateway regression-lock test**
+
+`translateEvent` already extracts `actor` from `character_name`; this test pins the scene-IC end of the contract. Add to `internal/web/translate_test.go`. **Note:** `core-scenes:scene_pose` is NOT in the file's `testRenderings` map (line ~42), so `withRendering(ev)` would yield a nil `Rendering` and `translateEvent` drops nil-Rendering frames (INV-EVENTBUS-6) — the test must **inline** `Rendering` directly (the pattern at `translate_test.go:~387`) and use `newTestHandler(t)` (the file idiom):
+
+```go
+func TestTranslateEvent_ScenePoseUsesCharacterNameAsActor(t *testing.T) {
+	h := newTestHandler(t)
+	ev := &corev1.EventFrame{
+		Type:    "core-scenes:scene_pose",
+		ActorId: "01HYXCHARALICE0000000000AA",
+		Payload: mustMarshal(t, map[string]string{"character_name": "Alice", "text": "smiles"}),
+		// Inline (not withRendering): scene_pose is absent from testRenderings.
+		// Any non-"state" category takes the generic-payload path that reads
+		// character_name.
+		Rendering: &corev1.RenderingMetadata{
+			Category:      "communication",
+			Format:        "action",
+			DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			SourcePlugin:  "core-scenes",
+		},
+	}
+	got := h.translateEvent(ev)
+	require.NotNil(t, got)
+	assert.Equal(t, "Alice", got.GetActor())
+}
+```
+
+- [ ] **Step 6: Run the gateway test + commit**
+
+Run: `task test -- -run TestTranslateEvent_ScenePoseUsesCharacterNameAsActor ./internal/web/`
+Expected: PASS.
+Commit (message: `feat(scenes): stamp pose author display name into IC payload (holomush-5rh.25)`).
+
+> **Review gate:** this change touches the `crypto.emits` IC payload shape — the `crypto-reviewer` agent MUST run before push (per root `CLAUDE.md`). Note it on the bead.
+
+---
+
+### Task 4: Integration test — cross-location roster + pose author
+
+Proves the fix end-to-end through the real stack: two participants in **different locations** still get resolved roster names (the co-location-independence that distinguishes this fix from the rejected ABAC-gated approach), and a posted pose surfaces the author's name.
+
+**Files:**
+
+- Create: `test/integration/scenes/scene_name_resolution_test.go`
+
+- [ ] **Step 1: Write the Ginkgo spec**
+
+Follow the harness usage in the sibling specs `test/integration/scenes/real_scene_join_subscription_test.go` and `test/integration/scenes/scene_command_join_delivery_test.go` for the exact helper API (scene create / member add / location placement / facade `GetSceneForViewer` / posting a `scene pose`). Skeleton:
+
+```go
+//go:build integration
+
+package scenes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+var _ = Describe("Scene character name resolution", func() {
+	It("resolves roster display names for participants in different locations", func() {
+		ts := integrationtest.Start(suiteT, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		defer ts.Close()
+
+		// GIVEN a scene whose two members are in DIFFERENT locations
+		//   (use the harness helpers to create characters at distinct locations,
+		//    create a scene, and add both as members — per the sibling specs).
+		// WHEN the viewer fetches the scene via the facade GetSceneForViewer
+		// THEN every roster ParticipantInfo.CharacterName is a display name,
+		//      NOT a 26-char ULID.
+		// Assertion shape:
+		//   for _, p := range scene.GetParticipants() {
+		//       Expect(p.GetCharacterName()).NotTo(MatchRegexp(`^[0-9A-HJKMNP-TV-Z]{26}$`),
+		//           "roster name must be a display name, not a ULID")
+		//   }
+	})
+
+	It("surfaces the pose author display name on the IC stream", func() {
+		// GIVEN a member posing in a scene
+		// WHEN the IC event is delivered/translated
+		// THEN the rendered author is the display name, not the actor ULID.
+	})
+})
+```
+
+Fill the GIVEN/WHEN bodies using the sibling harness helpers; the assertions (display-name-not-ULID) are the behavior under test. The ULID regex `^[0-9A-HJKMNP-TV-Z]{26}$` is the Crockford-base32 ULID shape — asserting a name does NOT match it is the precise "not a ULID" check.
+
+- [ ] **Step 2: Run the integration suite**
+
+Run: `task test:int -- ./test/integration/scenes/...`
+Expected: PASS (Docker required; `task plugin:build-all` runs automatically).
+
+- [ ] **Step 3: Commit + close the bug**
+
+Commit (message: `test(scenes): integration coverage for cross-location name resolution (holomush-5rh.25)`).
+This task closing-criteria: `holomush-5rh.25` is resolved at merge (do NOT `bd close` before the PR lands, per the close-at-merge convention).
+
+---
+
+## Verification (whole-feature)
+
+- `task pr-prep` green (fast lane: lint, fmt, unit, build).
+- `task test:int -- ./test/integration/scenes/...` green (Docker).
+- `crypto-reviewer` run for Task 3 (IC payload change).
+- Manual web check (optional): roster, pose-order strip, and a fresh pose all show display names.
+<!-- adr-capture: sha256=32fa279b73167ad7; session=cli; ts=2026-06-21T00:38:56Z; adrs=holomush-sv1ei -->

--- a/docs/superpowers/specs/2026-06-20-scene-character-name-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-20-scene-character-name-resolution-design.md
@@ -1,0 +1,138 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Scene Character Name Resolution — Design
+
+- **Status:** Draft (host-side design; supersedes two ruled-out approaches — see §10)
+- **Date:** 2026-06-20
+- **Design bead:** holomush-vdy2z
+- **Originating bug:** holomush-5rh.25 (three web scene surfaces render character ULIDs instead of display names)
+- **Theme:** `theme:social-spaces`
+
+RFC2119 keywords (MUST, MUST NOT, SHOULD, SHOULD NOT, MAY) are used per the root `CLAUDE.md` table.
+
+## 1. Problem & Root Cause
+
+Three **web** scene surfaces render a character's raw ULID where a display name belongs:
+
+1. **Roster** — `web/src/lib/components/scenes/SceneContextRail.svelte:89` (`{p.name}`)
+2. **Pose-order strip** — `web/src/lib/components/scenes/PoseOrderStrip.svelte` (`scene.participants[].name`)
+3. **Pose author** — `web/src/lib/components/scenes/PoseCard.svelte:37` (`entry.actorName || entry.actorId`)
+
+The client renders `.name` / `.actorName` correctly; the defect is upstream, in two distinct mechanisms:
+
+- **#1 + #2 share a source.** Both read `getScene` → `scene.participants[].characterName` (web `PoseOrderStrip` is a placeholder reusing roster data, not the dedicated `GetPoseOrder` RPC). The `core-scenes` plugin's `GetScene` deliberately stubs `ParticipantInfo.CharacterName = id` (`plugins/core-scenes/service.go:484-500`, *"no name resolver is wired in the plugin, fall back to the ID"*). `holomush-5rh.8.25` populated the roster but never resolved names. The client maps this at `web/src/lib/scenes/workspaceStore.svelte.ts:189` (`name = p.characterName`). The reporter's "name on one load, ULID on another" is the race between the placeholder (`asCharacterName` = real name, shown pre-enrichment) and the enriched roster (ULID-as-name, shown after).
+- **#3 is a distinct path.** Scene IC `scene_pose`/`scene_say` events carry only `{actor_id, scene_id, text}` (`plugins/core-scenes/commands.go:1310-1314`). The gateway's `translateEvent` fills `GameEvent.actor` from the payload's `character_name`/`sender_name` (`internal/web/translate.go:81-85`); absent → empty → client falls back to `actorId` (ULID). The proto contract says `GameEvent.actor` is the **display name** (`api/proto/holomush/web/v1/web.proto:372`).
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- **G1** — Scene rosters (`GetScene` participants + observers) MUST surface display names instead of ULIDs on the web (`SceneContextRail`, `PoseOrderStrip`).
+- **G2** — The scene IC log MUST surface the pose author's display name (`PoseCard`).
+- **G3** — Resolution is **best-effort**: if a name is unavailable, fall back to the ULID; never fail a read or drop an event.
+
+### Non-Goals
+
+- **NG1** — No client-side changes. Components + `workspaceStore.svelte.ts:189` already render `.name`/`.actor` correctly.
+- **NG2** — **Telnet roster / pose-order are out of scope** (the bug declares so). They render from the plugin directly, not the facade; fixing them would require a plugin-side path gated by a new ABAC scene-membership policy (see §10) — a separate follow-up if ever wanted.
+- **NG3** — No new ABAC attributes or policies; no change to scene visibility/privacy gates.
+- **NG4** — No caching layer. Names resolve fresh per call (rosters are small; renames apply immediately).
+- **NG5** — No change to the dedicated `GetPoseOrder` RPC's web wiring (still a follow-up bead); this design only ensures the facade-surfaced roster carries names.
+
+## 3. Architecture
+
+Resolution happens **host-side**, mirroring the established `ListFocusPresence` pattern — authorize the collection once, then resolve names for the authorized set via a non-ABAC resolver. Two independent, minimal changes:
+
+```text
+#1 + #2 (roster / pose-order):
+  WebGetScene (BFF, no logic) ─► GetSceneForViewer (facade, internal/grpc)
+      ├─ plugin GetScene → roster IDs (scene privacy gate already applied)
+      └─ characterNameResolver.Names(ids) ──► world.CharacterRepository.GetNamesByIDs
+         (overwrite ParticipantInfo.CharacterName; ULID fallback)
+
+#3 (pose author):
+  scene pose → host dispatcher (CommandRequest.CharacterName = exec.CharacterName())
+      └─ plugin handleEmit → add "character_name": req.CharacterName to IC payload
+         → gateway translateEvent already reads it → GameEvent.actor
+```
+
+### 3.1 #1 + #2 — resolve the roster in the facade
+
+`GetSceneForViewer` (`internal/grpc/sceneaccess_service.go:180`) already authorizes the caller: `resolveAndGate` + `ownedCharacter`, and the plugin's `GetScene` privacy gate (`plugins/core-scenes/service.go:439-468`) returns `NotFound` to non-members of non-open scenes (open-scene rosters are public board metadata). So by the time the facade holds the roster, the caller is authorized to see it. The facade then resolves names for that authorized set — **not** per-character, ABAC-co-location-gated reads.
+
+This mirrors `ListFocusPresence` (`internal/grpc/list_focus_presence.go`): one collection-level ABAC gate (lines 116-137), then `characterNameResolver.Names(uniqueIDs)` for the whole set (line 159) — a direct `GetNamesByIDs` repo batch with **no per-character ABAC**. One deliberate divergence on the miss path: presence *skips* unresolved entries (lines 166-180), but the roster **keeps the ULID** (the slot still exists and the ID uniquely identifies it). T2's unit test MUST assert the ULID-fallback behavior, not a presence-style skip.
+
+- **Resolver:** `characterNameResolver` (`internal/grpc/character_name_resolver.go`, `Names(ctx, ids []ulid.ULID) → map[ulid.ULID]string`, backed by `world.CharacterRepository.GetNamesByIDs`) already exists and is wired into `CoreServer`. `SceneAccessServer` is in the **same package** — inject it as a new field (`WithCharacterNameResolver` option; wire at `cmd/holomush/sub_grpc.go`).
+- **Apply:** after `GetScene`, collect participant + observer `CharacterId`s, one `Names()` batch call, overwrite `ParticipantInfo.CharacterName` from the map. Resolve observers too (INV-SCENE-61: listed separately). Best-effort — keep the ULID on a miss.
+- **No new ABAC** (NG3): name resolution of an already-authorized roster is downstream display, identical to presence. The co-location seed (`seed:player-character-colocation`) governs world *perception*, not scene-roster display, and is correctly bypassed here.
+- **Boundary:** resolution lives in the facade (`internal/grpc`, core), NOT the web BFF — the gateway-boundary invariant holds (the BFF proxies; the facade computes).
+
+### 3.2 #3 — stamp the host-provided author name at emit
+
+The host dispatcher already populates the pose author's display name: `dispatchToPlugin` builds `pluginsdk.CommandRequest{… CharacterName: exec.CharacterName() …}` (`internal/command/dispatcher.go:310`; field at `pkg/plugin/command.go:29-30`). So `handleEmit` already holds `req.CharacterName` — the posting character's name — with **zero** resolution work.
+
+- **Change:** in `handleEmit` (`plugins/core-scenes/commands.go:1310-1314`), add `"character_name": req.CharacterName` to the IC payload map when non-empty. `Sensitive: true` unchanged.
+- **Gateway:** no change — `translateEvent` already extracts `actor` from `character_name` (`internal/web/translate.go:82`). A test asserts a scene IC event with `character_name` yields a non-empty `GameEvent.actor`.
+- **Graceful fallback:** if `req.CharacterName` is ever empty, omit the field; the gateway falls back to `actorId` exactly as today — no regression.
+
+### 3.3 Crypto (#3 only)
+
+`scene_pose`/`scene_say` are `crypto.emits` (encrypted IC payloads, per-event DEK, AAD-bound to event ID + subject — `plugins/core-scenes/plugin.yaml:144-150`). `character_name` rides **inside** the encrypted payload: decrypted server-side for authorized participants on the same path that already yields the pose text, so `translateEvent` sees it in cleartext.
+
+- The display name is **no more sensitive** than the pose text it labels; bundling it in the same envelope is consistent. **AAD binding is unchanged** (event ID + subject — only a plaintext field is added before encryption).
+- This touches the `crypto.emits` payload shape, so it **MUST** pass the `crypto-reviewer` gate before push (per root `CLAUDE.md`). The change is minimal (a field the plugin already has, no resolution).
+
+## 4. Data Flow (after)
+
+1. **Roster / pose-order (#1+#2):** `WebGetScene` → `GetSceneForViewer` (plugin `GetScene` → roster IDs; facade `characterNameResolver.Names` → names; overwrite `CharacterName`) → `workspaceStore.svelte.ts:189` `name = p.characterName` → components render the name.
+2. **Pose author (#3):** `scene pose` → dispatcher stamps `CharacterName` → `handleEmit` adds `character_name` to the IC payload → encrypt/publish → participant decrypt → `translateEvent` sets `GameEvent.actor` → client `eventFrameToLogEntry` `actorName = ev.actor` → `PoseCard` renders the name.
+
+## 5. Error Handling
+
+- Resolver failure (#1/#2) → log with `errutil.LogErrorContext`, keep ULIDs, return the scene (never fail `GetSceneForViewer` on a name-resolution miss).
+- Empty `req.CharacterName` (#3) → omit `character_name`; gateway falls back to `actorId` (no regression).
+- Unknown/deleted ID → absent from the resolver map → ULID fallback (graceful).
+
+## 6. Testing
+
+| Tier | Coverage |
+|------|----------|
+| Unit (facade) | `GetSceneForViewer` overwrites participant + observer `CharacterName` from a mocked `characterNameResolver`; ULID retained on a resolver miss/error; resolver error does not fail the RPC. |
+| Unit (plugin) | `handleEmit` includes `character_name` from `req.CharacterName` in the IC payload; omits it when `req.CharacterName` is empty. |
+| Unit (gateway) | `translateEvent` fills `GameEvent.Actor` from `character_name` for a scene IC event. |
+| Integration (`task test:int`, `integrationtest.WithInTreePlugins`) | End-to-end: a scene with ≥2 participants in **different locations** returns resolved roster names (not ULIDs) — pins the co-location-independence (the bug's core failure mode); a posted pose surfaces the author's display name on the IC stream. |
+| Review gate | `crypto-reviewer` MUST run for the `handleEmit` / `crypto.emits` payload change before `code-reviewer`. |
+
+`>80%` per-package coverage maintained; tests precede implementation (TDD); names follow ACE.
+
+## 7. Invariants
+
+- **Respect** INV-SCENE-61 (observers listed separately) — resolve both rosters; never merge.
+- **Respect** the gateway-boundary invariant — resolution is in the facade (core), not the web BFF.
+- **No new invariant proposed.** "Scene rosters resolve display names" is a feature requirement, not a durable system-behavior guarantee (per `.claude/rules/invariants.md`). The integration test pins the co-location-independence behaviorally; defer any registry entry to the design-reviewer.
+
+## 8. Risks & Open Questions
+
+- **R1 (crypto):** the only crypto-touching change is `character_name` in the encrypted IC payload (§3.3). Mitigated by unchanged AAD + the `crypto-reviewer` gate. If the reviewer prefers the name out of ciphertext, the alternative is cleartext rendering metadata + a `translateEvent` actor-source change — heavier; default is the in-payload field.
+- **R2 (`req.CharacterName` population):** assumes the web `scene pose` path produces an `exec` with `CharacterName` set. The dispatcher always assigns it (`dispatcher.go:310`); residual risk is only that `exec.CharacterName()` is empty in some session state — handled by the graceful fallback (no regression). The integration test confirms the live web path.
+- **R3 (scene_ooc):** `scene_ooc` is also `crypto.emits` on the same `translateEvent` path. If the OOC author also shows a ULID, `handleEmit` for OOC needs the same `character_name` treatment — fold into T2 (it shares the code path) or note explicit exclusion.
+
+## 9. Task Breakdown (for plan-to-beads)
+
+- **T1** — Inject `characterNameResolver` into `SceneAccessServer` (`WithCharacterNameResolver` option; wire at `cmd/holomush/sub_grpc.go`). No behavior change yet. Tests.
+- **T2** — `GetSceneForViewer` resolves participant + observer names (best-effort, ULID fallback), incl. `scene_ooc` author parity check (R3). Tests with a mocked resolver.
+- **T3** — `handleEmit` adds `character_name` from `req.CharacterName` to the IC payload (#3); gateway `translateEvent` test. `crypto-reviewer` pass.
+- **T4** — Integration test (`WithInTreePlugins`): two participants in **different locations** → resolved roster names; a posted pose → resolved author. Close holomush-5rh.25.
+
+## 10. Appendix — Design History (ruled-out approaches)
+
+Two earlier approaches were ruled out by adversarial design review (full grounding in the `holomush-vdy2z` / `holomush-5rh.25` bd notes):
+
+1. **Plugin resolves via the `world.query` host capability.** Rejected: the binary plugin host exposes no `world.query` surface (`goplugin/host.go` `WorldQuerier() → nil` — intentional, Lua-only). Briefly mis-filed as a parity gap (`holomush-udfqi`, now **closed**); it re-opened deliberately-retired epic `holomush-q42fh`. See the new "Permitted asymmetry" section in `.claude/rules/plugin-runtime-symmetry.md`.
+2. **Plugin resolves via the `holomush.world.v1.WorldService` service** (the transport binary plugins do have). Rejected for the **roster**: `WorldService.GetCharacter` is gated by `seed:player-character-colocation` (`internal/access/policy/seed.go:48-52`), which denies reads of non-co-located characters. Scene participants are routinely in different locations, so roster reads would silently fall back to ULIDs — indistinguishable from the bug. (Self-resolution for #3 would have passed, but the host already provides the name via `req.CharacterName`, making even that unnecessary.)
+
+The chosen host-side design avoids all of the above: the facade resolves rosters for an already-authorized set (the `ListFocusPresence` pattern), and the pose author rides the name the dispatcher already supplies.
+<!-- adr-capture: sha256=c0b6ad71b40caa34; session=cli; ts=2026-06-21T00:38:56Z; adrs=holomush-sv1ei -->

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -707,15 +707,25 @@ func (h *Host) PropertyDefinition(string) (property.Definition, bool) {
 	return nil, false
 }
 
-// WorldQuerier returns the plugin-subject-stamped world read surface. The binary
-// host has no world surface (the WorldQueryService is Lua-only), so it returns
-// nil. Satisfies hostcap.HostCapabilities.
+// WorldQuerier returns the plugin-subject-stamped world read surface for the
+// host.v1 WorldQueryService capability. The binary host returns nil: it does not
+// expose world reads as a host CAPABILITY (that surface is Lua-only). This is NOT
+// "binary plugins cannot query the world" — they reach world reads via the
+// holomush.world.v1.WorldService SERVICE instead (broker-dialed from their
+// manifest `requires:`, ABAC-gated through the same world.Service chokepoint as
+// the Lua host functions). nil here means "no world host-capability surface", not
+// "no world access". See retired epic holomush-q42fh: binary world-query parity
+// is provided by the service transport, not this capability — do NOT re-add it as
+// a parity gap. Satisfies hostcap.HostCapabilities.
 func (h *Host) WorldQuerier(string) hostcap.WorldQuerier {
 	return nil
 }
 
-// WorldMutator returns the world write surface. The binary host has no world
-// surface, so it returns nil. Satisfies hostcap.HostCapabilities.
+// WorldMutator returns the world write surface for property mutation. The binary
+// host returns nil: world writes are exposed only as the Lua host-capability
+// surface, and (unlike world reads) there is no host-provided world-mutation
+// service for binary plugins to dial. The missing host-side character entity
+// mutator is tracked by holomush-ksf12. Satisfies hostcap.HostCapabilities.
 func (h *Host) WorldMutator() world.Mutator {
 	return nil
 }


### PR DESCRIPTION
## Summary

Design docs + implementation plan + ADR for fixing the three web scene surfaces that render character **ULIDs instead of display names** (roster, pose-order strip, pose author — bug `holomush-5rh.25`), plus prevent-recurrence documentation that came out of the design.

The chosen design is **host-side**:
- **Roster (#1/#2):** the facade `GetSceneForViewer` resolves names via the existing in-process `characterNameResolver` after the scene gate has already authorized the roster — mirroring `ListFocusPresence`. No new ABAC, no per-character co-location gate.
- **Pose author (#3):** `handleEmit` stamps the display name the host command dispatcher already supplies on every `CommandRequest` (`req.CharacterName`); the gateway already reads it.

## What's in this PR (docs + one comment-only code change)

- `docs/superpowers/specs/2026-06-20-scene-character-name-resolution-design.md` — design spec (design-reviewer READY).
- `docs/superpowers/plans/2026-06-20-scene-character-name-resolution.md` — 4-task implementation plan (plan-reviewer READY).
- `docs/adr/holomush-sv1ei-…md` (+ README index) — ADR: resolve scene roster names host-side via the facade, not plugin-side.
- `.claude/rules/plugin-runtime-symmetry.md` — new **"Permitted asymmetry"** section documenting that binary plugins reach world reads via the `WorldService` service while Lua uses the `world.query` host capability (same ABAC chokepoint) — so the binary host's `WorldQuerier() → nil` is intentional, not a gap.
- `internal/plugin/goplugin/host.go` — corrected the misleading `WorldQuerier`/`WorldMutator` nil-on-binary comments (comment-only; no behavior change).

## Why the prevent-recurrence docs

During design I briefly mis-filed a binary-world-query "parity gap" bead off the misleading `WorldQuerier` comment — it duplicated deliberately-retired epic `holomush-q42fh`. Two adversarial design-review rounds caught that and a subsequent co-location-ABAC issue; the docs above ensure the next reader (human or agent) doesn't repeat the misread.

## Tracking

Implementation is tracked in epic **`holomush-vdy2z`** (children `vdy2z.1`–`.4`); those land in follow-up PRs and close `holomush-5rh.25` at merge of the integration task. This PR is docs/design only — `task pr-prep` (fast lane) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)