### PR TITLE
feat(scenes): host-side character name resolution — roster, pose-order, pose author (holomush-5rh.25)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -233,3 +233,19 @@
   internal/plugin; ambient hostfuncs bypass the interceptor (decorator-wrap the reader, not just the broker handler).
   Tests have TEETH only if recordingEngine asserts the EXACT qualified resource + reader.called==false on deny.
   Latent non-blocking: binary Host.gameID set only via WithCA → no-mTLS binary plugins get gameID="" → fail closed.
+- **Scene roster name-resolution (5rh.25/vdy2z READY, 2026-06-20) — CLEAN host-side fix.** GetSceneForViewer
+  resolveRosterNames overwrites ParticipantInfo.CharacterName in-place via characterNameResolver (mirrors
+  ListFocusPresence). VERIFIED NON-ALIASING: plugin GetScene builds Participants (service.go:484) + Observers
+  (494) as SEPARATE &ParticipantInfo{} appends → combined-roster slice shares distinct pointers, in-place
+  mutate safe. Best-effort: nil-resolver/nil-scene/parse-err/resolver-err/missing-id all keep ULID; resolver
+  err LOGGED+return (DEGRADES, NOT INTERNAL — divergence from presence which hard-fails, doc'd in source).
+  slog.ErrorContext (not errutil.LogErrorContext) is FINE here: matches sibling list_focus_presence.go:161, ctx
+  carried (logging.md satisfied), err NOT returned to client (no opacity leak). Shared handleEmit (commands.go:1310)
+  stamps character_name for IC+OOC both (ooc only swaps subject 1306-08) → R3 parity free. actor_id ULID stays
+  (GameEvent.ActorId separate from Actor=character_name); translateEvent reads p.CharacterName→actor (translate.go:81).
+  Harness: worldCharRepo raw *worldpg.CharacterRepository (==prod sub_grpc.go:312 type) added; NewSceneAccessServer
+  helper == prod wiring; both files //go:build integration; NO prod import of integrationtest. Tests TEETH: facade
+  unit asserts resolved+ULID-fallback(missingID); plugin include/omit; gateway actor; int uses REAL `scene join`
+  cmd for plugin-DB roster row (JoinScene store-shortcut only touches focus_memberships, doc'd) + cross-loc
+  not-ULID regex + ContainElement seeded names + decrypted pose author. int roster checks participants only (not
+  observers) but unit covers observers — OK. All 5 unit tests pass; go vet -tags integration green.

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -594,6 +594,7 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 		if s.cfg.RekeyManager != nil {
 			saSrv.WithSceneDEKAdder(s.cfg.RekeyManager)
 		}
+		saSrv.WithCharacterNameResolver(holoGRPC.NewRepoCharacterNameResolver(charRepo))
 		sceneAccessSrv = saSrv
 		slog.InfoContext(ctx, "sceneAccessService facade registered")
 	} else {

--- a/internal/grpc/sceneaccess_service.go
+++ b/internal/grpc/sceneaccess_service.go
@@ -211,7 +211,49 @@ func (s *SceneAccessServer) GetSceneForViewer(ctx context.Context, req *sceneacc
 	if err != nil {
 		return nil, err //nolint:wrapcheck // gRPC status errors pass through as-is
 	}
-	return &sceneaccessv1.GetSceneForViewerResponse{Scene: resp.GetScene()}, nil
+	scene := resp.GetScene()
+	s.resolveRosterNames(ctx, scene)
+	return &sceneaccessv1.GetSceneForViewerResponse{Scene: scene}, nil
+}
+
+// resolveRosterNames overwrites participant + observer CharacterName fields with
+// resolved display names, in place. Best-effort: nil resolver, parse failure, a
+// resolver error, or a missing id all leave the raw ULID. The scene gate already
+// authorized this roster (plugin GetScene privacy gate), so name resolution is
+// downstream display — no per-character ABAC (mirrors ListFocusPresence).
+func (s *SceneAccessServer) resolveRosterNames(ctx context.Context, scene *scenev1.SceneInfo) {
+	if s.characterNameResolver == nil || scene == nil {
+		return
+	}
+	roster := append(append([]*scenev1.ParticipantInfo{}, scene.GetParticipants()...), scene.GetObservers()...)
+	if len(roster) == 0 {
+		return
+	}
+	ids := make([]ulid.ULID, 0, len(roster))
+	for _, p := range roster {
+		id, err := ulid.Parse(p.GetCharacterId())
+		if err != nil {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	names, err := s.characterNameResolver.Names(ctx, ids)
+	if err != nil {
+		// Log via slog.ErrorContext like ListFocusPresence (list_focus_presence.go:161-162).
+		// DELIBERATE divergence: presence HARD-FAILS (INTERNAL) on resolver error;
+		// the scene roster DEGRADES — keep the ULIDs, never fail GetSceneForViewer.
+		slog.ErrorContext(ctx, "scene roster name resolution failed", "error", err, "scene_id", scene.GetId())
+		return
+	}
+	for _, p := range roster {
+		id, err := ulid.Parse(p.GetCharacterId())
+		if err != nil {
+			continue
+		}
+		if n, ok := names[id]; ok && n != "" {
+			p.CharacterName = n
+		}
+	}
 }
 
 // ListMyScenes returns the verified character's scene participations.

--- a/internal/grpc/sceneaccess_service.go
+++ b/internal/grpc/sceneaccess_service.go
@@ -60,6 +60,11 @@ type SceneAccessServer struct {
 	// the AuthGuard permits decryption of sensitive scene events. nil disables
 	// seeding (KEK-less deployments / tests).
 	dekAdder sceneDEKAdder
+
+	// characterNameResolver resolves participant/observer display names by ID
+	// for GetSceneForViewer roster enrichment. Optional: nil leaves rosters
+	// with raw ULIDs (best-effort). Mirrors CoreServer's resolver (5b2j).
+	characterNameResolver characterNameResolver
 }
 
 // NewSceneAccessServer constructs a SceneAccessServer. All fields are required;
@@ -89,6 +94,13 @@ func NewSceneAccessServer(
 // (fatal on failure).
 func (s *SceneAccessServer) WithSceneDEKAdder(a sceneDEKAdder) {
 	s.dekAdder = a
+}
+
+// WithCharacterNameResolver attaches the roster name resolver. Call after
+// construction; when set, GetSceneForViewer overwrites ParticipantInfo
+// CharacterName with the resolved display name (ULID fallback on a miss).
+func (s *SceneAccessServer) WithCharacterNameResolver(r characterNameResolver) {
+	s.characterNameResolver = r
 }
 
 // ownedCharacter verifies that charIDStr is a valid ULID and is owned by

--- a/internal/grpc/sceneaccess_service_test.go
+++ b/internal/grpc/sceneaccess_service_test.go
@@ -707,6 +707,54 @@ func TestGetSceneForViewerResolvesRosterNames(t *testing.T) {
 	assert.Equal(t, "Observer One", obs[0].GetCharacterName())
 }
 
+// TestGetSceneForViewerKeepsULIDsWhenResolverErrors pins the deliberate
+// best-effort degradation (spec G3, and the DELIBERATE divergence from
+// ListFocusPresence which hard-fails): a resolver error MUST NOT fail
+// GetSceneForViewer — the roster is returned with the raw ULIDs intact.
+func TestGetSceneForViewerKeepsULIDsWhenResolverErrors(t *testing.T) {
+	ctx := context.Background()
+
+	playerID := idgen.New()
+	viewer := &world.Character{ID: idgen.New(), PlayerID: playerID, Name: "Viewer"}
+	ps := buildSATestPS(t, playerID)
+
+	playerRepo := authmocks.NewMockPlayerRepository(t)
+	playerRepo.EXPECT().GetByID(mock.Anything, playerID).
+		Return(&auth.Player{ID: playerID, IsGuest: false}, nil).Maybe()
+	psRepo := buildSASessionRepo(t, ps)
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return([]*world.Character{viewer}, nil).Maybe()
+	sessStore := sessionmocks.NewMockStore(t)
+	mgr := &stubPluginManager{}
+
+	memberID := idgen.New()
+	sceneMock := scenemocks.NewMockSceneServiceClient(t)
+	sceneMock.EXPECT().GetScene(mock.Anything, mock.Anything).Return(&scenev1.GetSceneResponse{
+		Scene: &scenev1.SceneInfo{
+			Id: "sc-1",
+			Participants: []*scenev1.ParticipantInfo{
+				{CharacterId: memberID.String(), CharacterName: memberID.String(), Role: "member"},
+			},
+		},
+	}, nil).Maybe()
+
+	srv := newTestSceneAccessServer(t, psRepo, playerRepo, charRepo, sessStore, &stubFocusCoordinator{}, sceneMock, mgr)
+	srv.WithCharacterNameResolver(&fakeNameResolver{err: errors.New("resolver boom")})
+
+	resp, err := srv.GetSceneForViewer(ctx, &sceneaccessv1.GetSceneForViewerRequest{
+		SessionId:          "ignored",
+		PlayerSessionToken: testSAToken,
+		CharacterId:        viewer.ID.String(),
+		SceneId:            "sc-1",
+	})
+	require.NoError(t, err, "resolver error must NOT fail the RPC (best-effort degradation)")
+	parts := resp.GetScene().GetParticipants()
+	require.Len(t, parts, 1)
+	assert.Equal(t, memberID.String(), parts[0].GetCharacterName(),
+		"resolver error leaves the raw ULID")
+}
+
 // failingSceneDEKAdder is a sceneDEKAdder whose EnsureParticipant always fails,
 // used to drive the fatal-seed branch of SetSceneFocus.
 type failingSceneDEKAdder struct{}

--- a/internal/grpc/sceneaccess_service_test.go
+++ b/internal/grpc/sceneaccess_service_test.go
@@ -645,6 +645,68 @@ func TestSetSceneFocusJoinsFocusThenSetsConnectionFocus(t *testing.T) {
 		"JoinFocus MUST be called exactly once for a valid participant")
 }
 
+// TestGetSceneForViewerResolvesRosterNames verifies that GetSceneForViewer
+// overwrites participant and observer CharacterName fields with display names
+// from the resolver, falling back to the raw ULID for unresolved IDs.
+func TestGetSceneForViewerResolvesRosterNames(t *testing.T) {
+	ctx := context.Background()
+
+	playerID := idgen.New()
+	viewer := &world.Character{ID: idgen.New(), PlayerID: playerID, Name: "Viewer"}
+	ps := buildSATestPS(t, playerID)
+
+	playerRepo := authmocks.NewMockPlayerRepository(t)
+	playerRepo.EXPECT().GetByID(mock.Anything, playerID).
+		Return(&auth.Player{ID: playerID, IsGuest: false}, nil).Maybe()
+	psRepo := buildSASessionRepo(t, ps)
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return([]*world.Character{viewer}, nil).Maybe()
+	sessStore := sessionmocks.NewMockStore(t)
+	mgr := &stubPluginManager{}
+
+	ownerID := idgen.New()
+	missingID := idgen.New() // NOT in the resolver map → ULID fallback
+	observerID := idgen.New()
+
+	sceneMock := scenemocks.NewMockSceneServiceClient(t)
+	sceneMock.EXPECT().GetScene(mock.Anything, mock.Anything).Return(&scenev1.GetSceneResponse{
+		Scene: &scenev1.SceneInfo{
+			Id: "sc-1",
+			Participants: []*scenev1.ParticipantInfo{
+				{CharacterId: ownerID.String(), CharacterName: ownerID.String(), Role: "owner"},
+				{CharacterId: missingID.String(), CharacterName: missingID.String(), Role: "member"},
+			},
+			Observers: []*scenev1.ParticipantInfo{
+				{CharacterId: observerID.String(), CharacterName: observerID.String(), Role: "observer"},
+			},
+		},
+	}, nil).Maybe()
+
+	srv := newTestSceneAccessServer(t, psRepo, playerRepo, charRepo, sessStore, &stubFocusCoordinator{}, sceneMock, mgr)
+	srv.WithCharacterNameResolver(&fakeNameResolver{names: map[ulid.ULID]string{
+		ownerID:    "Owner One",
+		observerID: "Observer One",
+		// missingID intentionally absent
+	}})
+
+	resp, err := srv.GetSceneForViewer(ctx, &sceneaccessv1.GetSceneForViewerRequest{
+		SessionId:          "ignored",
+		PlayerSessionToken: testSAToken,
+		CharacterId:        viewer.ID.String(),
+		SceneId:            "sc-1",
+	})
+	require.NoError(t, err)
+
+	parts := resp.GetScene().GetParticipants()
+	require.Len(t, parts, 2)
+	assert.Equal(t, "Owner One", parts[0].GetCharacterName())
+	assert.Equal(t, missingID.String(), parts[1].GetCharacterName(), "unresolved id keeps the ULID")
+	obs := resp.GetScene().GetObservers()
+	require.Len(t, obs, 1)
+	assert.Equal(t, "Observer One", obs[0].GetCharacterName())
+}
+
 // failingSceneDEKAdder is a sceneDEKAdder whose EnsureParticipant always fails,
 // used to drive the fatal-seed branch of SetSceneFocus.
 type failingSceneDEKAdder struct{}

--- a/internal/grpc/sceneaccess_service_test.go
+++ b/internal/grpc/sceneaccess_service_test.go
@@ -31,6 +31,34 @@ import (
 	sceneaccessv1 "github.com/holomush/holomush/pkg/proto/holomush/sceneaccess/v1"
 )
 
+// fakeNameResolver is a hand-rolled double for the unexported
+// characterNameResolver interface (mockery does not generate mocks for
+// unexported interfaces).
+type fakeNameResolver struct {
+	names map[ulid.ULID]string
+	err   error
+}
+
+func (f *fakeNameResolver) Names(_ context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make(map[ulid.ULID]string, len(ids))
+	for _, id := range ids {
+		if n, ok := f.names[id]; ok {
+			out[id] = n
+		}
+	}
+	return out, nil
+}
+
+func TestWithCharacterNameResolverSetsTheField(t *testing.T) {
+	srv := &SceneAccessServer{}
+	r := &fakeNameResolver{}
+	srv.WithCharacterNameResolver(r)
+	assert.Same(t, r, srv.characterNameResolver)
+}
+
 func TestWithSceneDEKAdderSetsField(t *testing.T) {
 	s := &SceneAccessServer{}
 	s.WithSceneDEKAdder(stubSceneDEKAdder{})

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -121,8 +121,12 @@ type Server struct {
 	playerSessionStore *store.PostgresPlayerSessionStore
 	playerRepo         *authpg.PlayerRepository
 	charRepo           auth.CharacterRepository
-	sessionStore       session.Store
-	locRepo            *worldpg.LocationRepository
+	// worldCharRepo is the raw world.CharacterRepository (not the auth adapter)
+	// retained so tests can build a SceneAccessServer with a real
+	// RepoCharacterNameResolver (mirrors production sub_grpc.go:597).
+	worldCharRepo *worldpg.CharacterRepository
+	sessionStore  session.Store
+	locRepo       *worldpg.LocationRepository
 
 	// services
 	authService *auth.Service
@@ -603,6 +607,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		playerSessionStore:   playerSessionStore,
 		playerRepo:           playerRepo,
 		charRepo:             charRepo,
+		worldCharRepo:        worldCharRepo,
 		sessionStore:         sessionStoreInst,
 		locRepo:              locRepo,
 		authService:          authService,
@@ -696,6 +701,34 @@ func (s *Server) SceneServiceClient() scenev1.SceneServiceClient {
 	require.NoError(s.t, err, "integrationtest.Server.SceneServiceClient: resolve SceneService")
 	require.NotNil(s.t, svc.Conn, "integrationtest.Server.SceneServiceClient: nil conn")
 	return scenev1.NewSceneServiceClient(svc.Conn)
+}
+
+// NewSceneAccessServer constructs a SceneAccessServer wired with the harness's
+// real repos, coordinator, and a RepoCharacterNameResolver backed by the
+// harness's worldCharRepo. This is the production-equivalent wiring (mirroring
+// cmd/holomush/sub_grpc.go:597) and is the correct server to use for any test
+// that calls GetSceneForViewer and expects display names (not ULIDs) on the
+// roster.
+//
+// Requires WithInTreePlugins (for the plugin manager + scene client) and
+// WithFocusDelivery (for the coordinator). Panics with a descriptive message
+// if either is missing.
+func (s *Server) NewSceneAccessServer() *holoGRPC.SceneAccessServer {
+	s.requirePlugins("NewSceneAccessServer")
+	if s.focusCoord == nil {
+		s.t.Fatalf("integrationtest.Server.NewSceneAccessServer: requires WithFocusDelivery (focusCoord is nil)")
+	}
+	facade := holoGRPC.NewSceneAccessServer(
+		s.playerSessionStore,
+		s.playerRepo,
+		s.charRepo,
+		s.sessionStore,
+		s.focusCoord,
+		s.SceneServiceClient(),
+		s.pluginSub.Manager(),
+	)
+	facade.WithCharacterNameResolver(holoGRPC.NewRepoCharacterNameResolver(s.worldCharRepo))
+	return facade
 }
 
 // AccessEngine returns the ABAC policy engine the stack evaluates against.

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -831,3 +831,25 @@ func (p *AuthedPlayer) OpenTelnetSession(_ context.Context) *Session {
 	p.server.t.Fatalf("integrationtest.AuthedPlayer.OpenTelnetSession: TODO iwzt-16 — telnet transport differentiation requires Subscribe goroutine wiring")
 	return nil
 }
+
+// GetSceneForViewer calls the REAL SceneAccessServer.GetSceneForViewer for
+// this session's character via the production facade path (player-session auth
+// → character ownership verification → plugin GetScene → roster name
+// resolution). Requires WithInTreePlugins and WithFocusDelivery (delegates to
+// Server.NewSceneAccessServer which requires both; panics via t.Fatalf if
+// either is absent).
+//
+// The returned SceneInfo has ParticipantInfo.CharacterName populated with
+// resolved display names when the harness is wired with a
+// RepoCharacterNameResolver (which NewSceneAccessServer always attaches). On a
+// name-resolution miss the raw ULID is left in place (best-effort, per
+// sceneaccess_service.go resolveRosterNames).
+func (s *Session) GetSceneForViewer(ctx context.Context, sceneID ulid.ULID) (*sceneaccessv1.GetSceneForViewerResponse, error) {
+	s.server.t.Helper()
+	facade := s.server.NewSceneAccessServer()
+	return facade.GetSceneForViewer(ctx, &sceneaccessv1.GetSceneForViewerRequest{
+		PlayerSessionToken: s.playerSessionToken,
+		CharacterId:        s.CharacterID.String(),
+		SceneId:            sceneID.String(),
+	})
+}

--- a/internal/web/translate_test.go
+++ b/internal/web/translate_test.go
@@ -401,6 +401,24 @@ func TestTranslateEventTranslatesEventWithUnknownTypeButPresentRendering(t *test
 	assert.Equal(t, "You teleport away.", got.GetText())
 }
 
+func TestTranslateEvent_ScenePoseUsesCharacterNameAsActor(t *testing.T) {
+	h := newTestHandler(t)
+	ev := &corev1.EventFrame{
+		Type:    "core-scenes:scene_pose",
+		ActorId: "01HYXCHARALICE0000000000AA",
+		Payload: mustMarshal(t, map[string]string{"character_name": "Alice", "text": "smiles"}),
+		Rendering: &corev1.RenderingMetadata{
+			Category:      "communication",
+			Format:        "action",
+			DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			SourcePlugin:  "core-scenes",
+		},
+	}
+	got := h.translateEvent(ev)
+	require.NotNil(t, got)
+	assert.Equal(t, "Alice", got.GetActor())
+}
+
 func TestTranslateEvent_CorruptPayload(t *testing.T) {
 	h := newTestHandler(t)
 	ev := &corev1.EventFrame{

--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -1307,11 +1307,19 @@ func (p *scenePlugin) handleEmit(
 		subject = dotStyleSceneSubjectOOC(p.service.gameID, sceneID)
 	}
 
-	payload, err := json.Marshal(map[string]string{
+	payloadMap := map[string]string{
 		"actor_id": req.CharacterID,
 		"scene_id": sceneID,
 		"text":     text,
-	})
+	}
+	// Stamp the author display name when the dispatcher provided one
+	// (internal/command/dispatcher.go:310). Empty → omit; the gateway falls
+	// back to actor_id exactly as before. Rides the encrypted IC payload
+	// (crypto.emits) — no more sensitive than the pose text it labels.
+	if req.CharacterName != "" {
+		payloadMap["character_name"] = req.CharacterName
+	}
+	payload, err := json.Marshal(payloadMap)
 	if err != nil {
 		err = oops.Code("SCENE_EMIT_PAYLOAD_MARSHAL_FAILED").
 			With("event_type", eventType).

--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -1313,9 +1313,10 @@ func (p *scenePlugin) handleEmit(
 		"text":     text,
 	}
 	// Stamp the author display name when the dispatcher provided one
-	// (internal/command/dispatcher.go:310). Empty → omit; the gateway falls
-	// back to actor_id exactly as before. Rides the encrypted IC payload
-	// (crypto.emits) — no more sensitive than the pose text it labels.
+	// (internal/command/dispatcher.go:310). Empty → omit; GameEvent.actor then
+	// comes out empty and the web client falls back to actor_id, exactly as
+	// before. Rides the encrypted IC payload (crypto.emits) — no more sensitive
+	// than the pose text it labels.
 	if req.CharacterName != "" {
 		payloadMap["character_name"] = req.CharacterName
 	}

--- a/plugins/core-scenes/commands_emit_test.go
+++ b/plugins/core-scenes/commands_emit_test.go
@@ -119,6 +119,42 @@ func TestSceneSubcommand_OOC_EmitsSceneEventOnOOCFacet(t *testing.T) {
 	assert.Contains(t, found.Payload, `"text":"brb getting coffee"`)
 }
 
+func TestSceneSubcommand_Pose_IncludesAuthorCharacterName(t *testing.T) {
+	t.Parallel()
+	p, sink := newTestPluginWithMember(t, "scene-author-test")
+
+	resp, err := p.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:       "scene",
+		Args:          "pose smiles",
+		CharacterID:   "char-alice",
+		CharacterName: "Alice",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+
+	found := findIntentByType(sink.intents, "core-scenes:scene_pose")
+	require.NotNil(t, found)
+	assert.Contains(t, found.Payload, `"character_name":"Alice"`)
+}
+
+func TestSceneSubcommand_Pose_OmitsCharacterNameWhenEmpty(t *testing.T) {
+	t.Parallel()
+	p, sink := newTestPluginWithMember(t, "scene-noauthor-test")
+
+	resp, err := p.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "pose smiles",
+		CharacterID: "char-alice",
+		// CharacterName intentionally empty
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+
+	found := findIntentByType(sink.intents, "core-scenes:scene_pose")
+	require.NotNil(t, found)
+	assert.NotContains(t, found.Payload, "character_name")
+}
+
 func TestSceneSubcommand_NonParticipant_PermissionDenied(t *testing.T) {
 	t.Parallel()
 	// scene-perm-test has char-owner + char-alice as members. char-bob is

--- a/plugins/core-scenes/commands_emit_test.go
+++ b/plugins/core-scenes/commands_emit_test.go
@@ -119,40 +119,50 @@ func TestSceneSubcommand_OOC_EmitsSceneEventOnOOCFacet(t *testing.T) {
 	assert.Contains(t, found.Payload, `"text":"brb getting coffee"`)
 }
 
-func TestSceneSubcommand_Pose_IncludesAuthorCharacterName(t *testing.T) {
+func TestSceneSubcommand_Pose_AuthorCharacterNameInPayload(t *testing.T) {
 	t.Parallel()
-	p, sink := newTestPluginWithMember(t, "scene-author-test")
+	tests := []struct {
+		name          string
+		scene         string
+		characterName string
+		assertPayload func(t *testing.T, payload string)
+	}{
+		{
+			name:          "includes character_name when the dispatcher provides one",
+			scene:         "scene-author-test",
+			characterName: "Alice",
+			assertPayload: func(t *testing.T, payload string) {
+				assert.Contains(t, payload, `"character_name":"Alice"`)
+			},
+		},
+		{
+			name:          "omits character_name when the dispatcher provides none",
+			scene:         "scene-noauthor-test",
+			characterName: "",
+			assertPayload: func(t *testing.T, payload string) {
+				assert.NotContains(t, payload, "character_name")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p, sink := newTestPluginWithMember(t, tt.scene)
 
-	resp, err := p.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
-		Command:       "scene",
-		Args:          "pose smiles",
-		CharacterID:   "char-alice",
-		CharacterName: "Alice",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+			resp, err := p.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
+				Command:       "scene",
+				Args:          "pose smiles",
+				CharacterID:   "char-alice",
+				CharacterName: tt.characterName,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, pluginsdk.CommandOK, resp.Status)
 
-	found := findIntentByType(sink.intents, "core-scenes:scene_pose")
-	require.NotNil(t, found)
-	assert.Contains(t, found.Payload, `"character_name":"Alice"`)
-}
-
-func TestSceneSubcommand_Pose_OmitsCharacterNameWhenEmpty(t *testing.T) {
-	t.Parallel()
-	p, sink := newTestPluginWithMember(t, "scene-noauthor-test")
-
-	resp, err := p.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
-		Command:     "scene",
-		Args:        "pose smiles",
-		CharacterID: "char-alice",
-		// CharacterName intentionally empty
-	})
-	require.NoError(t, err)
-	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
-
-	found := findIntentByType(sink.intents, "core-scenes:scene_pose")
-	require.NotNil(t, found)
-	assert.NotContains(t, found.Payload, "character_name")
+			found := findIntentByType(sink.intents, "core-scenes:scene_pose")
+			require.NotNil(t, found)
+			tt.assertPayload(t, found.Payload)
+		})
+	}
 }
 
 func TestSceneSubcommand_NonParticipant_PermissionDenied(t *testing.T) {

--- a/test/integration/scenes/scene_name_resolution_test.go
+++ b/test/integration/scenes/scene_name_resolution_test.go
@@ -33,10 +33,7 @@ import (
 // rather than leaving the field empty (no ULID was ever used there — the
 // field was simply absent pre-fix).
 var _ = Describe("holomush-5rh.25: scene name resolution", func() {
-
-	// ────────────────────────────────────────────────────────────────────────
-	// Spec 1: GetSceneForViewer roster — cross-location display names
-	// ────────────────────────────────────────────────────────────────────────
+	// Spec 1: GetSceneForViewer roster — cross-location display names.
 	Describe("GetSceneForViewer cross-location roster name resolution", func() {
 		var (
 			ts     *integrationtest.Server
@@ -69,7 +66,7 @@ var _ = Describe("holomush-5rh.25: scene name resolution", func() {
 			ts.Stop()
 		})
 
-		It("returns display names (not ULIDs) for participants in different locations (INV-SCENE-roster-name)", func() {
+		It("returns display names (not ULIDs) for participants in different locations", func() {
 			// Place owner and member in DIFFERENT locations — this is the exact
 			// cross-location case the pre-fix code could not resolve.
 			ownerLoc := ts.NewLocation(ctx)
@@ -132,9 +129,7 @@ var _ = Describe("holomush-5rh.25: scene name resolution", func() {
 		})
 	})
 
-	// ────────────────────────────────────────────────────────────────────────
-	// Spec 2: pose author display name in the IC event payload
-	// ────────────────────────────────────────────────────────────────────────
+	// Spec 2: pose author display name in the IC event payload.
 	Describe("scene pose command stamps author display name in IC payload", func() {
 		var (
 			ts    *integrationtest.Server

--- a/test/integration/scenes/scene_name_resolution_test.go
+++ b/test/integration/scenes/scene_name_resolution_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// holomush-5rh.25: cross-location roster name resolution and pose author
+// name resolution end-to-end.
+//
+// ROOT CAUSE (pre-fix): GetSceneForViewer returned raw ULID strings in
+// ParticipantInfo.CharacterName for participants whose sessions are in a
+// different location from the viewing character. The old implementation
+// resolved names only from the viewer's session location, so cross-location
+// participants fell through with ULID fallbacks. The fix (holomush-5rh.25)
+// introduces resolveRosterNames which fetches display names via
+// characterNameResolver.Names — a direct DB lookup that is location-agnostic.
+//
+// Similarly, handleEmit stamped the pose's character_name field from
+// req.CharacterName (the dispatcher provides the character's display name from
+// session.Info.CharacterName), so the IC payload now carries the display name
+// rather than leaving the field empty (no ULID was ever used there — the
+// field was simply absent pre-fix).
+var _ = Describe("holomush-5rh.25: scene name resolution", func() {
+
+	// ────────────────────────────────────────────────────────────────────────
+	// Spec 1: GetSceneForViewer roster — cross-location display names
+	// ────────────────────────────────────────────────────────────────────────
+	Describe("GetSceneForViewer cross-location roster name resolution", func() {
+		var (
+			ts     *integrationtest.Server
+			ctx    context.Context
+			owner  *integrationtest.Session
+			member *integrationtest.Session
+		)
+
+		BeforeEach(func() {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+			DeferCleanup(cancel)
+			ts = integrationtest.Start(
+				suiteT,
+				integrationtest.WithInTreePlugins(),
+				integrationtest.WithPluginCrypto(),
+				integrationtest.WithFocusDelivery(),
+			)
+			owner = ts.ConnectAuthed(ctx, "SceneOwner")
+			member = ts.ConnectAuthed(ctx, "CrossLocMember")
+		})
+
+		AfterEach(func() {
+			if member != nil {
+				member.Logout(ctx)
+			}
+			if owner != nil {
+				owner.Logout(ctx)
+			}
+			ts.Stop()
+		})
+
+		It("returns display names (not ULIDs) for participants in different locations (INV-SCENE-roster-name)", func() {
+			// Place owner and member in DIFFERENT locations — this is the exact
+			// cross-location case the pre-fix code could not resolve.
+			ownerLoc := ts.NewLocation(ctx)
+			memberLoc := ts.NewLocation(ctx)
+
+			owner.MoveTo(ctx, ownerLoc)
+			member.MoveTo(ctx, memberLoc)
+
+			// Owner creates the scene (CreateScene also seeds the creator as a
+			// participant row in the plugin DB). JoinScene (store shortcut) adds
+			// the session-side focus_memberships entry so the owner can view the
+			// scene via GetSceneForViewer.
+			sceneID := owner.CreateScene(ctx, ownerLoc)
+			Expect(sceneID).NotTo(BeZero(), "CreateScene must return a non-zero ULID")
+
+			// Add owner's session-side focus membership (for I-17 scope floor).
+			owner.JoinScene(ctx, sceneID)
+
+			// Add member via the REAL `scene join` command — this writes a
+			// participant row into the plugin DB (plugin_core_scenes.scene_participants),
+			// which is what GetScene reads for the roster. The harness
+			// Session.JoinScene store-shortcut only touches focus_memberships JSONB
+			// and does NOT write to the plugin DB, so it cannot produce roster entries.
+			//
+			// `scene join` requires a bare scene ULID (ADR holomush-vy0rt) and
+			// WithFocusDelivery so focusClient is non-nil (avoids the
+			// "focus client not configured" error path).
+			err := member.SendCommand(ctx, "scene join "+sceneID.String())
+			Expect(err).NotTo(HaveOccurred(), "member must be able to join the scene via `scene join`")
+
+			// Fetch via the REAL SceneAccessServer facade — the resolver is wired
+			// by Session.GetSceneForViewer → Server.NewSceneAccessServer →
+			// WithCharacterNameResolver(RepoCharacterNameResolver(worldCharRepo)).
+			resp, err := owner.GetSceneForViewer(ctx, sceneID)
+			Expect(err).NotTo(HaveOccurred(), "GetSceneForViewer must succeed")
+			Expect(resp.GetScene()).NotTo(BeNil(), "response must carry a scene")
+
+			participants := resp.GetScene().GetParticipants()
+			Expect(participants).NotTo(BeEmpty(), "scene must have at least one participant")
+
+			// Both participants must carry display names, not ULIDs.
+			ulid26RE := `^[0-9A-HJKMNP-TV-Z]{26}$`
+			for _, p := range participants {
+				Expect(p.GetCharacterName()).NotTo(MatchRegexp(ulid26RE),
+					"roster name for character %s must be a display name, not a ULID",
+					p.GetCharacterId())
+				Expect(p.GetCharacterName()).NotTo(BeEmpty(),
+					"roster CharacterName must be populated (not empty)")
+			}
+
+			// Stronger: assert the exact seeded names appear.
+			names := make([]string, 0, len(participants))
+			for _, p := range participants {
+				names = append(names, p.GetCharacterName())
+			}
+			Expect(names).To(ContainElement("SceneOwner"),
+				"owner's display name must appear on the roster")
+			Expect(names).To(ContainElement("CrossLocMember"),
+				"cross-location member's display name must appear on the roster")
+		})
+	})
+
+	// ────────────────────────────────────────────────────────────────────────
+	// Spec 2: pose author display name in the IC event payload
+	// ────────────────────────────────────────────────────────────────────────
+	Describe("scene pose command stamps author display name in IC payload", func() {
+		var (
+			ts    *integrationtest.Server
+			ctx   context.Context
+			alice *integrationtest.Session
+		)
+
+		BeforeEach(func() {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+			DeferCleanup(cancel)
+			ts = integrationtest.Start(
+				suiteT,
+				integrationtest.WithInTreePlugins(),
+				integrationtest.WithPluginCrypto(),
+				integrationtest.WithFocusDelivery(),
+			)
+			alice = ts.ConnectAuthed(ctx, "Alice")
+		})
+
+		AfterEach(func() {
+			if alice != nil {
+				alice.Logout(ctx)
+			}
+			ts.Stop()
+		})
+
+		It("decrypted pose payload carries character_name equal to the author's display name (not a ULID)", func() {
+			loc := ts.NewLocation(ctx)
+			sceneID := alice.CreateScene(ctx, loc)
+			Expect(sceneID).NotTo(BeZero())
+
+			// Alice joins the scene so single-membership inference in handleEmit
+			// can route the pose to this scene, and so the JoinedAt scope floor
+			// does not filter the event out during read-back.
+			alice.JoinScene(ctx, sceneID)
+
+			// Seed Alice as a DEK participant BEFORE the emit so the AuthGuard
+			// hot-tier permits decryption when QueryStreamHistory reads back.
+			ts.SeedSceneDEKParticipant(ctx, sceneID, alice)
+
+			// Emit via the REAL `scene pose` command path (dispatcher →
+			// handleEmit). The dispatcher stamps req.CharacterName from
+			// session.Info.CharacterName — "Alice" — so the IC payload carries
+			// character_name: "Alice".
+			const poseText = "stands at the window, watching the rain"
+			err := alice.SendCommand(ctx, "scene pose "+poseText)
+			Expect(err).NotTo(HaveOccurred(), "scene pose command must succeed")
+
+			// Build the dot-style IC subject for QueryStreamHistory.
+			// Pattern: events.<gameID>.scene.<sceneID>.ic
+			gameID := ts.GameID()
+			icSubject := "events." + gameID + ".scene." + sceneID.String() + ".ic"
+
+			// Read back with eventual consistency (the emit is async through
+			// JetStream). Alice is a DEK participant, so the payload is decrypted.
+			var decryptedPayload string
+			Eventually(func(g Gomega) {
+				events, queryErr := alice.QueryStreamHistory(ctx, icSubject)
+				g.Expect(queryErr).NotTo(HaveOccurred())
+				g.Expect(events).NotTo(BeEmpty(), "pose must appear in history")
+				last := events[len(events)-1]
+				g.Expect(last.GetMetadataOnly()).To(BeFalse(),
+					"Alice is a DEK participant — payload must be decrypted, not metadata-only")
+				decryptedPayload = string(last.GetPayload())
+			}).Should(Succeed())
+
+			// Parse the JSON payload and assert character_name is the display name.
+			var payloadMap map[string]string
+			Expect(json.Unmarshal([]byte(decryptedPayload), &payloadMap)).To(Succeed(),
+				"decrypted payload must be valid JSON")
+
+			charName, ok := payloadMap["character_name"]
+			Expect(ok).To(BeTrue(),
+				"decrypted IC payload must contain a character_name field; got: %s", decryptedPayload)
+
+			Expect(charName).To(Equal("Alice"),
+				"pose author character_name must equal the seeded display name")
+
+			ulid26RE := `^[0-9A-HJKMNP-TV-Z]{26}$`
+			Expect(charName).NotTo(MatchRegexp(ulid26RE),
+				"character_name must be a display name, not a ULID; got: %s", charName)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes the three web scene surfaces that rendered character **ULIDs instead of display names** (`holomush-5rh.25`): the roster, the pose-order strip, and the pose author in the log. Host-side design per the merged spec/ADR (`holomush-sv1ei`, #4483).

- **Roster + pose-order (both via `getScene`):** `GetSceneForViewer` resolves participant + observer names via the existing in-process `characterNameResolver` after the scene gate has already authorized the roster — mirroring `ListFocusPresence`. Best-effort (ULID fallback on a miss; resolver error is non-fatal). **No new ABAC, no per-character co-location gate** (the rejected plugin-side `WorldService.GetCharacter` path failed exactly on cross-location participants).
- **Pose author:** `handleEmit` stamps `character_name` (the display name the host dispatcher already provides as `req.CharacterName`) into the IC payload; the gateway already reads it. The shared content-emit handler covers pose/say/ooc.

## Commits (epic `holomush-vdy2z`, children `.1`–`.4`)

1. `feat(scenes): inject character name resolver into scene facade` — `SceneAccessServer` field + `WithCharacterNameResolver` + prod wiring.
2. `feat(scenes): resolve roster display names in GetSceneForViewer` — the `resolveRosterNames` helper.
3. `feat(scenes): stamp pose author display name into IC payload` — `handleEmit`.
4. `test(scenes): integration coverage for cross-location name resolution` — Ginkgo `WithInTreePlugins` test (two participants in **different locations** → resolved names; posted pose → resolved author). Also wires the resolver into the integration harness's facade (it previously didn't).

## Reviews & tests

- **crypto-reviewer: READY** — `character_name` rides the encrypted IC payload (no more sensitive than the pose text; AAD unchanged; no cleartext leak; sensitivity fence intact).
- **code-reviewer: READY** — no blocking findings (2 minor non-blocking: `slog.ErrorContext` deliberately mirrors `list_focus_presence.go`; observer resolution pinned by the facade unit test).
- Unit tests green (`task pr-prep` fast lane pass). Scenes integration suite **29/29** local.
- **Note:** touches the shared integration harness (`internal/testsupport/integrationtest/`, additive) — CI's required **Integration Test** + **E2E Test** checks validate the full suite.

## Test plan

- [ ] CI: Integration Test + E2E Test green.
- [ ] Manual: web roster, pose-order strip, and a fresh pose all show display names (not ULIDs); confirm with two characters in different locations.

Closes `holomush-5rh.25`. No client-side changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)